### PR TITLE
Add opt-in always-on mode via SessionStart hook (Claude Code)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
   "name": "i-have-adhd",
-  "description": "Shape Claude Code output for an ADHD reader: lead with the next action, number steps, suppress tangents, restate state, make wins visible."
+  "description": "Shape Claude Code output for an ADHD reader: lead with the next action, number steps, suppress tangents, restate state, make wins visible.",
+  "hooks": "./hooks/hooks.json"
 }

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,13 +37,19 @@ Or keep it installed and turn it off: `claude plugin disable i-have-adhd`.
 
 ### Always-on (optional)
 
-Add to `~/.claude/CLAUDE.md`:
+One command. A `SessionStart` hook loads the full ruleset at the start of every session — no `/i-have-adhd` needed:
 
-```markdown
-## Output style
-
-Always follow the rules in the `i-have-adhd` skill: action-first, numbered steps, no preamble, no closers, state restated each turn.
+```bash
+touch ~/.claude/.i-have-adhd-always
 ```
+
+Back to on-demand:
+
+```bash
+rm ~/.claude/.i-have-adhd-always
+```
+
+The hook only fires when the flag file exists, so installing the plugin changes nothing by itself. Honors `$CLAUDE_CONFIG_DIR` if you've moved your config dir. "stop adhd mode" still turns it off for the current session.
 
 </details>
 
@@ -195,13 +201,16 @@ Always follow the rules in the `i-have-adhd` skill: action-first, numbered steps
 
 1. **Installed, not invoked.** Nothing happens. `SKILL.md` sets `disable-model-invocation: true`, so the model never sees the skill and never applies the rules on its own.
 2. **You type `/i-have-adhd`.** Rules on for that session. "stop adhd mode" or "normal mode" turns them off.
-3. **You add the always-on config above.** Rules on from message one, every session.
+3. **You touch `~/.claude/.i-have-adhd-always`** (Claude Code). A `SessionStart` hook loads the full ruleset from message one, every session.
+4. **You add the always-on snippet above** (other harnesses). Keeps the core rules in your agent's persistent context.
 
 No middle ground. If you did not turn it on, it is off.
 
 ## Troubleshooting
 
 **`/i-have-adhd` not in autocomplete.** Restart the agent. The plugin index is read at startup.
+
+**Always-on flag has no effect.** Update the plugin (`claude plugin marketplace update i-have-adhd`) and restart — hooks are read at startup, and the flag needs the plugin version that ships `hooks/hooks.json`.
 
 **`claude plugin marketplace add` fails.** Use the `owner/repo` form. A local path must point at the repo root, not `.claude-plugin/`.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ claude plugin install i-have-adhd@i-have-adhd
 
 Then type `/i-have-adhd`. No local clone needed — Claude Code fetches the repo and keeps it updated.
 
+Want it on every session? `touch ~/.claude/.i-have-adhd-always` — see [INSTALL.md](./INSTALL.md).
+
 </details>
 
 <details>

--- a/hooks/always-on.js
+++ b/hooks/always-on.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// SessionStart hook — injects the full i-have-adhd ruleset when always-on
+// mode is enabled. Opt-in via flag file, so installing the plugin changes
+// nothing until you ask for it:
+//
+//   touch ~/.claude/.i-have-adhd-always    # enable
+//   rm ~/.claude/.i-have-adhd-always       # disable
+//
+// Honors $CLAUDE_CONFIG_DIR. Never blocks session start: any failure exits 0.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+const flagPath = path.join(claudeDir, '.i-have-adhd-always');
+
+try {
+  if (!fs.existsSync(flagPath)) process.exit(0);
+
+  const skillPath = path.join(__dirname, '..', 'skills', 'i-have-adhd', 'SKILL.md');
+  const body = fs
+    .readFileSync(skillPath, 'utf8')
+    .replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, ''); // strip YAML frontmatter
+
+  console.log(
+    'ADHD MODE ACTIVE (always-on) — the ruleset below applies to every response. ' +
+      '"stop adhd mode" turns it off for this session; ' +
+      `delete ${flagPath} to turn always-on off for good.\n\n${body}`
+  );
+} catch {
+  process.exit(0);
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/always-on.js\"",
+            "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\always-on.js\" }",
+            "timeout": 5,
+            "statusMessage": "Checking i-have-adhd always-on flag..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What

An opt-in **always-on mode** for Claude Code: a `SessionStart` hook that injects the full `SKILL.md` ruleset at the start of every session (including resume/clear/compact), gated behind a flag file.

```bash
touch ~/.claude/.i-have-adhd-always   # on
rm ~/.claude/.i-have-adhd-always      # off
```

## Why

#19 lays out the gap well: the documented always-on path (a `CLAUDE.md` snippet) only carries the five rules it happens to name — the skill body never loads, so rules 4, 6–9, "When to break the rules", and the pre-send check only apply in sessions where the user remembers `/i-have-adhd`. For the audience this skill is built for, remembering a per-session command is exactly the failure mode.

This is complementary to #20: even with model invocation enabled, loading stays at the model's discretion per message. The hook is deterministic — full ruleset, message one, every session. Same mechanism the ponytail plugin uses for its always-active mode, so there's working precedent for `"hooks"` in `.claude-plugin/plugin.json`.

## Design constraints

- **Off by default.** No flag file → the hook exits silently. Installing or updating the plugin changes nothing until the user opts in, so this can't affect existing installs or the perf concerns in #4.
- **Never blocks startup.** Any failure (missing skill file, unreadable flag dir) exits 0.
- **Claude Code only.** Other harnesses don't read `.claude-plugin/plugin.json`, so their install paths are untouched; their docs keep the existing snippet approach.
- **Session override still works.** "stop adhd mode" turns it off for the current session; the injected header says so and names the flag file to delete for permanent off.

## Files

- `hooks/always-on.js` — reads the flag, strips frontmatter, prints the ruleset (~30 lines, node stdlib only)
- `hooks/hooks.json` — `SessionStart` hook, with a Windows command variant
- `.claude-plugin/plugin.json` — adds the `"hooks"` reference
- `INSTALL.md` — replaces the Claude Code always-on snippet with the flag file, updates "How activation works", adds a troubleshooting entry
- `README.md` — one pointer line in the Claude Code install block

## Verification

```
PASS: hooks.json valid JSON
PASS: no flag -> silent exit 0
PASS: flag present -> header + full skill body in output
PASS: frontmatter stripped (no disable-model-invocation leak into context)
PASS: missing SKILL.md -> silent exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)