### PR TITLE
Add literal-language and shortest-path rules

### DIFF
--- a/skills/i-have-adhd/SKILL.md
+++ b/skills/i-have-adhd/SKILL.md
@@ -33,6 +33,8 @@ If the answer is a command, path, or snippet, it goes first. Prose comes after, 
 
 If the work takes more than one step, write a numbered list. Each step is one bounded action. No step contains "and then" twice.
 
+Use the fewest steps that still work. Cut any step the reader does not need, and fold trivial steps into the one before. A short path finished beats a complete path abandoned.
+
 Bad: "First open the file, find the function, swap it out, then run the tests."
 
 Good:
@@ -115,6 +117,7 @@ Before sending, delete:
 2. The last sentence if it asks "anything else?" or recaps what just happened.
 3. Any "by the way" sidebar.
 4. Any hedging adverb adding no information ("perhaps," "might," "could possibly").
+5. Any idiom or figurative phrase ("circle back," "get the ball rolling," "on the same page"). Replace with the literal action.
 
 Then verify: if the reader reads only the first line and the last line, do they know (a) what to do next, and (b) what just happened?
 


### PR DESCRIPTION
Two concrete behaviors drawn from **W3C Cognitive Accessibility Guidance (COGA)** that the skill operationalizes everywhere else but didn't yet state explicitly:

1. **Rule 2 — shortest path, not just numbered steps.** Numbering steps helps, but COGA calls for *short critical paths*: the fewest steps to done. Added a line to cut steps the reader doesn't need and fold trivial ones in.
2. **Pre-send check — literal language.** COGA calls for literal, non-figurative wording; idioms force the reader to translate before acting. Added a scan item to replace idioms/figurative phrasing with literal wording.

Both are one-line additions to existing sections, so the "10 rules" framing and the README stay intact. Everything else in the plain-language standards (ISO 24495-1, Plain Writing Act, JAN) was already covered by the existing rules — these two were the only net-new behaviors worth adding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)