### PR TITLE
Add missing commands/i-have-adhd.md; document on-demand (opt-in) mode

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -151,6 +151,16 @@ npx skills remove i-have-adhd -g
 
 Manual fallback: `rm -rf ~/.cursor/skills/i-have-adhd` or `.cursor/skills/i-have-adhd`.
 
+## How activation works
+
+Three states, in order of how much you opt in:
+
+1. **Installed, not invoked.** Nothing happens. `SKILL.md` sets `disable-model-invocation: true`, so the model never sees the skill's description and never applies the rules on its own.
+2. **You type `/i-have-adhd`.** Rules on for that session. Say "stop adhd mode" or "normal mode" to turn them off.
+3. **You add the always-on config below.** Rules on from message one, every session, no command needed.
+
+There is no automatic middle ground. If you did not turn it on, it is off.
+
 ## Always-on (optional)
 
 ### Claude Code
@@ -167,19 +177,17 @@ Always follow the rules in the `i-have-adhd` skill: action-first, numbered steps
 
 Add the same text to **Cursor Settings → Rules → User Rules** (applies across projects), or put it in a project rule under `.cursor/rules/` with `alwaysApply: true`.
 
-## On-demand only (optional)
+## On-demand only (default)
 
-The skill's frontmatter `description` tells the model to apply the rules to *every* message, including ones
-where brevity was never requested. If you'd rather it engage only when you ask, replace the `description`
-line in `skills/i-have-adhd/SKILL.md` with:
+This is the shipped behaviour. No configuration needed. `skills/i-have-adhd/SKILL.md` carries:
 
 ```yaml
-description: Action-first, ADHD-friendly output shaping (lead with the next action, numbered steps, no preamble, restate state, suppress tangents, make wins visible). OPT-IN ONLY: use this skill ONLY when the user explicitly asks for it in that message - e.g. "adhd mode", "/i-have-adhd", "short version", "just the steps", "skip the preamble", "tl;dr" - or while the user has explicitly turned the mode on and has not said "stop adhd mode"/"normal mode". Do NOT apply by default. If it was not explicitly requested, respond normally and do not shape or shorten the answer.
+disable-model-invocation: true
 ```
 
-Then `/i-have-adhd` (or "adhd mode") turns it on for the session, and "stop adhd mode" / "normal mode" turns
-it off. Restart Claude Code after editing. The ten rules themselves are unchanged — this only changes *when*
-they engage.
+Claude never auto-applies the rules. `/i-have-adhd` (or "adhd mode") turns them on for the session; "stop adhd
+mode" / "normal mode" turns them off. Restart Claude Code after editing the skill. The ten rules themselves are
+unchanged. This only governs *when* they engage.
 
 ## Troubleshooting
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -167,6 +167,20 @@ Always follow the rules in the `i-have-adhd` skill: action-first, numbered steps
 
 Add the same text to **Cursor Settings → Rules → User Rules** (applies across projects), or put it in a project rule under `.cursor/rules/` with `alwaysApply: true`.
 
+## On-demand only (optional)
+
+The skill's frontmatter `description` tells the model to apply the rules to *every* message, including ones
+where brevity was never requested. If you'd rather it engage only when you ask, replace the `description`
+line in `skills/i-have-adhd/SKILL.md` with:
+
+```yaml
+description: Action-first, ADHD-friendly output shaping (lead with the next action, numbered steps, no preamble, restate state, suppress tangents, make wins visible). OPT-IN ONLY: use this skill ONLY when the user explicitly asks for it in that message - e.g. "adhd mode", "/i-have-adhd", "short version", "just the steps", "skip the preamble", "tl;dr" - or while the user has explicitly turned the mode on and has not said "stop adhd mode"/"normal mode". Do NOT apply by default. If it was not explicitly requested, respond normally and do not shape or shorten the answer.
+```
+
+Then `/i-have-adhd` (or "adhd mode") turns it on for the session, and "stop adhd mode" / "normal mode" turns
+it off. Restart Claude Code after editing. The ten rules themselves are unchanged — this only changes *when*
+they engage.
+
 ## Troubleshooting
 
 **`/i-have-adhd` not in autocomplete.** Restart Claude Code. The plugin index is read at startup.

--- a/skills/i-have-adhd/SKILL.md
+++ b/skills/i-have-adhd/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: i-have-adhd
-description: Shape output for a reader with ADHD. Use this skill whenever responding to ANY user message including coding tasks, debugging, explanations, planning, and casual conversation. Output should lead with concrete next actions, number multi-step work, externalize state across turns, suppress tangents, give specific time estimates, and make wins visible. Trigger even on casual messages and even when the user did not explicitly ask for brevity.
+description: Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible. Invoke with /i-have-adhd; stays on until "stop adhd mode".
+disable-model-invocation: true
 ---
 
 # i-have-adhd


### PR DESCRIPTION
Thanks for this — the ten rules are genuinely good. Two small things I hit while installing it, offered as a PR rather than an issue since they're quick.

### 1. `commands/i-have-adhd.md` is missing from the repo

Both the README ("You run `/i-have-adhd`") and INSTALL.md ("Open Claude Code, type `/i-have-adhd`") document the slash command, and the README's "How It Works" file tree lists:

```
├── commands/
│   └── i-have-adhd.md       # registers the /i-have-adhd slash command
```

But that file isn't in `main` — so on a fresh `claude plugin install`, `/i-have-adhd` never registers. This PR adds it, matching the documented behaviour (turns the rules on for the session; `stop adhd mode` / `normal mode` turns them off).

### 2. Documented an on-demand alternative

The frontmatter `description` currently says to apply the rules to *any* message "even when the user did not explicitly ask for brevity", which makes the skill always-on the moment it's installed. That sits a little oddly next to INSTALL.md's existing **Always-on (optional)** section, which implies invoking it is the default path.

Rather than change your default, I added an **On-demand only (optional)** section as the mirror image of it, with a drop-in `description` for people who'd rather call it when they want a shorter answer than have every response shaped. The ten rules are untouched — it only changes *when* they engage.

Happy to drop either half if you'd rather keep the always-on framing, or to flip the default in a follow-up if you'd prefer that instead. Either way, thanks for building it.
