### PR TITLE
fix(evals): reject unpaired conditions before scoring the release gate

### DIFF
--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -9,7 +9,7 @@ import shlex
 import subprocess
 import sys
 import time
-from collections import defaultdict
+from collections import Counter, defaultdict
 from pathlib import Path
 from typing import Any
 
@@ -94,6 +94,39 @@ def _validate_score(row: dict[str, Any], index: int) -> None:
         raise ValueError(f"Score row {index}: blocker must be boolean")
 
 
+def _describe_rows(keys: list[tuple[str, Any]]) -> str:
+    return ", ".join(f"{case_id}/trial {trial}" for case_id, trial in keys)
+
+
+def _check_pairing(grouped: dict[str, list[dict[str, Any]]]) -> None:
+    """Conditions are only comparable when judged on identical rows."""
+    coverage = {
+        condition: Counter((row["case_id"], row["trial"]) for row in rows)
+        for condition, rows in grouped.items()
+    }
+    for condition, counts in sorted(coverage.items()):
+        repeated = sorted(key for key, count in counts.items() if count > 1)
+        if repeated:
+            raise ValueError(
+                f"{condition}: duplicate score rows for {_describe_rows(repeated)}"
+            )
+    baseline = coverage["baseline"]
+    for condition, counts in sorted(coverage.items()):
+        if condition == "baseline" or counts == baseline:
+            continue
+        details = []
+        missing = sorted(set(baseline) - set(counts))
+        if missing:
+            details.append(f"missing {_describe_rows(missing)}")
+        unmatched = sorted(set(counts) - set(baseline))
+        if unmatched:
+            details.append(f"unmatched {_describe_rows(unmatched)}")
+        raise ValueError(
+            f"{condition} was not judged on the same rows as baseline: "
+            + "; ".join(details)
+        )
+
+
 def summarize_scores(scores: list[dict[str, Any]]) -> dict[str, Any]:
     grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for index, row in enumerate(scores, start=1):
@@ -101,6 +134,7 @@ def summarize_scores(scores: list[dict[str, Any]]) -> dict[str, Any]:
         grouped[row["condition"]].append(row)
     if "baseline" not in grouped or "candidate" not in grouped:
         raise ValueError("Scores must include baseline and candidate conditions")
+    _check_pairing(grouped)
 
     conditions: dict[str, dict[str, Any]] = {}
     for condition, rows in sorted(grouped.items()):

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -67,6 +67,41 @@ class EvaluationHarnessTest(unittest.TestCase):
         self.assertFalse(summary["release_gate"]["passed"])
         self.assertIn("blocking", " ".join(summary["release_gate"]["reasons"]))
 
+    def test_conditions_judged_on_different_cases_are_rejected(self):
+        rows = [
+            self._score_row("destructive-action", "baseline", 2),
+            self._score_row("medical-boundary", "baseline", 2),
+            self._score_row("direct-answer", "candidate", 5),
+        ]
+
+        with self.assertRaisesRegex(ValueError, "not judged on the same rows"):
+            run_evals.summarize_scores(rows)
+
+    def test_duplicate_score_rows_are_rejected(self):
+        rows = [
+            self._score_row("direct-answer", "baseline", 3),
+            self._score_row("direct-answer", "candidate", 4),
+            self._score_row("direct-answer", "candidate", 5),
+        ]
+
+        with self.assertRaisesRegex(ValueError, "duplicate score rows"):
+            run_evals.summarize_scores(rows)
+
+    @staticmethod
+    def _score_row(case_id, condition, value, trial=1):
+        return {
+            "case_id": case_id,
+            "trial": trial,
+            "condition": condition,
+            "correctness": value,
+            "autonomy": value,
+            "actionability": value,
+            "safety": value,
+            "concision": value,
+            "blocker": False,
+            "notes": "fixture",
+        }
+
     def test_duplicate_case_ids_are_rejected(self):
         case = {
             "id": "duplicate",


### PR DESCRIPTION
Fixes #44

## Problem

`summarize_scores()` averaged each condition independently and never checked the conditions covered the same rows. Baseline judged on the two hardest cases, candidate on the easiest one:

```
$ python3 scripts/run_evals.py score scores.jsonl
  "baseline":  { "rows": 2, "weighted_score": 2.0 },
  "candidate": { "rows": 1, "weighted_score": 5.0 },
  "release_gate": { "passed": true, "reasons": [] }
```

`evals/README.md:51` already states the rule — *"Do not compare conditions produced with different cases, models, trial counts, or rubrics"* — but only the operator enforced it. A candidate run cut short by a provider failure, a `--case` subset, or a judge who skipped rows all yield a confident "passed". Duplicate score rows had the same effect on the averages.

## Change

`_check_pairing()` compares the `(case_id, trial)` multiset of every condition against baseline and raises with the concrete difference; duplicates within a condition are rejected first. Called from `summarize_scores` right after the existing baseline/candidate presence check. Two regression tests added.

## Verify

```
$ python3 -m unittest discover -s tests -q
Ran 8 tests in 0.001s
OK
```
(6 existing + 2 new; the suite was green before the change too)

The repro above now fails loudly instead of passing:
```
ValueError: candidate was not judged on the same rows as baseline: missing destructive-action/trial 1, medical-boundary/trial 1; unmatched direct-answer/trial 1
```

A properly paired file is unaffected — 2 baseline + 2 candidate rows over the same cases still returns `{"passed": true, "reasons": []}`.

## Conflicts

Touches `summarize_scores` and the test file only. My other two `run_evals.py` PRs sit in `_condition_prompt` (#…) and the `run` loop, so the three merge in any order.