### PR TITLE
fix(evals): isolate the claude runner from the operator's own config

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -32,7 +32,9 @@ python3 scripts/run_evals.py run \
 
 The default Claude runner reports dollar cost and receives the remaining condition budget on every call. Runners without cost reporting are rejected unless `--allow-unmetered` is supplied; use that flag only when the provider account has its own hard cap.
 
-Both example runners isolate the call from the operator's own agent configuration — `--setting-sources ""` for Claude, `--ignore-user-config --ephemeral` for Codex. Keep that isolation when adding runners: without it, user-level plugins, hooks, memory, and output styles leak into every condition and shape the responses being judged. The sharpest case is this repo's own always-on flag (`~/.claude/.i-have-adhd-always`), which would inject the full i-have-adhd ruleset into the **baseline** condition and make the comparison measure the skill against itself.
+Both example runners isolate the call from the operator's own agent configuration: `--setting-sources ""` for Claude, `--ignore-user-config --ephemeral` for Codex. Keep that isolation when adding runners: without it, user-level plugins, hooks, memory, and output styles leak into every condition and shape the responses being judged. The sharpest case is this repo's own always-on flag (`~/.claude/.i-have-adhd-always`), which would inject the full i-have-adhd ruleset into the **baseline** condition and make the comparison measure the skill against itself.
+
+Isolation also drops the operator's saved model and effort settings, so the claude runner pins `--model` explicitly. Keep a pin when editing the runner: without one, the eval silently runs whatever the operator (or the CLI release) defaults to; the model would vary between operators and over time, and per-token cost varies with it. The pinned model is part of the result: record it with published numbers, as below.
 
 Runs are resumable: rerun the same command after a provider failure and completed `(case, trial, condition, runner)` rows are skipped. Each incomplete call is retried twice by default, and the final provider error is preserved.
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -32,6 +32,8 @@ python3 scripts/run_evals.py run \
 
 The default Claude runner reports dollar cost and receives the remaining condition budget on every call. Runners without cost reporting are rejected unless `--allow-unmetered` is supplied; use that flag only when the provider account has its own hard cap.
 
+Both example runners isolate the call from the operator's own agent configuration — `--setting-sources ""` for Claude, `--ignore-user-config --ephemeral` for Codex. Keep that isolation when adding runners: without it, user-level plugins, hooks, memory, and output styles leak into every condition and shape the responses being judged. The sharpest case is this repo's own always-on flag (`~/.claude/.i-have-adhd-always`), which would inject the full i-have-adhd ruleset into the **baseline** condition and make the comparison measure the skill against itself.
+
 Runs are resumable: rerun the same command after a provider failure and completed `(case, trial, condition, runner)` rows are skipped. Each incomplete call is retried twice by default, and the final provider error is preserved.
 
 ## Judge and score

--- a/evals/runners.example.json
+++ b/evals/runners.example.json
@@ -7,6 +7,8 @@
       "--output-format",
       "json",
       "--no-session-persistence",
+      "--setting-sources",
+      "",
       "--tools",
       ""
     ],

--- a/evals/runners.example.json
+++ b/evals/runners.example.json
@@ -9,6 +9,8 @@
       "--no-session-persistence",
       "--setting-sources",
       "",
+      "--model",
+      "claude-opus-4-8",
       "--tools",
       ""
     ],


### PR DESCRIPTION
Fixes #52

## Problem

The `claude` command in `evals/runners.example.json` inherits the operator's user-level Claude Code configuration — plugins, `SessionStart`/`UserPromptSubmit` hooks, memory, `CLAUDE.md`, **and the saved model/effort settings** — into every condition, baseline included. The `codex` runner in the same file already isolates (`--ephemeral --ignore-user-config`); the claude one had no equivalent.

Live repro on a machine with an output-style plugin installed — the harness's own `baseline` row for `direct-answer` ("What is 17 multiplied by 6?"):

```
"response": "102.\n\nSide note: caveman statusline badge not configured. Want me add statusLine…"
```

Operator styling plus an operator-hook tangent, in the baseline. Sharpest case: `INSTALL.md` recommends `touch ~/.claude/.i-have-adhd-always`, whose SessionStart hook injects the **full i-have-adhd ruleset into every eval subprocess** — an operator with the flag set runs a baseline that already contains the skill under test, so the comparison measures the skill against itself and the gate false-fails on "weighted score did not beat baseline".

The model leak is its own hazard: pre-fix, the eval silently ran whatever model the operator had configured — in the repro, the contaminated call ran the operator's Fable 5 while the isolated call fell back to the CLI default Opus 4.8 (verified to the cent from `usage` under each model's pricing). Different operators would publish numbers measured on different models without knowing it.

## Change

- `evals/runners.example.json`: add `--setting-sources ""` (config isolation) **and** `--model claude-opus-4-8` (isolation drops the saved model setting, so the runner must pin one — otherwise the model varies by operator and CLI release).
- `evals/README.md`: paragraph on why both the isolation and the pin must be kept, with the always-on-flag case named.

## Verify

Through the harness itself, same machine, same case:

| runner config | response | cache-write tokens | billed model |
|---|---|---|---|
| before | `102.\n\nSide note: caveman statusline badge…` (221 output tokens) | 6,790 | operator's configured model (Fable 5) |
| after (isolated + pinned) | `102` (3 output tokens) | 3,221 | `claude-opus-4-8`, cost matches Opus pricing to the cent |

Context contamination alone (same-model comparison) roughly halves the input tokens and eliminates the styled output. OAuth unaffected; `result` and `total_cost_usd` still present (budget accounting and the unmetered gate depend on them). `python3 -c "import json; json.load(open('evals/runners.example.json'))"` passes.