### PR TITLE
Add Gemini CLI support

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,5 @@
+# i-have-adhd
+
+Shape every response for a reader with ADHD. Follow the rules imported below in full: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible, and cut all preamble and closers.
+
+@./skills/i-have-adhd/SKILL.md

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -311,6 +311,54 @@ Exceptions: explain fully when asked to explain. Confirm before destructive acti
 </details>
 
 <details>
+<summary><strong>Gemini CLI</strong></summary>
+
+Gemini CLI has no plugin marketplace, so there are two native routes: a **custom command** (opt-in, off until you invoke it) or an **extension** (always-on once installed). The command route matches this skill's default posture; pick it unless you want the rules on every session.
+
+### Install (command, opt-in)
+
+```bash
+mkdir -p ~/.gemini/commands
+curl -fsSL https://raw.githubusercontent.com/ayghri/i-have-adhd/main/skills/i-have-adhd/agents/gemini.toml \
+  -o ~/.gemini/commands/i-have-adhd.toml
+```
+
+Start a new session, type `/i-have-adhd`. It stays on for that session.
+
+### Install (extension, always-on)
+
+```bash
+gemini extensions install https://github.com/ayghri/i-have-adhd
+```
+
+The extension loads `GEMINI.md`, which imports the full skill, so the rules apply from message one. `git` must be installed.
+
+### Verify
+
+```bash
+gemini extensions list          # extension route
+ls ~/.gemini/commands           # command route: i-have-adhd.toml present
+```
+
+Or type `/` in a session and confirm `i-have-adhd` is listed.
+
+### Update
+
+```bash
+gemini extensions update i-have-adhd    # extension route
+# command route: re-run the curl above
+```
+
+### Uninstall
+
+```bash
+gemini extensions uninstall i-have-adhd    # extension route
+rm ~/.gemini/commands/i-have-adhd.toml     # command route
+```
+
+</details>
+
+<details>
 <summary><strong>Antigravity (<code>agy</code>)</strong></summary>
 
 ### Install

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,6 @@
+{
+  "name": "i-have-adhd",
+  "version": "0.1.0",
+  "description": "Shape Gemini CLI output for an ADHD reader: lead with the next action, number steps, suppress tangents, restate state, make wins visible.",
+  "contextFileName": "GEMINI.md"
+}

--- a/skills/i-have-adhd/agents/gemini.toml
+++ b/skills/i-have-adhd/agents/gemini.toml
@@ -1,0 +1,24 @@
+# Gemini CLI custom command for i-have-adhd.
+# Install: copy to ~/.gemini/commands/i-have-adhd.toml, then type /i-have-adhd.
+# Self-contained so it works as a global command from any directory.
+
+description = "ADHD-friendly output: action-first, numbered steps, no preamble or closers."
+
+prompt = """
+For the rest of this session, shape every response for a reader with ADHD. The output is not just brief; it is shaped so an ADHD brain can act on it.
+
+1. Lead with the next action. The first line is a command, path, or snippet the reader can run, not context, not a plan.
+2. Number multi-step work. One bounded action per step; no step with two "and then"s.
+3. End with one concrete next action the reader can do in under two minutes.
+4. Suppress tangents. Finish the current issue, then offer a second one as a separate question.
+5. Restate state every turn ("Step 3 of 5 done: schema updated. Next: backfill the column.").
+6. Give time estimates in concrete units (minutes, hours), never "a bit" or "some work".
+7. Make completed work visible in concrete terms ("Login works with magic links. Try: npm run dev").
+8. State errors matter-of-factly: cause, then fix. No "uh oh" or "there seems to be a problem".
+9. Cap lists at 5 items; split into now/later or must/nice-to-have if longer.
+10. No preamble, no recap, no closing pleasantries. Start with the answer; end when it is done.
+
+Break these rules only when: the reader asks you to "explain" or "walk through" (go as long as the topic needs, still no preamble/closer); a destructive action is ahead (confirm first; safety beats brevity); you are in a debug spiral (name the assumption that might be wrong, ask one diagnostic question); or the request is genuinely ambiguous (ask one short clarifying question).
+
+{{args}}
+"""


### PR DESCRIPTION
Adds [Gemini CLI](https://github.com/google-gemini/gemini-cli) to the supported agents, alongside Claude Code, Codex, and Antigravity.

## How it works

Gemini CLI has no plugin marketplace, so this ships the two native routes — and both single-source the rules from the existing `SKILL.md` (no divergent second copy):

- **Custom command (opt-in)** — `skills/i-have-adhd/agents/gemini.toml`, copied to `~/.gemini/commands/i-have-adhd.toml` and invoked with `/i-have-adhd`. Off until you invoke it, matching this skill's default "installed, not invoked" posture. It's self-contained so it works as a global command from any directory (Gemini's `@{...}` file injection is cwd-relative, so a global command can't reference a bundled file — hence the rules are inlined here, drawn from the repo's own 10-rule summary).
- **Extension (always-on)** — `gemini-extension.json` + `GEMINI.md`, installed with `gemini extensions install https://github.com/ayghri/i-have-adhd`. `GEMINI.md` imports the full skill via `@./skills/i-have-adhd/SKILL.md`, so the rules apply from message one with no duplication.

## Changes

- **skills/i-have-adhd/agents/gemini.toml** — the opt-in command, placed next to the existing `openai.yaml` so per-agent config stays in one directory.
- **gemini-extension.json** + **GEMINI.md** — the always-on extension manifest and its imported context file.
- **README.md** — a Gemini CLI install block (command route first, extension as the one-liner alternative).
- **INSTALL.md** — Gemini CLI added to the intro and a full section (both routes, verify, update, uninstall, always-on) mirroring the other agents.

## Verified against gemini-cli docs

- Custom commands: TOML in `~/.gemini/commands/<name>.toml` → `/<name>`; `@{path}` file injection is documented as cwd-relative.
- Extensions: `gemini extensions install <github-url>` reads `gemini-extension.json`; `contextFileName` loads a context file; `GEMINI.md` supports `@./file` imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)