### PR TITLE
Opt-in always-on mode for Claude Code

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,5 +5,6 @@
   "author": {
     "name": "Ayoub G.",
     "url": "https://github.com/ayghri"
-  }
+  },
+  "hooks": "./hooks/hooks.json"
 }

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,26 +37,19 @@ Or keep it installed and turn it off: `claude plugin disable i-have-adhd`.
 
 ### Always-on (optional)
 
-Add to `~/.claude/CLAUDE.md`:
+A `SessionStart` hook loads the full ruleset at the start of every session, no `/i-have-adhd` needed:
 
-```markdown
-## Output style
-
-The reader has ADHD. Shape every response so it can be acted on:
-
-1. Lead with the answer or next action: command, path, or snippet first.
-2. Number multi-step work; one bounded action per step.
-3. End with one next action doable in under two minutes.
-4. Finish the current issue before raising a new one.
-5. Restate progress each turn ("step 3 of 5 done").
-6. Give time estimates in concrete units, never "a bit".
-7. After a change, show what now works.
-8. Errors: state location, cause, and fix. No drama.
-9. Cap lists at 5 items.
-10. No preamble, no recaps, no closers.
-
-Exceptions: explain fully when asked to explain. Confirm before destructive actions. After three failed fixes, stop and name the doubtful assumption. If the request is ambiguous, ask one short question.
+```bash
+touch ~/.claude/.i-have-adhd-always
 ```
+
+Back to on-demand:
+
+```bash
+rm ~/.claude/.i-have-adhd-always
+```
+
+The hook only fires when the flag file exists, so installing the plugin changes nothing by itself. Honors `$CLAUDE_CONFIG_DIR` if you've moved your config dir. "stop adhd mode" still turns it off for the current session.
 
 </details>
 
@@ -247,13 +240,16 @@ Exceptions: explain fully when asked to explain. Confirm before destructive acti
 
 1. **Installed, not invoked.** Nothing happens. `SKILL.md` sets `disable-model-invocation: true`, so the model never sees the skill and never applies the rules on its own.
 2. **You type `/i-have-adhd`.** Rules on for that session. "stop adhd mode" or "normal mode" turns them off.
-3. **You add the always-on config above.** Rules on from message one, every session.
+3. **You touch `~/.claude/.i-have-adhd-always`** (Claude Code). A `SessionStart` hook loads the full ruleset from message one, every session.
+4. **You add the always-on snippet above** (other harnesses). Keeps the core rules in your agent's persistent context.
 
 No middle ground. If you did not turn it on, it is off.
 
 ## Troubleshooting
 
 **`/i-have-adhd` not in autocomplete.** Restart the agent. The plugin index is read at startup.
+
+**Always-on flag has no effect.** Update the plugin (`claude plugin marketplace update i-have-adhd`) and restart. Hooks are read at startup, and the flag needs the plugin version that ships `hooks/hooks.json`.
 
 **`claude plugin marketplace add` fails.** Use the `owner/repo` form. A local path must point at the repo root, not `.claude-plugin/`.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ claude plugin install i-have-adhd@i-have-adhd
 
 Then type `/i-have-adhd`. No local clone needed: Claude Code fetches the repo and keeps it updated.
 
+Want it on every session? `touch ~/.claude/.i-have-adhd-always` (see [INSTALL.md](./INSTALL.md)).
+
 </details>
 
 <details>

--- a/hooks/always-on.js
+++ b/hooks/always-on.js
@@ -1,0 +1,25 @@
+// SessionStart hook: injects the full i-have-adhd ruleset when the user has
+// opted in by creating $CLAUDE_CONFIG_DIR/.i-have-adhd-always (default ~/.claude).
+// Never blocks session start: any failure exits 0.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+const flagPath = path.join(claudeDir, '.i-have-adhd-always');
+
+try {
+  if (!fs.existsSync(flagPath)) process.exit(0);
+
+  const skillPath = path.join(__dirname, '..', 'skills', 'i-have-adhd', 'SKILL.md');
+  const body = fs
+    .readFileSync(skillPath, 'utf8')
+    .replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, ''); // strip YAML frontmatter
+
+  console.log(
+    'ADHD MODE ACTIVE (always-on). The ruleset below applies to every response. ' +
+      '"stop adhd mode" turns it off for this session; ' +
+      `delete ${flagPath} to turn always-on off for good.\n\n${body}`
+  );
+} catch {}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/always-on.js\"",
+            "timeout": 5,
+            "statusMessage": "Checking i-have-adhd always-on flag..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The always-on path in INSTALL.md (a CLAUDE.md snippet) only keeps the handful of rules it names in context — the full skill body never loads unless you type `/i-have-adhd` each session (#19 covers this well). For the people this skill is for, remembering a per-session command is the exact problem the skill exists to solve.

This adds a SessionStart hook that loads the whole ruleset every session, gated behind a flag file:

```
touch ~/.claude/.i-have-adhd-always   # on
rm ~/.claude/.i-have-adhd-always      # off
```

Off by default — without the flag the hook exits silently, so installing or updating changes nothing for anyone. Any failure also exits 0, so it can never block startup. Only Claude Code reads the plugin hooks field, so other harnesses keep the documented snippet approach. Same mechanism the ponytail plugin uses, so there's working precedent.

Complementary to #20: that lets the model decide to invoke the skill; this makes it deterministic for people who want it every session.