### PR TITLE
fix(evals): name the real flag when the condition skill is missing

### DIFF
--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -138,7 +138,7 @@ def _condition_prompt(task: str, condition: str, skill_path: Path | None) -> str
     if condition == "baseline":
         return task
     if skill_path is None:
-        raise ValueError(f"--{condition}-skill is required for {condition}")
+        raise ValueError(f"--condition-skill is required for the {condition} condition")
     instructions = skill_path.read_text(encoding="utf-8")
     return (
         "Follow the response-style skill below while completing the task. "


### PR DESCRIPTION
Fixes #46

## Problem

`run_evals.py:141` built the flag name from the condition:

```python
raise ValueError(f"--{condition}-skill is required for {condition}")
```

The parser defines one `--condition-skill` (`:284`), so the advice is unfollowable:

```
$ python3 scripts/run_evals.py run --runner claude --condition candidate --output out.jsonl
ValueError: --candidate-skill is required for candidate

$ python3 scripts/run_evals.py run --runner claude --condition candidate --candidate-skill skills/i-have-adhd/SKILL.md --output out.jsonl
run_evals.py: error: unrecognized arguments: --candidate-skill skills/i-have-adhd/SKILL.md
```

`evals/README.md:27` documents the correct flag, so only the message was wrong.

## Change

One line:

```
ValueError: --condition-skill is required for the candidate condition
```

## Verify

Reproduced before and after against a stub runner; `python3 -m unittest discover -s tests -q` gives 6 tests, OK.

## Conflicts

`_condition_prompt` only. My other two `run_evals.py` PRs touch `summarize_scores` (#48) and the `run_evaluations` preamble (#49), so all three merge in any order.