### PR TITLE
docs(install): make the fork instructions actually install the fork

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -301,6 +301,15 @@ No middle ground. If you did not turn it on, it is off.
 
 **Installed but replies still preamble.** Open a new session. If it still drifts, tighten the wording in `skills/i-have-adhd/SKILL.md`.
 
-**Want different rules.** Fork, edit `skills/i-have-adhd/SKILL.md`, install your fork: `claude plugin marketplace add <your-username>/i-have-adhd`.
+**Want different rules.** Fork, edit `skills/i-have-adhd/SKILL.md`, then swap your copy in:
+
+```bash
+claude plugin uninstall i-have-adhd            # drop the upstream copy first:
+claude plugin marketplace remove i-have-adhd   # fork and upstream share both names
+claude plugin marketplace add <your-username>/i-have-adhd
+claude plugin install i-have-adhd@i-have-adhd
+```
+
+Restart, then re-invoke `/i-have-adhd`.
 
 **Skill missing after `npx skills add`.** Start a new agent chat. Skills are indexed at session start. Confirm the folder landed where your agent scans (`~/.cursor/skills/` for Cursor, `.agents/skills/` for OpenCode) and that the frontmatter `name` matches the folder name.


### PR DESCRIPTION
Fixes #47

## Problem

`INSTALL.md:304` (Troubleshooting):

> **Want different rules.** Fork, edit `skills/i-have-adhd/SKILL.md`, install your fork: `claude plugin marketplace add <your-username>/i-have-adhd`.

`marketplace add` registers a marketplace and installs nothing:

```
$ claude plugin marketplace add --help
Add a marketplace from a URL, path, or GitHub repo
$ claude plugin install --help
Install a plugin from available marketplaces (use plugin@marketplace for specific marketplace)
```

So the upstream plugin stays installed, `/i-have-adhd` keeps serving upstream rules, and the fork edits do nothing with no error to explain it. The fork also shares both the marketplace name and the plugin name with upstream, so `i-have-adhd@i-have-adhd` stays ambiguous until the upstream copy is removed.

This is the same defect #37 fixed in `README.md`; I left this line out at the time because five open PRs were editing `INSTALL.md`. They have all landed, so it is a clean change now.

## Change

Replaces the one-liner with the same four-command block `README.md` now carries.

## Verify

```bash
claude plugin list    # i-have-adhd sourced from <your-username>, not ayghri
```
then invoke `/i-have-adhd` and confirm an edit to `SKILL.md` is in effect.