### PR TITLE
fix(skill): instruct persistence and define the "stop adhd mode" off-switch

### DIFF
--- a/skills/i-have-adhd/SKILL.md
+++ b/skills/i-have-adhd/SKILL.md
@@ -8,6 +8,12 @@ disable-model-invocation: true
 
 The reader has ADHD. Output is not just brief. It is shaped so an ADHD brain can act on it.
 
+## Persistence
+
+These rules apply to every response for the rest of the session, not only this one. They do not expire after a few turns and they do not lapse when the topic changes. If you are unsure whether they still apply, they do.
+
+Turn them off only when the reader says "stop adhd mode" or "normal mode". Confirm in one line, then return to your default style.
+
 ## What ADHD changes about reading
 
 Five facts drive every rule below:


### PR DESCRIPTION
Fixes #31

## Problem

The frontmatter promises `Invoke with /i-have-adhd; stays on until "stop adhd mode"`, and `INSTALL.md:197` repeats it. The body of `SKILL.md` — the part the model actually reads — says neither thing:

```
$ grep -n 'stop adhd mode\|normal mode\|every response\|persist' skills/i-have-adhd/SKILL.md
3:description: '… stays on until "stop adhd mode".'
```

One hit, in the frontmatter. `description` is selection metadata, not an instruction the model is told to obey, so persistence was never actually instructed and "stop adhd mode" was undefined behaviour.

## Change

Six lines: a `## Persistence` section placed directly after the intro, before the ADHD facts, so it is read before the rules it governs. It states that the rules hold for the rest of the session and that "stop adhd mode" / "normal mode" turns them off.

No rule text changed; nothing removed.

## Verify

```bash
grep -n 'stop adhd mode\|normal mode' skills/i-have-adhd/SKILL.md
```

now matches in the body, not only the frontmatter. Behaviourally: invoke `/i-have-adhd`, run ~10 unrelated turns, confirm the reply shape holds; then say "stop adhd mode" and confirm it drops.

Frontmatter re-parsed as YAML after the edit — unchanged and still valid (`name`, `description`, `disable-model-invocation`).

## Conflicts

Touches only `skills/i-have-adhd/SKILL.md`, in a region no open PR edits (#20 edits the frontmatter, #21/#26/#30 edit the rule list further down).