### PR TITLE
fix(marketplace): replace 404 `$schema` URL with the published SchemaStore one

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "$schema": "https://www.schemastore.org/claude-code-marketplace.json",
   "name": "i-have-adhd",
   "description": "Shape Claude Code output for an ADHD reader. Action-first, numbered steps, no tangents.",
   "owner": {


### PR DESCRIPTION
Fixes #34

## Problem

`.claude-plugin/marketplace.json:2` points at a URL that does not exist:

```
$ curl -s -o /dev/null -w "%{http_code}\n" -L https://anthropic.com/claude-code/marketplace.schema.json
404
```

`$schema` is ignored when the plugin loads, so nothing fails loudly — the manifest simply gets no completion or validation in the editor, and looks like it has some. For the file that decides whether the plugin is installable at all, that is the one worth having checked as you type.

## Change

One line. SchemaStore publishes the schema and its catalog maps it to `**/.claude-plugin/marketplace.json`:

```
"url": "https://www.schemastore.org/claude-code-marketplace.json",
"description": "Marketplace manifest (.claude-plugin/marketplace.json) listing Claude Code plugins"
```

## Verify

```
$ curl -s -o /dev/null -w "%{http_code}\n" -L https://www.schemastore.org/claude-code-marketplace.json
200
```

The current manifest satisfies the schemas `required` set (`name`, `owner`, `plugins`), and `claude plugin validate .` still passes on this branch. Open the file in an editor with SchemaStore support — completion and validation now work.

There is a matching `https://www.schemastore.org/claude-code-plugin-manifest.json` for `.claude-plugin/plugin.json` if you want the same treatment there; left out to keep this to one line.