### PR TITLE
fix(evals): reject unmetered runners before the first paid call

### DIFF
--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -218,6 +218,11 @@ def run_evaluations(args: argparse.Namespace) -> int:
     runner = config[args.runner]
     command = list(runner["command"])
     response_format = runner.get("response_format", "text")
+    if response_format != "claude-json" and not args.allow_unmetered:
+        raise RuntimeError(
+            f"The {response_format!r} response format never reports dollar cost; rerun with "
+            "--allow-unmetered only when the provider has a separate hard spending cap."
+        )
     reported_cost = 0.0
     prior_rows = read_jsonl(args.output) if args.output.exists() else []
     done = completed_keys(prior_rows)

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import sys
 import tempfile
@@ -119,6 +120,45 @@ class EvaluationHarnessTest(unittest.TestCase):
             path.write_text(json.dumps({"id": "ok"}) + "\nnot-json\n")
             with self.assertRaisesRegex(ValueError, "line 2"):
                 run_evals.read_jsonl(path)
+
+    def test_unmetered_runner_is_rejected_before_any_call(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            marker = tmp_path / "ran"
+            runner_config = tmp_path / "runners.json"
+            runner_config.write_text(
+                json.dumps(
+                    {
+                        "stub": {
+                            "command": ["sh", "-c", f"touch {marker} && echo hi"],
+                            "response_format": "text",
+                        }
+                    }
+                )
+            )
+            args = argparse.Namespace(
+                cases=ROOT / "evals" / "cases.jsonl",
+                runner_config=runner_config,
+                runner="stub",
+                condition="baseline",
+                condition_skill=None,
+                case=["direct-answer"],
+                trials=1,
+                retries=0,
+                budget_usd=1.0,
+                allow_unmetered=False,
+                output=tmp_path / "out.jsonl",
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "never reports dollar cost"):
+                run_evals.run_evaluations(args)
+
+            self.assertFalse(marker.exists(), "runner was invoked before the rejection")
+            self.assertFalse((tmp_path / "out.jsonl").exists())
+
+            args.allow_unmetered = True
+            self.assertEqual(0, run_evals.run_evaluations(args))
+            self.assertTrue(marker.exists())
 
     def test_completed_keys_support_resuming_partial_runs(self):
         rows = [


### PR DESCRIPTION
Fixes #53

## Problem

`run_evals.py` raised `Runner did not report dollar cost; rerun with --allow-unmetered…` **after** the subprocess had run. For the `text` and `codex-jsonl` formats, `_parse_response` returns `cost = None` unconditionally — no output those runners can produce ever passes the check — so the failure is fully determined by config before any call. First codex run without `--allow-unmetered`: one full API call paid, response discarded (row never written), rerun pays for it again.

## Change

Pre-flight in `run_evaluations`, right after `response_format` resolves:

```python
if response_format != "claude-json" and not args.allow_unmetered:
    raise RuntimeError(
        f"The {response_format!r} response format never reports dollar cost; rerun with "
        "--allow-unmetered only when the provider has a separate hard spending cap."
    )
```

The per-call check stays — for `claude-json` responses that omit `total_cost_usd`, which is only knowable at runtime.

Regression test included: a `text` stub runner whose command touches a marker file — without `--allow-unmetered` the run raises with the marker **absent** and no output file created (nothing executed, nothing paid); flipping the flag runs it and the marker appears.

## Verify

```
$ python3 -m unittest discover -s tests
Ran 9 tests … OK
```

Manual: a `codex-jsonl` config without the flag now fails before executing anything; the shipped claude runner is unaffected (verified against a claude-json stub).

## Conflicts

`run_evaluations` preamble + test file. Independent of #56 (evals config/README only).