### PR TITLE
docs(readme): make "Tune it" actually install the fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,16 @@ A skill for your coding assistant that stops it from burying the answer. Action 
 
 ## Tune it
 
-Fork, edit `skills/i-have-adhd/SKILL.md`, install your fork: `claude plugin marketplace add <your-username>/i-have-adhd`. Re-invoke `/i-have-adhd`.
+Fork, edit `skills/i-have-adhd/SKILL.md`, then swap your copy in:
+
+```bash
+claude plugin uninstall i-have-adhd            # drop the upstream copy first:
+claude plugin marketplace remove i-have-adhd   # fork and upstream share both names
+claude plugin marketplace add <your-username>/i-have-adhd
+claude plugin install i-have-adhd@i-have-adhd
+```
+
+Restart Claude Code, then re-invoke `/i-have-adhd`.
 
 ## Credits
 


### PR DESCRIPTION
Fixes #32

## Problem

`README.md:92` told users to customise the skill with:

> install your fork: `claude plugin marketplace add <your-username>/i-have-adhd`

`marketplace add` registers a marketplace. It installs nothing:

```
$ claude plugin marketplace add --help
Add a marketplace from a URL, path, or GitHub repo
$ claude plugin install --help
Install a plugin from available marketplaces (use plugin@marketplace for specific marketplace)
```

READMEs own install section (lines 17-20) uses both commands; "Tune it" dropped the second one. So the user ends up with the **upstream** plugin still installed, `/i-have-adhd` still serving upstream rules, and their edits doing nothing — with no error to explain it.

The fork also carries `name: "i-have-adhd"` in both `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json`, identical to upstream, so `i-have-adhd@i-have-adhd` stays ambiguous until the upstream marketplace is removed. Both steps are now in the block.

## Change

One paragraph → a four-line bash block plus a restart note. `README.md` only.

## Verify

```bash
claude plugin list    # i-have-adhd sourced from <your-username>, not ayghri
```

then invoke `/i-have-adhd` and confirm an edit made to `SKILL.md` is in effect.

## Note

`INSTALL.md:210` ("Want different rules.") has the identical wording and gap. I left it out so this PR stays one file / one screen and does not collide with the five open PRs currently editing `INSTALL.md` — happy to fold it in if you prefer one PR.