### PR TITLE
fix(plugin): add `version` and `author` to `.claude-plugin/plugin.json`

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,4 +1,9 @@
 {
   "name": "i-have-adhd",
-  "description": "Shape Claude Code output for an ADHD reader: lead with the next action, number steps, suppress tangents, restate state, make wins visible."
+  "version": "0.1.0",
+  "description": "Shape Claude Code output for an ADHD reader: lead with the next action, number steps, suppress tangents, restate state, make wins visible.",
+  "author": {
+    "name": "Ayoub G.",
+    "url": "https://github.com/ayghri"
+  }
 }


### PR DESCRIPTION
Fixes #33

## Problem

```
$ claude plugin validate .
⚠ Found 2 warnings:
  ❯ plugins[0] plugin.json → version: No version specified. Consider adding a version following semver (e.g., "1.0.0")
  ❯ plugins[0] plugin.json → author: No author information provided. Consider adding author details for plugin attribution
```

Consequences of the missing `version`: `claude plugin list` and the marketplace UI show none, so a user cannot tell which revision of the rules they are running; plugin autoupdate logs `updated <plugin> from <old> to <new>` with nothing to compare; and `claude plugin tag` — which builds a `{name}--v{version}` tag and checks that `plugin.json` and the marketplace entry agree — has nothing to work with.

`.codex-plugin/plugin.json` already declares `"version": "0.1.0"` and an `author` block, so the two manifests for the same plugin currently disagree.

## Change

Four lines added to `.claude-plugin/plugin.json`, copying the values already in the Codex manifest. `0.1.0` matches what `.codex-plugin/plugin.json` claims today — say the word if you would rather cut a different number.

## Verify

```
$ claude plugin validate .
✔ Validation passed
```

(run against this branch — no warnings, down from 2)

## Conflicts

Open PR #25 also edits this file (adds a `hooks` key). Different lines, but whichever lands second may want a one-line rebase.