### PR TITLE
[cursor] Add Cursor skill install docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Install i-have-adhd
 
-A Claude Code plugin. One skill inside.
+One skill. Installable in Claude Code, Codex, and Cursor.
 
 ## TL;DR
 
@@ -25,6 +25,30 @@ codex plugin add i-have-adhd@i-have-adhd
 
 In Codex, type `$i-have-adhd` to request the output style explicitly.
 
+### Cursor
+
+```bash
+mkdir -p ~/.cursor/skills
+git clone --depth 1 https://github.com/ayghri/i-have-adhd.git /tmp/i-have-adhd
+cp -R /tmp/i-have-adhd/skills/i-have-adhd ~/.cursor/skills/
+rm -rf /tmp/i-have-adhd
+```
+
+Open a new Cursor Agent chat, type `/i-have-adhd`.
+
+If you already cloned the repo (e.g. for Claude Code), skip the clone and copy from that checkout:
+
+```bash
+cp -R ./skills/i-have-adhd ~/.cursor/skills/
+```
+
+Project-only install (this repo / one workspace):
+
+```bash
+mkdir -p .cursor/skills
+cp -R /path/to/i-have-adhd/skills/i-have-adhd .cursor/skills/
+```
+
 ## Verify
 
 ### Claude Code
@@ -42,6 +66,16 @@ codex plugin list
 ```
 
 Look for `i-have-adhd` in the configured `i-have-adhd` marketplace.
+
+### Cursor
+
+Confirm the skill directory exists:
+
+```bash
+ls ~/.cursor/skills/i-have-adhd/SKILL.md
+```
+
+In a new Agent chat, type `/` and look for `i-have-adhd`.
 
 ## Update
 
@@ -61,6 +95,17 @@ codex plugin remove i-have-adhd
 codex plugin add i-have-adhd@i-have-adhd
 ```
 
+### Cursor
+
+```bash
+rm -rf ~/.cursor/skills/i-have-adhd
+git clone --depth 1 https://github.com/ayghri/i-have-adhd.git /tmp/i-have-adhd
+cp -R /tmp/i-have-adhd/skills/i-have-adhd ~/.cursor/skills/
+rm -rf /tmp/i-have-adhd
+```
+
+Start a new Agent chat so Cursor re-reads the skill.
+
 ## Uninstall
 
 ### Claude Code
@@ -77,7 +122,17 @@ codex plugin remove i-have-adhd
 codex plugin marketplace remove i-have-adhd
 ```
 
+### Cursor
+
+```bash
+rm -rf ~/.cursor/skills/i-have-adhd
+```
+
+For a project install, remove `.cursor/skills/i-have-adhd` instead.
+
 ## Always-on (optional)
+
+### Claude Code
 
 To skip `/i-have-adhd` and apply the rules from message one, add to `~/.claude/CLAUDE.md`:
 
@@ -86,6 +141,10 @@ To skip `/i-have-adhd` and apply the rules from message one, add to `~/.claude/C
 
 Always follow the rules in the `i-have-adhd` skill: action-first, numbered steps, no preamble, no closers, state restated each turn.
 ```
+
+### Cursor
+
+Add the same text to **Cursor Settings → Rules → User Rules** (applies across projects), or put it in a project rule under `.cursor/rules/` with `alwaysApply: true`.
 
 ## Troubleshooting
 
@@ -96,3 +155,7 @@ Always follow the rules in the `i-have-adhd` skill: action-first, numbered steps
 **Skill activates but model still preambles.** Open a new session. Old context may carry. If it still drifts, tighten the rule wording in `skills/i-have-adhd/SKILL.md`, then re-invoke.
 
 **Want different rules.** Edit `skills/i-have-adhd/SKILL.md`. Re-invoke `/i-have-adhd` (or restart) and the new rules apply.
+
+**Cursor: `/i-have-adhd` missing after install.** Start a new Agent chat. Skills are indexed at session start. Confirm `~/.cursor/skills/i-have-adhd/SKILL.md` exists and that the frontmatter `name` matches the folder name.
+
+**Cursor: skill present but replies still preamble.** Invoke `/i-have-adhd` once in the chat, or use the Always-on User Rule above. Skill auto-invocation is relevance-based; always-on User Rules are stricter.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,16 +52,10 @@ Open a new Cursor Agent chat, type `/i-have-adhd`.
 
 ```bash
 mkdir -p ~/.cursor/skills
-git clone --depth 1 https://github.com/ayghri/i-have-adhd.git /tmp/i-have-adhd
-cp -R /tmp/i-have-adhd/skills/i-have-adhd ~/.cursor/skills/
-rm -rf /tmp/i-have-adhd
+cp -R /path/to/i-have-adhd/skills/i-have-adhd ~/.cursor/skills/
 ```
 
-Already cloned (e.g. for Claude Code):
-
-```bash
-cp -R ./skills/i-have-adhd ~/.cursor/skills/
-```
+Replace `/path/to/i-have-adhd` with an existing checkout, such as the checkout used for Claude Code.
 
 Project-only without the CLI:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,6 +27,29 @@ In Codex, type `$i-have-adhd` to request the output style explicitly.
 
 ### Cursor
 
+Project (this workspace):
+
+```bash
+npx skills add ayghri/i-have-adhd
+```
+
+Global (all Cursor projects):
+
+```bash
+npx skills add ayghri/i-have-adhd -g
+```
+
+Cursor-only (skip other agents):
+
+```bash
+npx skills add ayghri/i-have-adhd -a cursor -y
+```
+
+Open a new Cursor Agent chat, type `/i-have-adhd`.
+
+<details>
+<summary>Manual fallback (clone + copy)</summary>
+
 ```bash
 mkdir -p ~/.cursor/skills
 git clone --depth 1 https://github.com/ayghri/i-have-adhd.git /tmp/i-have-adhd
@@ -34,20 +57,20 @@ cp -R /tmp/i-have-adhd/skills/i-have-adhd ~/.cursor/skills/
 rm -rf /tmp/i-have-adhd
 ```
 
-Open a new Cursor Agent chat, type `/i-have-adhd`.
-
-If you already cloned the repo (e.g. for Claude Code), skip the clone and copy from that checkout:
+Already cloned (e.g. for Claude Code):
 
 ```bash
 cp -R ./skills/i-have-adhd ~/.cursor/skills/
 ```
 
-Project-only install (this repo / one workspace):
+Project-only without the CLI:
 
 ```bash
 mkdir -p .cursor/skills
 cp -R /path/to/i-have-adhd/skills/i-have-adhd .cursor/skills/
 ```
+
+</details>
 
 ## Verify
 
@@ -69,11 +92,13 @@ Look for `i-have-adhd` in the configured `i-have-adhd` marketplace.
 
 ### Cursor
 
-Confirm the skill directory exists:
-
 ```bash
-ls ~/.cursor/skills/i-have-adhd/SKILL.md
+npx skills list
+# or, if installed globally:
+npx skills ls -g
 ```
+
+Look for `i-have-adhd`. Or confirm the file exists: `ls ~/.cursor/skills/i-have-adhd/SKILL.md` (global) / `.cursor/skills/i-have-adhd/SKILL.md` (project).
 
 In a new Agent chat, type `/` and look for `i-have-adhd`.
 
@@ -98,10 +123,9 @@ codex plugin add i-have-adhd@i-have-adhd
 ### Cursor
 
 ```bash
-rm -rf ~/.cursor/skills/i-have-adhd
-git clone --depth 1 https://github.com/ayghri/i-have-adhd.git /tmp/i-have-adhd
-cp -R /tmp/i-have-adhd/skills/i-have-adhd ~/.cursor/skills/
-rm -rf /tmp/i-have-adhd
+npx skills update i-have-adhd
+# or, if installed globally:
+npx skills update -g
 ```
 
 Start a new Agent chat so Cursor re-reads the skill.
@@ -125,10 +149,12 @@ codex plugin marketplace remove i-have-adhd
 ### Cursor
 
 ```bash
-rm -rf ~/.cursor/skills/i-have-adhd
+npx skills remove i-have-adhd
+# or, if installed globally:
+npx skills remove i-have-adhd -g
 ```
 
-For a project install, remove `.cursor/skills/i-have-adhd` instead.
+Manual fallback: `rm -rf ~/.cursor/skills/i-have-adhd` or `.cursor/skills/i-have-adhd`.
 
 ## Always-on (optional)
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ npx skills add ayghri/i-have-adhd
 
 Global: `npx skills add ayghri/i-have-adhd -g`. Cursor-only: `npx skills add ayghri/i-have-adhd -a cursor -y`.
 
-In Cursor Agent: `/i-have-adhd` (or `@i-have-adhd`). Start a new Agent chat after install.
+In Cursor Agent: `/i-have-adhd`. Start a new Agent chat after install.
 
 To uninstall: `npx skills remove i-have-adhd` (or `-g` if installed globally).
 
@@ -49,9 +49,7 @@ To uninstall: `npx skills remove i-have-adhd` (or `-g` if installed globally).
 
 ```bash
 mkdir -p ~/.cursor/skills
-git clone --depth 1 https://github.com/ayghri/i-have-adhd.git /tmp/i-have-adhd
-cp -R /tmp/i-have-adhd/skills/i-have-adhd ~/.cursor/skills/
-rm -rf /tmp/i-have-adhd
+cp -R /path/to/i-have-adhd/skills/i-have-adhd ~/.cursor/skills/
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -35,15 +35,26 @@ In Codex: use `$i-have-adhd` when you want the output style applied explicitly. 
 ### Cursor
 
 ```bash
+npx skills add ayghri/i-have-adhd
+```
+
+Global: `npx skills add ayghri/i-have-adhd -g`. Cursor-only: `npx skills add ayghri/i-have-adhd -a cursor -y`.
+
+In Cursor Agent: `/i-have-adhd` (or `@i-have-adhd`). Start a new Agent chat after install.
+
+To uninstall: `npx skills remove i-have-adhd` (or `-g` if installed globally).
+
+<details>
+<summary>Manual fallback (clone + copy)</summary>
+
+```bash
 mkdir -p ~/.cursor/skills
 git clone --depth 1 https://github.com/ayghri/i-have-adhd.git /tmp/i-have-adhd
 cp -R /tmp/i-have-adhd/skills/i-have-adhd ~/.cursor/skills/
 rm -rf /tmp/i-have-adhd
 ```
 
-In Cursor Agent: `/i-have-adhd` (or `@i-have-adhd`). Start a new Agent chat after install.
-
-To uninstall: `rm -rf ~/.cursor/skills/i-have-adhd`.
+</details>
 
 More in [INSTALL.md](./INSTALL.md).
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,24 @@ codex plugin add i-have-adhd@i-have-adhd
 
 In Codex: use `$i-have-adhd` when you want the output style applied explicitly. The skill can also be invoked implicitly when Codex sees a task that benefits from action-first, ADHD-friendly output.
 
+### Cursor
+
+```bash
+mkdir -p ~/.cursor/skills
+git clone --depth 1 https://github.com/ayghri/i-have-adhd.git /tmp/i-have-adhd
+cp -R /tmp/i-have-adhd/skills/i-have-adhd ~/.cursor/skills/
+rm -rf /tmp/i-have-adhd
+```
+
+In Cursor Agent: `/i-have-adhd` (or `@i-have-adhd`). Start a new Agent chat after install.
+
+To uninstall: `rm -rf ~/.cursor/skills/i-have-adhd`.
+
 More in [INSTALL.md](./INSTALL.md).
 
 ## What it does
 
-A Claude Code skill that stops burying the answer. Action first. Steps numbered. No "Hope this helps!"
+A skill for Claude Code, Codex, and Cursor that stops burying the answer. Action first. Steps numbered. No "Hope this helps!"
 
 
 ## What changes


### PR DESCRIPTION
## Summary
- Document Cursor install for the existing `skills/i-have-adhd` skill (no skill-file changes needed: frontmatter already matches [Cursor Agent Skills](https://cursor.com/docs/skills)).
- Cover global (`~/.cursor/skills/`) and project (`.cursor/skills/`) installs, plus verify / update / uninstall / always-on / troubleshooting in `INSTALL.md`.
- Note Cursor in the README install section and “What it does” line.

## Why
Same pattern as the Codex compatibility PR: keep one `SKILL.md`, document how each agent loads it. Cursor discovers skills from `~/.cursor/skills/` and `.cursor/skills/` ([docs](https://cursor.com/docs/skills)).

## Validation
Verified on macOS with Cursor’s skill layout:

1. `name` in frontmatter matches folder name `i-have-adhd`
2. Description ≤ 1024 chars; body < 500 lines; no `disable-model-invocation` (allows relevance-based auto-invoke)
3. Fresh install recipe from README produces `~/.cursor/skills/i-have-adhd/SKILL.md` identical to upstream
4. Local install used successfully as a personal Cursor skill before opening this PR

## Usage

```bash
mkdir -p ~/.cursor/skills
git clone --depth 1 https://github.com/ayghri/i-have-adhd.git /tmp/i-have-adhd
cp -R /tmp/i-have-adhd/skills/i-have-adhd ~/.cursor/skills/
rm -rf /tmp/i-have-adhd
```

In Cursor Agent: `/i-have-adhd` (new chat after install).