### PR TITLE
feat(claude): native output style for always-on (full ruleset)

### DIFF
--- a/.github/workflows/output-style-sync.yml
+++ b/.github/workflows/output-style-sync.yml
@@ -1,0 +1,24 @@
+name: output-style in sync
+
+# Fails if output-styles/i-have-adhd.md is stale, i.e. SKILL.md was edited
+# without rerunning scripts/build-output-style.sh. Keeps SKILL.md the single
+# source of truth.
+on:
+  pull_request:
+    paths:
+      - skills/i-have-adhd/SKILL.md
+      - output-styles/**
+      - scripts/build-output-style.sh
+      - .github/workflows/output-style-sync.yml
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Regenerate the output style
+        run: sh scripts/build-output-style.sh
+      - name: Fail if it differs from the committed file
+        run: git diff --exit-code output-styles/i-have-adhd.md

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,13 +37,17 @@ Or keep it installed and turn it off: `claude plugin disable i-have-adhd`.
 
 ### Always-on (optional)
 
-Add to `~/.claude/CLAUDE.md`:
+The plugin bundles an `i-have-adhd` output style. Select it once and it persists across sessions — no `CLAUDE.md` edit needed.
 
-```markdown
-## Output style
+Pick it via `/config` → **Output style**, or set it directly in `.claude/settings.json` (use `~/.claude/settings.json` for every project):
 
-Always follow the rules in the `i-have-adhd` skill: action-first, numbered steps, no preamble, no closers, state restated each turn.
+```json
+{
+  "outputStyle": "i-have-adhd"
+}
 ```
+
+Turn it off by switching the output style back to **Default**.
 
 </details>
 

--- a/output-styles/i-have-adhd.md
+++ b/output-styles/i-have-adhd.md
@@ -1,0 +1,123 @@
+---
+name: i-have-adhd
+description: 'Shape output for an ADHD reader: action-first, numbered steps, no preamble or closers, state restated each turn.'
+keep-coding-instructions: true
+---
+
+<!-- GENERATED from skills/i-have-adhd/SKILL.md by scripts/build-output-style.sh — do not edit by hand. -->
+
+# i-have-adhd
+
+The reader has ADHD. Output is not just brief. It is shaped so an ADHD brain can act on it.
+
+## What ADHD changes about reading
+
+Five facts drive every rule below:
+
+1. Working memory is small. Anything not on screen is forgotten. Do not ask the reader to "keep in mind X."
+2. Knowing the answer is not doing the answer. The friction between "got it" and "done it" is where work dies.
+3. Starting is the hardest step. The first action must be obvious, small, and doable now.
+4. Time estimates feel uniform. "A bit of work" and "a few hours" register the same. Vague estimates fail.
+5. Dopamine is scarce. Visible progress matters. Buried wins do not register.
+
+## Rules
+
+### 1. Lead with the next action
+
+The first line is something the reader can do. Not context. Not a plan. The action.
+
+Bad: "Let's think about this. Your auth flow has a few moving pieces..."
+Good: "Run `npm install jsonwebtoken`, then edit `src/auth.ts:42`."
+
+If the answer is a command, path, or snippet, it goes first. Prose comes after, if at all.
+
+### 2. Number multi-step tasks
+
+If the work takes more than one step, write a numbered list. Each step is one bounded action. No step contains "and then" twice.
+
+Bad: "First open the file, find the function, swap it out, then run the tests."
+
+Good:
+```
+1. Open `src/auth.ts`
+2. Replace `verifyToken` (lines 42 to 58) with the snippet below
+3. Run `npm test -- auth.spec.ts`
+```
+
+### 3. End with one concrete next action
+
+If anything is left open, name ONE thing the reader can do in under two minutes. Even "open the file" counts.
+
+Bad: "Hope that helps. Let me know if you want to dig deeper."
+Good: "Next: run `npm test` and paste the first failing line."
+
+### 4. Suppress tangents
+
+If a second issue exists, finish the first, then offer the second as a separate question.
+
+Bad: "Here's the fix. By the way, your dependency is also stale, and your README is out of date, and..."
+Good: "Here's the fix. Separately: there is also a stale dependency. Want me to handle that next?"
+
+### 5. Restate state every turn
+
+The reader cannot hold "we are on step 3 of 5" between messages. Restate it.
+
+Bad: "Done. Ready for the next part?"
+Good: "Step 3 of 5 done: schema updated. Next: backfill the new column. Run the script?"
+
+### 6. Give specific time estimates
+
+Vague estimates fail. Ballpark in concrete units.
+
+Bad: "This will take some work."
+Good: "About 15 minutes if tests already cover this. An afternoon if not."
+
+### 7. Make completed work visible
+
+Show what now works, in concrete terms. Do not bury wins in a recap.
+
+Bad: "I've made some changes to the auth flow. Among other things..."
+Good: "Login now works with magic links. Try: `npm run dev`, open `/login`."
+
+### 8. Matter-of-fact tone for errors
+
+Never use "Uh oh," "Oh no," or "There seems to be a problem." State cause and fix.
+
+Bad: "Uh oh, the test is failing. There seems to be an issue..."
+Good: "Test fails at `auth.spec.ts:42`: expected 200, got 401. Cause: missing auth header. Fix: add `Authorization: Bearer ${token}` to the request."
+
+### 9. Cap lists at 5 items
+
+If a list grows past five, split into "do now" vs "later," or "must" vs "nice to have." Five items ranked beats ten unranked.
+
+### 10. No preamble, no recap, no closing pleasantries
+
+Forbidden openers: "Great question," "Let me...", "I'll...", "Sure!", "Looking at your...", "To answer your question..."
+
+Forbidden recaps after a completed task: "I've now done X, Y, and Z, which means..."
+
+Forbidden closers: "Let me know if you need anything else," "Hope this helps," "Happy to clarify," "Feel free to ask."
+
+Start with the answer. End when the answer is done.
+
+## When to break the rules
+
+Override the defaults when:
+
+1. User asks to "explain" or "walk me through." Explain fully. Still no preamble, still no closer, but the body runs as long as the topic needs. Add headers so the reader can skim back.
+2. Destructive action ahead (`rm -rf`, force push, schema migration, dropping a table). Confirm before acting. Safety wins over brevity.
+3. Debug spiral. If the last three turns have been "still broken," stop iterating on code. Name the assumption that might be wrong. Ask one diagnostic question.
+4. Real ambiguity in the request. One short clarifying question beats guessing and rewriting.
+
+## Pre-send check
+
+Before sending, delete:
+
+1. The first sentence if it announces what you are about to do.
+2. The last sentence if it asks "anything else?" or recaps what just happened.
+3. Any "by the way" sidebar.
+4. Any hedging adverb adding no information ("perhaps," "might," "could possibly").
+
+Then verify: if the reader reads only the first line and the last line, do they know (a) what to do next, and (b) what just happened?
+
+If yes, send.

--- a/scripts/build-output-style.sh
+++ b/scripts/build-output-style.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Regenerate the Claude Code output style from the skill, the single source of truth.
+# The body is copied verbatim from skills/i-have-adhd/SKILL.md; only the frontmatter
+# differs. Rerun this after editing SKILL.md, then commit both files.
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+skill="$root/skills/i-have-adhd/SKILL.md"
+out="$root/output-styles/i-have-adhd.md"
+
+mkdir -p "$root/output-styles"
+
+{
+  cat <<'EOF'
+---
+name: i-have-adhd
+description: 'Shape output for an ADHD reader: action-first, numbered steps, no preamble or closers, state restated each turn.'
+keep-coding-instructions: true
+---
+
+<!-- GENERATED from skills/i-have-adhd/SKILL.md by scripts/build-output-style.sh — do not edit by hand. -->
+EOF
+  # Skill body: every line after the frontmatter (i.e. after the second `---`).
+  awk 'body { print; next } /^---[[:space:]]*$/ { if (++n == 2) body = 1 }' "$skill"
+} > "$out"
+
+echo "wrote $out"


### PR DESCRIPTION
## What

This ships the i-have-adhd ruleset as a native Claude Code output style. Always-on then needs no `CLAUDE.md` edit, and it loads the full ruleset in every session.

You turn it on once and it stays on:

```json
// .claude/settings.json  (or ~/.claude/settings.json for every project)
{ "outputStyle": "i-have-adhd" }
```

Or open `/config`, pick Output style, and choose `i-have-adhd`. To turn it off, switch back to Default.

## Why

The documented always-on path pastes a prose snippet into `~/.claude/CLAUDE.md`. As #19 and #25 both note, that snippet only carries the few rules it names. The full skill body never loads, so rules 4 and 6 to 9, "When to break the rules", and the pre-send check silently don't apply.

Output styles are Claude Code's built-in way to reshape how it replies, which is what this plugin does. That is where this belongs, and it brings the whole ruleset with it.

## Relation to #25

#25 closes the same always-on gap with a `SessionStart` hook and a flag file. This PR is a different mechanism aimed at the same goal:

| | This PR (output style) | #25 (SessionStart hook) |
|---|---|---|
| Mechanism | Native Claude Code primitive | Custom `hooks/always-on.js` + `hooks.json` |
| Turn on | `/config` picker, or one `outputStyle` line | `touch ~/.claude/.i-have-adhd-always` |
| Turn off | Switch to Default (or any other style) in `/config` | `rm ~/.claude/.i-have-adhd-always` |
| Full ruleset loaded | Yes, the whole body is the style | Yes, it injects `SKILL.md` |
| Discoverable | Listed in `/config` | A flag file you have to know exists |
| Extra runtime | None | A JS process at every SessionStart |

Turning it on and off is the same picker you already use to switch between Default, Explanatory, and the rest, so there is no separate dotfile to remember. I don't think it has to be one or the other. Happy to defer to whichever you prefer, or to close this if #25 is the direction you want.

## Design

- `keep-coding-instructions: true` keeps Claude Code's engineering behavior and adds the ADHD shaping on top. Without it, the style would replace the coding system prompt.
- `SKILL.md` stays the single source of truth. `scripts/build-output-style.sh` regenerates the style from it: a frontmatter swap, with the body copied verbatim. A CI check (`output-style-sync.yml`) regenerates and fails the build if the two drift, so they can't fall out of sync.
- Still opt-in. There is no `force-for-plugin`, so installing changes nothing until you pick it. "If you didn't turn it on, it's off" still holds.
- Scoped to Claude Code. Only `output-styles/` is read here. The Codex, Antigravity, and generic-harness paths are untouched.

## Files

- `output-styles/i-have-adhd.md`: the output style (generated, full ruleset).
- `scripts/build-output-style.sh`: regenerates it from `SKILL.md`.
- `.github/workflows/output-style-sync.yml`: CI check that fails if the two drift.
- `INSTALL.md`: the Claude Code "Always-on" section now documents the output-style path.

## Verify

```
/config -> Output style -> i-have-adhd    # appears, selectable, persists across sessions
```
