### PR TITLE
Refine ADHD-friendly response behavior

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,14 +1,14 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "i-have-adhd",
-  "description": "Shape Claude Code output for an ADHD reader. Action-first, numbered steps, no tangents.",
+  "description": "Shape Claude Code output for an ADHD reader. Answers first, bounded steps, visible progress.",
   "owner": {
     "name": "Ayoub G."
   },
   "plugins": [
     {
       "name": "i-have-adhd",
-      "description": "Action-first, ADHD-friendly output shaping for Claude Code.",
+      "description": "Low-friction, ADHD-friendly output shaping for Claude Code.",
       "source": "./",
       "category": "productivity"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,4 +1,4 @@
 {
   "name": "i-have-adhd",
-  "description": "Shape Claude Code output for an ADHD reader: lead with the next action, number steps, suppress tangents, restate state, make wins visible."
+  "description": "Shape Claude Code output for an ADHD reader with answers first, bounded steps, visible progress, and preserved agent autonomy."
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "i-have-adhd",
-  "version": "0.1.0",
-  "description": "ADHD-friendly output shaping for Codex: action first, numbered steps, no tangents, and visible progress.",
+  "version": "0.2.0",
+  "description": "ADHD-friendly output shaping for Codex: answers first, bounded steps, visible progress, and preserved agent autonomy.",
   "author": {
     "name": "Ayoub G.",
     "url": "https://github.com/ayghri"
@@ -19,8 +19,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "I Have ADHD",
-    "shortDescription": "Action-first output for ADHD readers",
-    "longDescription": "Shape Codex responses for an ADHD reader by leading with the next action, numbering multi-step work, suppressing tangents, restating state, and making progress visible.",
+    "shortDescription": "Low-friction output for ADHD readers",
+    "longDescription": "Shape Codex responses for an ADHD reader with answers first, bounded steps, visible progress, necessary detail, and preserved agent autonomy.",
     "developerName": "Ayoub G.",
     "category": "Productivity",
     "capabilities": [
@@ -29,8 +29,8 @@
     "websiteURL": "https://github.com/ayghri/i-have-adhd",
     "defaultPrompt": [
       "Use i-have-adhd for this task.",
-      "Make this answer action-first and easy to execute.",
-      "Review this response for ADHD-friendly structure."
+      "Make this answer easy to start, scan, and execute.",
+      "Review this response for ADHD-friendly structure without losing necessary detail."
     ],
     "brandColor": "#2563EB",
     "composerIcon": "./logo.png",

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ More in [INSTALL.md](./INSTALL.md).
 
 ## What it does
 
-A Claude Code skill that stops burying the answer. Action first. Steps numbered. No "Hope this helps!"
+A cross-agent skill that stops burying the answer. Answers first. Bounded steps. No "Hope this helps!"
 
 
 ## What changes
@@ -73,16 +73,16 @@ A Claude Code skill that stops burying the answer. Action first. Steps numbered.
 
 10 rules. Full text in [SKILL.md](./skills/i-have-adhd/SKILL.md).
 
-1. Lead with the next action.
-2. Number multi-step tasks.
-3. End with one concrete next step.
-4. Suppress tangents.
-5. Restate state every turn.
-6. Specific time estimates (minutes, not "a bit").
-7. Make wins visible.
-8. Matter-of-fact errors.
-9. Cap lists at 5 items.
-10. No preamble. No recap. No closers.
+1. Lead with the answer or next action.
+2. Turn procedures into bounded steps.
+3. Track substantial work visibly.
+4. Make progress concrete.
+5. Suppress tangents.
+6. Preserve necessary detail.
+7. Use time estimates only when useful.
+8. Report errors matter-of-factly.
+9. Respect the user's output contract.
+10. Remove filler.
 
 ## Tune it
 

--- a/skills/i-have-adhd/SKILL.md
+++ b/skills/i-have-adhd/SKILL.md
@@ -1,120 +1,77 @@
 ---
 name: i-have-adhd
-description: Shape output for a reader with ADHD. Use this skill whenever responding to ANY user message including coding tasks, debugging, explanations, planning, and casual conversation. Output should lead with concrete next actions, number multi-step work, externalize state across turns, suppress tangents, give specific time estimates, and make wins visible. Trigger even on casual messages and even when the user did not explicitly ask for brevity.
+description: Shape responses for an ADHD reader with answer-first structure, bounded steps, visible progress, and low-friction next actions. Use when the user asks for ADHD-friendly, focus-mode, action-first, concise, or easy-to-execute output, and for substantial multi-step work that benefits from explicit state tracking. Do not invoke for every casual or purely informational message unless the user explicitly requests the style.
 ---
 
-# i-have-adhd
+# I Have ADHD
 
-The reader has ADHD. Output is not just brief. It is shaped so an ADHD brain can act on it.
+Make the response easy to start, scan, and finish. Preserve correctness, safety, necessary detail, and agent autonomy; shorter is useful only when it removes friction.
 
-## What ADHD changes about reading
+## Core rules
 
-Five facts drive every rule below:
+### 1. Lead with the answer or next action
 
-1. Working memory is small. Anything not on screen is forgotten. Do not ask the reader to "keep in mind X."
-2. Knowing the answer is not doing the answer. The friction between "got it" and "done it" is where work dies.
-3. Starting is the hardest step. The first action must be obvious, small, and doable now.
-4. Time estimates feel uniform. "A bit of work" and "a few hours" register the same. Vague estimates fail.
-5. Dopamine is scarce. Visible progress matters. Buried wins do not register.
+Put the most useful information first.
 
-## Rules
+- For a question, lead with the answer.
+- For a user-owned task, lead with the smallest useful action.
+- For agent-owned work, do the work and lead the final response with the result.
 
-### 1. Lead with the next action
+Do not force the user to run commands, edit files, or gather facts when the agent can safely do that work.
 
-The first line is something the reader can do. Not context. Not a plan. The action.
+### 2. Turn procedures into bounded steps
 
-Bad: "Let's think about this. Your auth flow has a few moving pieces..."
-Good: "Run `npm install jsonwebtoken`, then edit `src/auth.ts:42`."
+Number tasks with more than one meaningful action. Keep one action per step and split a long workflow into groups of at most five items.
 
-If the answer is a command, path, or snippet, it goes first. Prose comes after, if at all.
+Do not number a direct answer, acknowledgment, or casual reply merely to satisfy the format.
 
-### 2. Number multi-step tasks
+### 3. Track substantial work visibly
 
-If the work takes more than one step, write a numbered list. Each step is one bounded action. No step contains "and then" twice.
+For work with several meaningful stages, use the harness's native plan or task tracker when available. Keep one stage in progress and update it as work changes.
 
-Bad: "First open the file, find the function, swap it out, then run the tests."
+In user-facing updates, state the current stage and the next meaningful action. Do not duplicate a full plan the user can already see unless they ask or the interface hides it.
 
-Good:
-```
-1. Open `src/auth.ts`
-2. Replace `verifyToken` (lines 42 to 58) with the snippet below
-3. Run `npm test -- auth.spec.ts`
-```
+### 4. Make progress concrete
 
-### 3. End with one concrete next action
+Name completed work in observable terms: what now works, which check passed, or which artifact changed. If work remains, end with one next action. If the task is complete, end with the result instead of inventing another task.
 
-If anything is left open, name ONE thing the reader can do in under two minutes. Even "open the file" counts.
+### 5. Suppress tangents
 
-Bad: "Hope that helps. Let me know if you want to dig deeper."
-Good: "Next: run `npm test` and paste the first failing line."
+Finish the requested task before introducing a separate concern. Mention a secondary issue only when it changes correctness, safety, or the user's immediate decision.
 
-### 4. Suppress tangents
+### 6. Preserve necessary detail
 
-If a second issue exists, finish the first, then offer the second as a separate question.
+Match the user's requested depth. Use headers and short sections for long explanations; do not remove prerequisites, tradeoffs, rollback steps, citations, or failure details merely to be brief.
 
-Bad: "Here's the fix. By the way, your dependency is also stale, and your README is out of date, and..."
-Good: "Here's the fix. Separately: there is also a stale dependency. Want me to handle that next?"
+### 7. Use time estimates only when useful
 
-### 5. Restate state every turn
+Give an effort range when the user is choosing or scheduling work and evidence supports an estimate. State the assumptions behind it. Do not promise future completion times or add false precision to a simple answer.
 
-The reader cannot hold "we are on step 3 of 5" between messages. Restate it.
+### 8. Report errors matter-of-factly
 
-Bad: "Done. Ready for the next part?"
-Good: "Step 3 of 5 done: schema updated. Next: backfill the new column. Run the script?"
+State the failure, location, cause when known, and smallest safe fix. Preserve decisive error text exactly. Avoid alarmist or apologetic filler.
 
-### 6. Give specific time estimates
+### 9. Respect the user's output contract
 
-Vague estimates fail. Ballpark in concrete units.
+If the user requests only code, JSON, a command, a detailed walkthrough, or another specific shape, follow that contract. The requested format takes priority over default styling.
 
-Bad: "This will take some work."
-Good: "About 15 minutes if tests already cover this. An afternoon if not."
+### 10. Remove filler
 
-### 7. Make completed work visible
+Delete greetings, praise, narration about answering, redundant recaps, and closing pleasantries. Required safety confirmations, progress updates, source attribution, and blocking questions are not filler.
 
-Show what now works, in concrete terms. Do not bury wins in a recap.
+## Override rules
 
-Bad: "I've made some changes to the auth flow. Among other things..."
-Good: "Login now works with magic links. Try: `npm run dev`, open `/login`."
-
-### 8. Matter-of-fact tone for errors
-
-Never use "Uh oh," "Oh no," or "There seems to be a problem." State cause and fix.
-
-Bad: "Uh oh, the test is failing. There seems to be an issue..."
-Good: "Test fails at `auth.spec.ts:42`: expected 200, got 401. Cause: missing auth header. Fix: add `Authorization: Bearer ${token}` to the request."
-
-### 9. Cap lists at 5 items
-
-If a list grows past five, split into "do now" vs "later," or "must" vs "nice to have." Five items ranked beats ten unranked.
-
-### 10. No preamble, no recap, no closing pleasantries
-
-Forbidden openers: "Great question," "Let me...", "I'll...", "Sure!", "Looking at your...", "To answer your question..."
-
-Forbidden recaps after a completed task: "I've now done X, Y, and Z, which means..."
-
-Forbidden closers: "Let me know if you need anything else," "Hope this helps," "Happy to clarify," "Feel free to ask."
-
-Start with the answer. End when the answer is done.
-
-## When to break the rules
-
-Override the defaults when:
-
-1. User asks to "explain" or "walk me through." Explain fully. Still no preamble, still no closer, but the body runs as long as the topic needs. Add headers so the reader can skim back.
-2. Destructive action ahead (`rm -rf`, force push, schema migration, dropping a table). Confirm before acting. Safety wins over brevity.
-3. Debug spiral. If the last three turns have been "still broken," stop iterating on code. Name the assumption that might be wrong. Ask one diagnostic question.
-4. Real ambiguity in the request. One short clarifying question beats guessing and rewriting.
+1. Before destructive or difficult-to-recover actions, resolve the exact target with a read-only preview, show what would change, and then confirm. Never invent or broaden the target.
+2. Ask one concise question when genuine ambiguity would materially change the result.
+3. After three failed iterations, stop the loop, name the uncertain assumption, and request one diagnostic.
+4. Never imply that this response style diagnoses or treats ADHD.
 
 ## Pre-send check
 
-Before sending, delete:
+Verify that:
 
-1. The first sentence if it announces what you are about to do.
-2. The last sentence if it asks "anything else?" or recaps what just happened.
-3. Any "by the way" sidebar.
-4. Any hedging adverb adding no information ("perhaps," "might," "could possibly").
-
-Then verify: if the reader reads only the first line and the last line, do they know (a) what to do next, and (b) what just happened?
-
-If yes, send.
+1. The first line contains the answer, result, or next action.
+2. Agent-owned work was not pushed back to the user.
+3. Necessary detail, safety information, and explicit format requests remain intact.
+4. Progress is visible without repeating the entire conversation.
+5. The final line is useful and contains no generic invitation or pleasantry.

--- a/skills/i-have-adhd/agents/openai.yaml
+++ b/skills/i-have-adhd/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "I Have ADHD"
-  short_description: "Action-first output for ADHD readers"
-  default_prompt: "Use $i-have-adhd to make this response action-first and easy to execute."
+  short_description: "Low-friction output for ADHD readers"
+  default_prompt: "Use $i-have-adhd to make this response easy to start, scan, and execute."
 
 policy:
   allow_implicit_invocation: true


### PR DESCRIPTION
## What changed

- narrow implicit activation to explicit ADHD/focus requests and substantial action-heavy work
- lead with the answer, next action, or completed result according to task ownership
- prevent the skill from delegating agent-owned edits and checks back to the user
- use native plan/task tracking for substantial work without hardcoding harness tool names
- preserve requested detail, output contracts, safety context, and rollback information
- require read-only target resolution before destructive-action confirmation
- make timing conditional and evidence-based instead of mandatory
- synchronize Claude, Codex, README, and OpenAI-facing metadata; bump Codex metadata to `0.2.0`

## Why

The original frontmatter requested activation for every message, although the README described contextual implicit invocation. Several rules also conflicted in real agent workflows: the first line always had to be a user action, timing was mandatory, and every turn had to restate state even when no workflow existed.

These conflicts could make the skill less correct, less autonomous, or more verbose—the concern raised in #4.

Closes #3.

## User impact

The skill keeps its action-first identity but now adapts to the task:

- direct questions start with answers
- agent-owned work is performed and reported
- complex work exposes progress
- detailed explanations retain necessary depth
- casual replies do not become artificial numbered workflows

Always-on behavior remains available through the documented user configuration.

## Validation

- skill quick validator: pass
- Codex plugin validator: pass
- all JSON manifests parsed with `jq`: pass
- `git diff --check`: pass
- independent forward tests: agent autonomy, destructive-action safety, and detailed OAuth explanation
- destructive-action test exposed one broad-target defect; the rule was tightened and the repeat test correctly requested the repository path and promised a read-only preview

Live paired evaluation is being tracked in #9. Claude produced 22 baseline responses with `$6.65` reported spend before the account reached its weekly usage limit; no benchmark result is claimed yet.
