### PR TITLE
fix: install directions for claude

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,10 +7,11 @@ A Claude Code plugin. One skill inside.
 ### Claude Code
 
 ```bash
-git clone https://github.com/ayghri/i-have-adhd ./i-have-adhd
-claude plugin marketplace add ./i-have-adhd
+claude plugin marketplace add ayghri/i-have-adhd
 claude plugin install i-have-adhd@i-have-adhd
 ```
+
+No local clone needed — Claude Code fetches the repo and keeps it updated.
 
 Open Claude Code, type `/i-have-adhd`.
 
@@ -48,10 +49,10 @@ Look for `i-have-adhd` in the configured `i-have-adhd` marketplace.
 ### Claude Code
 
 ```bash
-cd ./i-have-adhd && git pull
+claude plugin marketplace update i-have-adhd
 ```
 
-The marketplace re-reads the local checkout. Next Claude Code session picks up changes.
+Next Claude Code session picks up changes.
 
 ### Codex
 
@@ -91,8 +92,8 @@ Always follow the rules in the `i-have-adhd` skill: action-first, numbered steps
 
 **`/i-have-adhd` not in autocomplete.** Restart Claude Code. The plugin index is read at startup.
 
-**`claude plugin marketplace add` fails.** Point at the repo root, not at `.claude-plugin/`. The path must contain `.claude-plugin/marketplace.json`.
+**`claude plugin marketplace add` fails.** Use the `owner/repo` form: `claude plugin marketplace add ayghri/i-have-adhd`. If you point it at a local path instead, it must be the repo root (the directory containing `.claude-plugin/marketplace.json`), not `.claude-plugin/` itself.
 
 **Skill activates but model still preambles.** Open a new session. Old context may carry. If it still drifts, tighten the rule wording in `skills/i-have-adhd/SKILL.md`, then re-invoke.
 
-**Want different rules.** Edit `skills/i-have-adhd/SKILL.md`. Re-invoke `/i-have-adhd` (or restart) and the new rules apply.
+**Want different rules.** Fork the repo, edit `skills/i-have-adhd/SKILL.md`, then install your fork: `claude plugin marketplace add <your-username>/i-have-adhd`. (Or clone locally and `claude plugin marketplace add ./i-have-adhd`.) Re-invoke `/i-have-adhd` and the new rules apply.

--- a/README.md
+++ b/README.md
@@ -11,27 +11,31 @@
 
 ## Install
 
-### Claude Code
+<details>
+<summary><strong>Claude Code</strong></summary>
 
 ```bash
 claude plugin marketplace add ayghri/i-have-adhd
 claude plugin install i-have-adhd@i-have-adhd
 ```
 
-In Claude Code: `/i-have-adhd`.
+Then type `/i-have-adhd`. No local clone needed — Claude Code fetches the repo and keeps it updated.
 
-To disable: `claude plugin disable i-have-adhd` or use `/plugin disable i-have-adhd` from within CC.
+</details>
 
-### Codex
+<details>
+<summary><strong>Codex</strong></summary>
 
 ```bash
 codex plugin marketplace add ayghri/i-have-adhd --ref main
 codex plugin add i-have-adhd@i-have-adhd
 ```
 
-In Codex: use `$i-have-adhd` when you want the output style applied explicitly. The skill can also be invoked implicitly when Codex sees a task that benefits from action-first, ADHD-friendly output.
+Then type `$i-have-adhd` to apply the output style explicitly. The skill can also be invoked implicitly when Codex sees a task that benefits from it.
 
-More in [INSTALL.md](./INSTALL.md).
+</details>
+
+Everything else — verify, update, disable, uninstall, troubleshooting — lives in [INSTALL.md](./INSTALL.md).
 
 ## What it does
 
@@ -85,7 +89,7 @@ A Claude Code skill that stops burying the answer. Action first. Steps numbered.
 
 ## Tune it
 
-Edit `skills/i-have-adhd/SKILL.md`. Re-invoke `/i-have-adhd`.
+Fork, edit `skills/i-have-adhd/SKILL.md`, install your fork: `claude plugin marketplace add <your-username>/i-have-adhd`. Re-invoke `/i-have-adhd`.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@
 ### Claude Code
 
 ```bash
-git clone https://github.com/ayghri/i-have-adhd ./i-have-adhd
-claude plugin marketplace add ./i-have-adhd
+claude plugin marketplace add ayghri/i-have-adhd
 claude plugin install i-have-adhd@i-have-adhd
 ```
 


### PR DESCRIPTION
Claude allows `claude plugin marketplace add` to take a git repo. Rather than having the user maintain updating a clone, the Claude Code harness can do so for them.

I know I'd forget to update it by hand if I had to 😉

```
❯ claude plugin marketplace add ayghri/i-have-adhd
Cloning via SSH: git@github.com:ayghri/i-have-adhd.git
Refreshing marketplace cache (timeout: 120s)…
Cloning repository (timeout: 120s): git@github.com:ayghri/i-have-adhd.git
Clone complete, validating marketplace…
Cleaning up old marketplace cache…
✔ Successfully added marketplace: i-have-adhd (declared in user settings)

❯ claude plugin install i-have-adhd@i-have-adhd
✔ Successfully installed plugin: i-have-adhd@i-have-adhd (scope: user)
```
