### PR TITLE
[codex] Add Codex plugin compatibility

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "i-have-adhd",
+  "interface": {
+    "displayName": "I Have ADHD"
+  },
+  "plugins": [
+    {
+      "name": "i-have-adhd",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/ayghri/i-have-adhd.git",
+        "ref": "main"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "i-have-adhd",
+  "version": "0.1.0",
+  "description": "ADHD-friendly output shaping for Codex: action first, numbered steps, no tangents, and visible progress.",
+  "author": {
+    "name": "Ayoub G.",
+    "url": "https://github.com/ayghri"
+  },
+  "homepage": "https://github.com/ayghri/i-have-adhd",
+  "repository": "https://github.com/ayghri/i-have-adhd",
+  "license": "MIT",
+  "keywords": [
+    "adhd",
+    "output-style",
+    "productivity",
+    "skills",
+    "codex"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "I Have ADHD",
+    "shortDescription": "Action-first output for ADHD readers",
+    "longDescription": "Shape Codex responses for an ADHD reader by leading with the next action, numbering multi-step work, suppressing tangents, restating state, and making progress visible.",
+    "developerName": "Ayoub G.",
+    "category": "Productivity",
+    "capabilities": [
+      "Instructions"
+    ],
+    "websiteURL": "https://github.com/ayghri/i-have-adhd",
+    "defaultPrompt": [
+      "Use i-have-adhd for this task.",
+      "Make this answer action-first and easy to execute.",
+      "Review this response for ADHD-friendly structure."
+    ],
+    "brandColor": "#2563EB",
+    "composerIcon": "./logo.png",
+    "logo": "./logo.png"
+  }
+}

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,6 +4,8 @@ A Claude Code plugin. One skill inside.
 
 ## TL;DR
 
+### Claude Code
+
 ```bash
 git clone https://github.com/ayghri/i-have-adhd ./i-have-adhd
 claude plugin marketplace add ./i-have-adhd
@@ -14,7 +16,18 @@ Open Claude Code, type `/i-have-adhd`.
 
 To disable: `claude plugin disable i-have-adhd` (or `/plugin disable i-have-adhd` from within Claude Code). Re-enable later with `enable` instead of `disable`.
 
+### Codex
+
+```bash
+codex plugin marketplace add ayghri/i-have-adhd --ref main
+codex plugin add i-have-adhd@i-have-adhd
+```
+
+In Codex, type `$i-have-adhd` to request the output style explicitly.
+
 ## Verify
+
+### Claude Code
 
 ```bash
 claude plugin list
@@ -22,7 +35,17 @@ claude plugin list
 
 Look for `i-have-adhd  (enabled)`.
 
+### Codex
+
+```bash
+codex plugin list
+```
+
+Look for `i-have-adhd` in the configured `i-have-adhd` marketplace.
+
 ## Update
+
+### Claude Code
 
 ```bash
 cd ./i-have-adhd && git pull
@@ -30,11 +53,28 @@ cd ./i-have-adhd && git pull
 
 The marketplace re-reads the local checkout. Next Claude Code session picks up changes.
 
+### Codex
+
+```bash
+codex plugin marketplace upgrade i-have-adhd
+codex plugin remove i-have-adhd
+codex plugin add i-have-adhd@i-have-adhd
+```
+
 ## Uninstall
+
+### Claude Code
 
 ```bash
 claude plugin uninstall i-have-adhd
 claude plugin marketplace remove i-have-adhd
+```
+
+### Codex
+
+```bash
+codex plugin remove i-have-adhd
+codex plugin marketplace remove i-have-adhd
 ```
 
 ## Always-on (optional)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 ## Install
 
+### Claude Code
+
 ```bash
 git clone https://github.com/ayghri/i-have-adhd ./i-have-adhd
 claude plugin marketplace add ./i-have-adhd
@@ -20,6 +22,15 @@ claude plugin install i-have-adhd@i-have-adhd
 In Claude Code: `/i-have-adhd`.
 
 To disable: `claude plugin disable i-have-adhd` or use `/plugin disable i-have-adhd` from within CC.
+
+### Codex
+
+```bash
+codex plugin marketplace add ayghri/i-have-adhd --ref main
+codex plugin add i-have-adhd@i-have-adhd
+```
+
+In Codex: use `$i-have-adhd` when you want the output style applied explicitly. The skill can also be invoked implicitly when Codex sees a task that benefits from action-first, ADHD-friendly output.
 
 More in [INSTALL.md](./INSTALL.md).
 

--- a/skills/i-have-adhd/agents/openai.yaml
+++ b/skills/i-have-adhd/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "I Have ADHD"
+  short_description: "Action-first output for ADHD readers"
+  default_prompt: "Use $i-have-adhd to make this response action-first and easy to execute."
+
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
## Summary

- Add a Codex plugin manifest at `.codex-plugin/plugin.json`.
- Add a Codex marketplace entry at `.agents/plugins/marketplace.json`.
- Add Codex skill UI metadata at `skills/i-have-adhd/agents/openai.yaml`.
- Document Codex install, verify, update, and uninstall commands in README and INSTALL.

## Why

This repository already works as a Claude Code plugin, but it did not include the Codex plugin manifest and marketplace metadata needed for Codex's plugin marketplace flow. This change keeps the existing Claude Code setup intact while making the same skill discoverable and installable from Codex.

## Usage

```bash
codex plugin marketplace add ayghri/i-have-adhd --ref main
codex plugin add i-have-adhd@i-have-adhd
```

In Codex, users can explicitly invoke the skill with `$i-have-adhd`.

## Validation

- `jq . .codex-plugin/plugin.json`
- `jq . .agents/plugins/marketplace.json`
- `python3 /Users/seonghobae/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py .`
- `python3 /Users/seonghobae/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/i-have-adhd`
- `CODEX_HOME=<temp> codex plugin marketplace add . --json`
- `CODEX_HOME=<temp> codex plugin list --marketplace i-have-adhd --available --json`

## Fork-side review

I also opened a separate fork-side review PR and requested Copilot review there: https://github.com/seonghobae/i-have-adhd/pull/1

Copilot reviewed all 5 changed files and generated no comments.
