### PR TITLE
Let the model invoke the skill by default

### DIFF
--- a/skills/i-have-adhd/SKILL.md
+++ b/skills/i-have-adhd/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: i-have-adhd
 description: Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible. Invoke with /i-have-adhd; stays on until "stop adhd mode".
-disable-model-invocation: true
 ---
 
 # i-have-adhd


### PR DESCRIPTION
Removes `disable-model-invocation: true` from `skills/i-have-adhd/SKILL.md`.

## Why

With the flag set, `/i-have-adhd` is the only way the skill can ever load. Asking Claude to apply it does nothing — per the [Claude Code docs](https://code.claude.com/docs/en/skills#control-who-invokes-a-skill), the flag blocks model invocation *and* removes the description from the model's context:

| Frontmatter | You can invoke | Claude can invoke | When loaded into context |
| :-- | :-- | :-- | :-- |
| (default) | Yes | Yes | Description always in context, full skill loads when invoked |
| `disable-model-invocation: true` | Yes | **No** | **Description not in context**, full skill loads when you invoke |

The `~/.claude/CLAUDE.md` snippet in the README keeps the five rules it names in context permanently, but the skill body never loads — so rules 4 and 6–9, the "When to break the rules" section, and the pre-send check only apply in sessions where the user remembers the command.

The docs recommend this flag for side-effecting commands (`/commit`, `/deploy`) where you don't want Claude picking the moment. An output style has neither side effects nor timing sensitivity, and users install it because buried, unstructured output is a persistent problem for them rather than a per-message one.

Full reasoning in #19.

## Impact

**Strictly additive.** `user-invocable` defaults to `true`, so `/i-have-adhd` behaves exactly as it does today. The only change is that the model can also apply the skill on its own, and the description returns to context.

Anyone preferring manual-only can add the line back locally.

## Note on ordering

Branched from `main`, independent of #17 (the YAML frontmatter fix). The two touch adjacent lines in the same block, so whichever merges second may need a one-line rebase — happy to do that whenever suits.

Fixes #19
