### PR TITLE
Add Hermes support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -171,6 +171,70 @@ Exceptions: explain fully when asked to explain. Confirm before destructive acti
 </details>
 
 <details>
+<summary><strong>Hermes</strong></summary>
+
+### Install
+
+```bash
+hermes skills install ayghri/i-have-adhd/skills/i-have-adhd
+```
+
+Type `/i-have-adhd`. The skill installs into `~/.hermes/skills/` and is exposed as a slash command at the next session start.
+
+Prefer to browse first? Add this repo as a skill source (a "tap"), then search and install:
+
+```bash
+hermes skills tap add ayghri/i-have-adhd
+hermes skills search adhd
+hermes skills install ayghri/i-have-adhd/skills/i-have-adhd
+```
+
+### Verify
+
+```bash
+hermes skills list
+```
+
+### Update
+
+```bash
+hermes skills update i-have-adhd
+```
+
+### Uninstall
+
+```bash
+hermes skills uninstall i-have-adhd
+```
+
+Or remove the tap too: `hermes skills tap remove ayghri/i-have-adhd`.
+
+### Always-on (optional)
+
+Add to the `AGENTS.md` in your working directory (Hermes loads it per workdir), or to your persona `SOUL.md` for every session:
+
+```markdown
+## Output style
+
+The reader has ADHD. Shape every response so it can be acted on:
+
+1. Lead with the answer or next action: command, path, or snippet first.
+2. Number multi-step work; one bounded action per step.
+3. End with one next action doable in under two minutes.
+4. Finish the current issue before raising a new one.
+5. Restate progress each turn ("step 3 of 5 done").
+6. Give time estimates in concrete units, never "a bit".
+7. After a change, show what now works.
+8. Errors: state location, cause, and fix. No drama.
+9. Cap lists at 5 items.
+10. No preamble, no recaps, no closers.
+
+Exceptions: explain fully when asked to explain. Confirm before destructive actions. After three failed fixes, stop and name the doubtful assumption. If the request is ambiguous, ask one short question.
+```
+
+</details>
+
+<details>
 <summary><strong>Antigravity (<code>agy</code>)</strong></summary>
 
 ### Install

--- a/skills/i-have-adhd/SKILL.md
+++ b/skills/i-have-adhd/SKILL.md
@@ -2,6 +2,12 @@
 name: i-have-adhd
 description: 'Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible. Invoke with /i-have-adhd; stays on until "stop adhd mode".'
 disable-model-invocation: true
+license: MIT
+metadata:
+  hermes:
+    tags: [ADHD, Output Style, Productivity, Formatting]
+    category: productivity
+    related_skills: []
 ---
 
 # i-have-adhd


### PR DESCRIPTION
Adds [Hermes](https://github.com/nousresearch/hermes-agent) to the list of supported agents, alongside Claude Code, Codex, and Antigravity.

## How it works

Hermes installs external skills straight from a GitHub repo through its **Skills Hub** (`GitHubSource` in `tools/skills_hub.py`): it reads a `SKILL.md` by the identifier `owner/repo/<path-to-skill-dir>` and drops the skill into `~/.hermes/skills/`, where it's exposed as a slash command. No repo-level plugin manifest is consumed — i-have-adhd is a prompt/output-style skill, so it maps to a Hermes **skill**, not a Python plugin. That means Hermes support needs no new manifest file, only docs plus a small additive frontmatter block.

## Changes

- **README.md** — a `Hermes` install block:
  ```bash
  hermes skills install ayghri/i-have-adhd/skills/i-have-adhd
  ```
  then `/i-have-adhd`.
- **INSTALL.md** — Hermes added to the intro line and a full section (install, add-as-tap + search, verify, update, uninstall, always-on) mirroring the other agents.
- **skills/i-have-adhd/SKILL.md** — an additive `metadata.hermes` block (`tags`, `category`) so the skill lists cleanly in Hermes' hub search. It's ignored by Claude Code, Codex, and Antigravity, and the existing `name` / `description` / `disable-model-invocation` are untouched — so the "installed, not invoked until you type `/i-have-adhd`" behavior holds on Hermes too (installed skills are explicit slash commands).

## Verified against hermes-agent

- Identifier layout: a tap points at `repo` + `path` and each subdir with a `SKILL.md` is a skill → `ayghri/i-have-adhd/skills/i-have-adhd`.
- CLI verbs exist: `skills install`, `skills tap add/remove`, `skills search`, `skills list`, `skills update`, `skills uninstall`.
- Slash-command exposure: `agent/skill_commands.py` scans `~/.hermes/skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)