### PR TITLE
Add Zed support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Install i-have-adhd
 
-One skill. Claude Code, Codex, Antigravity, and any harness that reads agent skills.
+One skill. Claude Code, Codex, Zed, Antigravity, and any harness that reads agent skills.
 
 <details>
 <summary><strong>Claude Code</strong></summary>
@@ -83,6 +83,52 @@ codex plugin marketplace remove i-have-adhd
 ### Always-on (optional)
 
 Add to `~/.codex/AGENTS.md`:
+
+```markdown
+## Output style
+
+Always follow the rules in the `i-have-adhd` skill: action-first, numbered steps, no preamble, no closers, state restated each turn.
+```
+
+</details>
+
+<details>
+<summary><strong>Zed</strong></summary>
+
+Zed's Agent reads Agent Skills natively — the same `SKILL.md`, no conversion. (Zed's older "Rules" were replaced by Skills + `AGENTS.md` instructions.)
+
+### Install
+
+In the Agent Panel, open the Skills manager and choose **Create skill from URL** (also available from the command palette as `agent: create skill from url`), then paste:
+
+```
+https://github.com/ayghri/i-have-adhd/blob/main/skills/i-have-adhd/SKILL.md
+```
+
+Save it in **User** scope for every project, or **Project** scope for one. Then type `/i-have-adhd` in the Agent Panel.
+
+Prefer the filesystem? Clone the repo and drop the skill folder into your user skills directory:
+
+```bash
+git clone https://github.com/ayghri/i-have-adhd
+cp -R i-have-adhd/skills/i-have-adhd ~/.config/zed/skills/
+```
+
+### Verify
+
+Open the Skills manager in the Agent Panel — `i-have-adhd` is listed. Or type `/` and confirm it appears.
+
+### Update
+
+Re-import from the same URL (overwrites), or re-copy the folder after `git pull`.
+
+### Uninstall
+
+Remove `i-have-adhd` from the Skills manager, or delete `~/.config/zed/skills/i-have-adhd`.
+
+### Always-on (optional)
+
+Add to your personal `~/.config/zed/AGENTS.md`:
 
 ```markdown
 ## Output style

--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ Then type `$i-have-adhd` to apply the output style explicitly. The skill can als
 
 </details>
 
+<details>
+<summary><strong>Zed</strong></summary>
+
+Zed's Agent reads Agent Skills natively. In the Agent Panel, open the Skills manager and choose **Create skill from URL**, then paste:
+
+```
+https://github.com/ayghri/i-have-adhd/blob/main/skills/i-have-adhd/SKILL.md
+```
+
+Then type `/i-have-adhd` in the Agent Panel. Off until you invoke it.
+
+</details>
+
 Install instructions for other coding agents live in [INSTALL.md](./INSTALL.md).
 
 ## What it does


### PR DESCRIPTION
Adds [Zed](https://zed.dev) to the supported agents.

## How it works

Zed's Agent reads **Agent Skills** natively — the same `skills/i-have-adhd/SKILL.md`, no conversion and no new manifest. (Per Zed's docs, its older "Rules" were replaced by Skills for reusable/on-demand instructions and `AGENTS.md` for always-on ones.) So this PR is docs-only.

## Changes

- **README.md** — a Zed install block: Agent Panel → **Create skill from URL** with the raw `SKILL.md` URL, then `/i-have-adhd`.
- **INSTALL.md** — Zed added to the intro and a full section (URL import or filesystem copy into `~/.config/zed/skills/`, verify, update, uninstall, always-on via `~/.config/zed/AGENTS.md`) mirroring the other agents.

## Verified against zed.dev docs

- Skills are a folder with a `SKILL.md` (frontmatter + Markdown); Zed loads them on demand or via slash command.
- Skills can be imported from a GitHub Markdown URL (`agent: create skill from url`), created via the Skills manager, and saved in User or Project scope.
- Personal always-on instructions live in `~/.config/zed/AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)