### PR TITLE
fix: quote SKILL.md description to repair invalid YAML frontmatter

### DIFF
--- a/skills/i-have-adhd/SKILL.md
+++ b/skills/i-have-adhd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: i-have-adhd
-description: Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible. Invoke with /i-have-adhd; stays on until "stop adhd mode".
+description: 'Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible. Invoke with /i-have-adhd; stays on until "stop adhd mode".'
 disable-model-invocation: true
 ---
 


### PR DESCRIPTION
## Problem

The frontmatter in `skills/i-have-adhd/SKILL.md` is not valid YAML. The `description` is an unquoted plain scalar containing `: ` (colon + space):

```yaml
description: Shape output for a reader with ADHD: lead with the next action, ...
```

A YAML plain scalar cannot contain `": "`, so any spec-compliant parser fails:

```
yaml.scanner.ScannerError: mapping values are not allowed here
  in "<unicode string>", line 2, column 49
```

## Impact

The documented install command currently fails on `main`:

```console
$ npx skills add https://github.com/ayghri/i-have-adhd --skill i-have-adhd
◇  Repository cloned
◇  No skills found
└  No valid skills found. Skills require a SKILL.md with name and description.
```

That is the exact command in `INSTALL.md` and on the skills.sh page, so the documented path is broken for every agent that installs through that CLI (Codex, Cursor, Gemini CLI, and the shared `~/.agents/skills` targets). Installing as a Claude Code plugin still works, because that path does not parse the frontmatter with a strict YAML parser — which is probably why this slipped through.

The previous revision used a period instead of a colon and parsed fine, so this is a regression from the most recent description rewrite.

## Fix

Wrap the value in single quotes. Single-quoted YAML keeps the inner `"stop adhd mode"` literal, so **no escaping is needed and the description text is unchanged** — the only difference is the surrounding quotes.

## Verification

Before the change both checks fail; after it both pass.

```console
$ python3 -c 'import yaml,re,sys; t=open("skills/i-have-adhd/SKILL.md").read(); print(list(yaml.safe_load(re.match(r"^---\n(.*?)\n---\n",t,re.S).group(1)).keys()))'
['name', 'description', 'disable-model-invocation']

$ npx skills add . -l
◇  Available Skills
│    i-have-adhd
│      Shape output for a reader with ADHD: lead with the next action, ...
```

Confirmed the parsed `description` string is byte-identical to the current text.


Fixes #18
