### PR TITLE
feat: add support for Google Antigravity (agy) CLI

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,202 +1,43 @@
 # Install i-have-adhd
 
-One skill. Installable in Claude Code, Codex, and Cursor.
+One skill. Claude Code, Codex, Antigravity, Cursor.
 
-## TL;DR
+<details>
+<summary><strong>Claude Code</strong></summary>
 
-### Claude Code
+### Install
 
 ```bash
 claude plugin marketplace add ayghri/i-have-adhd
 claude plugin install i-have-adhd@i-have-adhd
 ```
 
-No local clone needed — Claude Code fetches the repo and keeps it updated.
+Type `/i-have-adhd`.
 
-Open Claude Code, type `/i-have-adhd`.
-
-To disable: `claude plugin disable i-have-adhd` (or `/plugin disable i-have-adhd` from within Claude Code). Re-enable later with `enable` instead of `disable`.
-
-### Codex
-
-```bash
-codex plugin marketplace add ayghri/i-have-adhd --ref main
-codex plugin add i-have-adhd@i-have-adhd
-```
-
-In Codex, type `$i-have-adhd` to request the output style explicitly.
-
-### Antigravity (`agy`)
-
-```bash
-agy plugin install https://github.com/ayghri/i-have-adhd
-```
-
-In Antigravity, type `/skills` to verify that `i-have-adhd` is loaded.
-
-To disable: `agy plugin disable i-have-adhd`.
-
-### Cursor
-
-Project (this workspace):
-
-```bash
-npx skills add ayghri/i-have-adhd
-```
-
-Global (all Cursor projects):
-
-```bash
-npx skills add ayghri/i-have-adhd -g
-```
-
-Cursor-only (skip other agents):
-
-```bash
-npx skills add ayghri/i-have-adhd -a cursor -y
-```
-
-Open a new Cursor Agent chat, type `/i-have-adhd`.
-
-<details>
-<summary>Manual fallback (clone + copy)</summary>
-
-```bash
-mkdir -p ~/.cursor/skills
-cp -R /path/to/i-have-adhd/skills/i-have-adhd ~/.cursor/skills/
-```
-
-Replace `/path/to/i-have-adhd` with a local clone (`git clone https://github.com/ayghri/i-have-adhd`).
-
-Project-only without the CLI:
-
-```bash
-mkdir -p .cursor/skills
-cp -R /path/to/i-have-adhd/skills/i-have-adhd .cursor/skills/
-```
-
-</details>
-
-## Verify
-
-### Claude Code
+### Verify
 
 ```bash
 claude plugin list
 ```
 
-Look for `i-have-adhd  (enabled)`.
-
-### Codex
-
-```bash
-codex plugin list
-```
-
-Look for `i-have-adhd` in the configured `i-have-adhd` marketplace.
-
-### Antigravity (`agy`)
-
-```bash
-agy plugin list
-```
-
-Look for `i-have-adhd` in the list of installed plugins.
-
-### Cursor
-
-```bash
-npx skills list
-# or, if installed globally:
-npx skills ls -g
-```
-
-Look for `i-have-adhd`. Or confirm the file exists: `ls ~/.cursor/skills/i-have-adhd/SKILL.md` (global) / `.cursor/skills/i-have-adhd/SKILL.md` (project).
-
-In a new Agent chat, type `/` and look for `i-have-adhd`.
-
-## Update
-
-### Claude Code
+### Update
 
 ```bash
 claude plugin marketplace update i-have-adhd
 ```
 
-Next Claude Code session picks up changes.
-
-### Codex
-
-```bash
-codex plugin marketplace upgrade i-have-adhd
-codex plugin remove i-have-adhd
-codex plugin add i-have-adhd@i-have-adhd
-```
-
-### Antigravity (`agy`)
-
-```bash
-agy plugin uninstall i-have-adhd
-agy plugin install https://github.com/ayghri/i-have-adhd
-```
-
-### Cursor
-
-```bash
-npx skills update i-have-adhd
-# or, if installed globally:
-npx skills update -g
-```
-
-Start a new Agent chat so Cursor re-reads the skill.
-
-## Uninstall
-
-### Claude Code
+### Uninstall
 
 ```bash
 claude plugin uninstall i-have-adhd
 claude plugin marketplace remove i-have-adhd
 ```
 
-### Codex
+Or keep it installed and turn it off: `claude plugin disable i-have-adhd`.
 
-```bash
-codex plugin remove i-have-adhd
-codex plugin marketplace remove i-have-adhd
-```
+### Always-on (optional)
 
-### Antigravity (`agy`)
-
-```bash
-agy plugin uninstall i-have-adhd
-```
-
-### Cursor
-
-```bash
-npx skills remove i-have-adhd
-# or, if installed globally:
-npx skills remove i-have-adhd -g
-```
-
-Manual fallback: `rm -rf ~/.cursor/skills/i-have-adhd` or `.cursor/skills/i-have-adhd`.
-
-## How activation works
-
-Three states, in order of how much you opt in:
-
-1. **Installed, not invoked.** Nothing happens. `SKILL.md` sets `disable-model-invocation: true`, so the model never sees the skill's description and never applies the rules on its own.
-2. **You type `/i-have-adhd`.** Rules on for that session. Say "stop adhd mode" or "normal mode" to turn them off.
-3. **You add the always-on config below.** Rules on from message one, every session, no command needed.
-
-There is no automatic middle ground. If you did not turn it on, it is off.
-
-## Always-on (optional)
-
-### Claude Code
-
-To skip `/i-have-adhd` and apply the rules from message one, add to `~/.claude/CLAUDE.md`:
+Add to `~/.claude/CLAUDE.md`:
 
 ```markdown
 ## Output style
@@ -204,36 +45,165 @@ To skip `/i-have-adhd` and apply the rules from message one, add to `~/.claude/C
 Always follow the rules in the `i-have-adhd` skill: action-first, numbered steps, no preamble, no closers, state restated each turn.
 ```
 
-### Antigravity (`agy`)
+</details>
 
-Add the same block to `~/.gemini/GEMINI.md`.
+<details>
+<summary><strong>Codex</strong></summary>
 
-### Cursor
+### Install
 
-Add the same text to **Cursor Settings → Rules → User Rules** (applies across projects), or put it in a project rule under `.cursor/rules/` with `alwaysApply: true`.
-
-## On-demand only (default)
-
-This is the shipped behaviour. No configuration needed. `skills/i-have-adhd/SKILL.md` carries:
-
-```yaml
-disable-model-invocation: true
+```bash
+codex plugin marketplace add ayghri/i-have-adhd --ref main
+codex plugin add i-have-adhd@i-have-adhd
 ```
 
-Claude never auto-applies the rules. `/i-have-adhd` (or "adhd mode") turns them on for the session; "stop adhd
-mode" / "normal mode" turns them off. Restart Claude Code after editing the skill. The ten rules themselves are
-unchanged. This only governs *when* they engage.
+Type `$i-have-adhd`.
+
+### Verify
+
+```bash
+codex plugin list
+```
+
+### Update
+
+```bash
+codex plugin marketplace upgrade i-have-adhd
+codex plugin remove i-have-adhd
+codex plugin add i-have-adhd@i-have-adhd
+```
+
+### Uninstall
+
+```bash
+codex plugin remove i-have-adhd
+codex plugin marketplace remove i-have-adhd
+```
+
+### Always-on (optional)
+
+Add to `~/.codex/AGENTS.md`:
+
+```markdown
+## Output style
+
+Always follow the rules in the `i-have-adhd` skill: action-first, numbered steps, no preamble, no closers, state restated each turn.
+```
+
+</details>
+
+<details>
+<summary><strong>Antigravity (<code>agy</code>)</strong></summary>
+
+### Install
+
+```bash
+agy plugin install https://github.com/ayghri/i-have-adhd
+```
+
+### Verify
+
+```bash
+agy plugin list
+```
+
+### Update
+
+```bash
+agy plugin uninstall i-have-adhd
+agy plugin install https://github.com/ayghri/i-have-adhd
+```
+
+### Uninstall
+
+```bash
+agy plugin uninstall i-have-adhd
+```
+
+Or keep it installed and turn it off: `agy plugin disable i-have-adhd`.
+
+### Always-on (optional)
+
+Add to `~/.gemini/GEMINI.md`:
+
+```markdown
+## Output style
+
+Always follow the rules in the `i-have-adhd` skill: action-first, numbered steps, no preamble, no closers, state restated each turn.
+```
+
+</details>
+
+<details>
+<summary><strong>Cursor</strong></summary>
+
+### Install
+
+```bash
+npx skills add ayghri/i-have-adhd        # this workspace
+npx skills add ayghri/i-have-adhd -g     # all projects
+npx skills add ayghri/i-have-adhd -a cursor -y   # Cursor only
+```
+
+New Agent chat, type `/i-have-adhd`.
+
+Without the CLI:
+
+```bash
+git clone https://github.com/ayghri/i-have-adhd
+mkdir -p ~/.cursor/skills                              # or .cursor/skills for this project only
+cp -R i-have-adhd/skills/i-have-adhd ~/.cursor/skills/
+```
+
+### Verify
+
+```bash
+npx skills list
+npx skills ls -g    # if installed globally
+```
+
+### Update
+
+```bash
+npx skills update i-have-adhd
+npx skills update -g    # if installed globally
+```
+
+### Uninstall
+
+```bash
+npx skills remove i-have-adhd
+npx skills remove i-have-adhd -g    # if installed globally
+```
+
+### Always-on (optional)
+
+Paste into **Cursor Settings → Rules → User Rules**, or a project rule under `.cursor/rules/` with `alwaysApply: true`:
+
+```markdown
+## Output style
+
+Always follow the rules in the `i-have-adhd` skill: action-first, numbered steps, no preamble, no closers, state restated each turn.
+```
+
+</details>
+
+## How activation works
+
+1. **Installed, not invoked.** Nothing happens. `SKILL.md` sets `disable-model-invocation: true`, so the model never sees the skill and never applies the rules on its own.
+2. **You type `/i-have-adhd`.** Rules on for that session. "stop adhd mode" or "normal mode" turns them off.
+3. **You add the always-on config above.** Rules on from message one, every session.
+
+No middle ground. If you did not turn it on, it is off.
 
 ## Troubleshooting
 
-**`/i-have-adhd` not in autocomplete.** Restart Claude Code. The plugin index is read at startup.
+**`/i-have-adhd` not in autocomplete.** Restart the agent. The plugin index is read at startup.
 
-**`claude plugin marketplace add` fails.** Use the `owner/repo` form: `claude plugin marketplace add ayghri/i-have-adhd`. If you point it at a local path instead, it must be the repo root (the directory containing `.claude-plugin/marketplace.json`), not `.claude-plugin/` itself.
+**`claude plugin marketplace add` fails.** Use the `owner/repo` form. A local path must point at the repo root, not `.claude-plugin/`.
 
-**Skill activates but model still preambles.** Open a new session. Old context may carry. If it still drifts, tighten the rule wording in `skills/i-have-adhd/SKILL.md`, then re-invoke.
+**Installed but replies still preamble.** Open a new session. If it still drifts, tighten the wording in `skills/i-have-adhd/SKILL.md`.
 
-**Want different rules.** Fork the repo, edit `skills/i-have-adhd/SKILL.md`, then install your fork: `claude plugin marketplace add <your-username>/i-have-adhd`. (Or clone locally and `claude plugin marketplace add ./i-have-adhd`.) Re-invoke `/i-have-adhd` and the new rules apply.
+**Want different rules.** Fork, edit `skills/i-have-adhd/SKILL.md`, install your fork: `claude plugin marketplace add <your-username>/i-have-adhd`.
 
-**Cursor: `/i-have-adhd` missing after install.** Start a new Agent chat. Skills are indexed at session start. Confirm `~/.cursor/skills/i-have-adhd/SKILL.md` exists and that the frontmatter `name` matches the folder name.
-
-**Cursor: skill present but replies still preamble.** Invoke `/i-have-adhd` once in the chat, or use the Always-on User Rule above. Skill auto-invocation is relevance-based; always-on User Rules are stricter.
+**Cursor: skill missing after install.** Start a new Agent chat. Confirm `~/.cursor/skills/i-have-adhd/SKILL.md` exists and its frontmatter `name` matches the folder name.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,6 +26,16 @@ codex plugin add i-have-adhd@i-have-adhd
 
 In Codex, type `$i-have-adhd` to request the output style explicitly.
 
+### Antigravity (`agy`)
+
+```bash
+agy plugin install https://github.com/ayghri/i-have-adhd
+```
+
+In Antigravity, type `/skills` to verify that `i-have-adhd` is loaded.
+
+To disable: `agy plugin disable i-have-adhd`.
+
 ### Cursor
 
 Project (this workspace):
@@ -85,6 +95,14 @@ codex plugin list
 
 Look for `i-have-adhd` in the configured `i-have-adhd` marketplace.
 
+### Antigravity (`agy`)
+
+```bash
+agy plugin list
+```
+
+Look for `i-have-adhd` in the list of installed plugins.
+
 ### Cursor
 
 ```bash
@@ -115,6 +133,13 @@ codex plugin remove i-have-adhd
 codex plugin add i-have-adhd@i-have-adhd
 ```
 
+### Antigravity (`agy`)
+
+```bash
+agy plugin uninstall i-have-adhd
+agy plugin install https://github.com/ayghri/i-have-adhd
+```
+
 ### Cursor
 
 ```bash
@@ -139,6 +164,12 @@ claude plugin marketplace remove i-have-adhd
 ```bash
 codex plugin remove i-have-adhd
 codex plugin marketplace remove i-have-adhd
+```
+
+### Antigravity (`agy`)
+
+```bash
+agy plugin uninstall i-have-adhd
 ```
 
 ### Cursor
@@ -172,6 +203,10 @@ To skip `/i-have-adhd` and apply the rules from message one, add to `~/.claude/C
 
 Always follow the rules in the `i-have-adhd` skill: action-first, numbered steps, no preamble, no closers, state restated each turn.
 ```
+
+### Antigravity (`agy`)
+
+Add the same block to `~/.gemini/GEMINI.md`.
 
 ### Cursor
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://antigravity.google/schemas/v1/plugin.json",
+  "name": "i-have-adhd",
+  "version": "0.1.0",
+  "description": "Shape Antigravity output for an ADHD reader: lead with the next action, number steps, suppress tangents, restate state, make wins visible.",
+  "author": {
+    "name": "Ayoub G.",
+    "url": "https://github.com/ayghri"
+  },
+  "homepage": "https://github.com/ayghri/i-have-adhd",
+  "repository": "https://github.com/ayghri/i-have-adhd",
+  "license": "MIT"
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,13 +1,5 @@
 {
   "$schema": "https://antigravity.google/schemas/v1/plugin.json",
   "name": "i-have-adhd",
-  "version": "0.1.0",
-  "description": "Shape Antigravity output for an ADHD reader: lead with the next action, number steps, suppress tangents, restate state, make wins visible.",
-  "author": {
-    "name": "Ayoub G.",
-    "url": "https://github.com/ayghri"
-  },
-  "homepage": "https://github.com/ayghri/i-have-adhd",
-  "repository": "https://github.com/ayghri/i-have-adhd",
-  "license": "MIT"
+  "description": "Shape Antigravity output for an ADHD reader: lead with the next action, number steps, suppress tangents, restate state, make wins visible."
 }


### PR DESCRIPTION
Adds Google Antigravity (`agy`) CLI integration:
    - Adds root `plugin.json` to define the package as an Antigravity plugin.
    - Updates `README.md` and `INSTALL.md` with `agy` instructions (installation via remote Git URL,
  verification, update, and uninstallation).

Fixes #7 