### PR TITLE
fix(antigravity): drop the dead `$schema` URL from root `plugin.json`

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://antigravity.google/schemas/v1/plugin.json",
   "name": "i-have-adhd",
   "description": "Shape Antigravity output for an ADHD reader: lead with the next action, number steps, suppress tangents, restate state, make wins visible."
 }


### PR DESCRIPTION
Fixes #35

## Problem

`plugin.json:2` points at a schema that does not exist:

```
$ curl -s -o /dev/null -w "%{http_code}\n" -L https://antigravity.google/schemas/v1/plugin.json
404
```

The host itself is live (`https://antigravity.google/` → 200); only the schema path is missing. Nearby guesses 404 too (`/schemas/plugin.json`, `/schema/v1/plugin.json`, `/schemas/v1/plugin.schema.json`), and the Antigravity plugin docs never mention a schema — they describe the manifest as a marker file:

> Every plugin must have a `plugin.json` file at its root. This file identifies the directory as a plugin.
> ```json
> { "name": "my-custom-plugin" }
> ```
> The `name` field is optional and defaults to the directory name if omitted.

— https://antigravity.google/docs/plugins

## Change

Delete the one key. Editor-only metadata, so nothing about loading changes — but a dead URL is worse than none: the editor tries to fetch it, fails, and the manifest ends up unvalidated while looking authoritative.

If there is a canonical Antigravity schema URL I could not find, I am happy to point at that instead — just say which and I will amend.

## Verify

```bash
python3 -c "import json;print(list(json.load(open('plugin.json')).keys()))"
# ['name', 'description']
```

Still valid JSON, and `name` is all the documented Antigravity manifest requires.