### PR TITLE
fix(evals): fail when `--case` matches no evaluation case

### DIFF
--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -177,6 +177,9 @@ def run_evaluations(args: argparse.Namespace) -> int:
     errors = validate_cases(cases)
     if errors:
         raise ValueError("\n".join(errors))
+    unknown = sorted(set(args.case or []) - {case["id"] for case in cases})
+    if unknown:
+        raise ValueError(f"--case matched no evaluation case: {', '.join(unknown)}")
     config = json.loads(args.runner_config.read_text(encoding="utf-8"))
     runner = config[args.runner]
     command = list(runner["command"])


### PR DESCRIPTION
Fixes #45

## Problem

`run_evals.py:200` filters with `if args.case and case["id"] not in args.case: continue`, so an id that matches nothing filters out every case and the run reports success:

```
$ python3 scripts/run_evals.py run --runner claude --condition baseline \
    --output evals/results/responses.jsonl --trials 1 --case direct-anwser
Reported cost: $0.0000
$ echo $?
0
```

Zero rows, no warning. `$0.0000` is not a red flag either — resume skips completed rows, so a zero-cost run is normal. The operator believes that condition was measured; `score` then compares whatever is in the file.

## Change

Three lines in `run_evaluations`, after the existing case validation:

```python
unknown = sorted(set(args.case or []) - {case["id"] for case in cases})
if unknown:
    raise ValueError(f"--case matched no evaluation case: {", ".join(unknown)}")
```

## Verify

```
$ python3 scripts/run_evals.py run ... --case direct-anwser
ValueError: --case matched no evaluation case: direct-anwser
$ echo $?
1
```

Unaffected paths, checked against a stub runner: `--case direct-answer` runs that one case; omitting `--case` runs all 14. `python3 -m unittest discover -s tests -q` gives 6 tests, OK.

## Conflicts

Only the `run_evaluations` preamble. My other two `run_evals.py` PRs touch `summarize_scores` (#48) and `_condition_prompt`, so all three merge in any order.