### PR TITLE
docs(install): scope the "model never sees the skill" claim to Claude Code

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -485,12 +485,12 @@ Exceptions: explain fully when asked to explain. Confirm before destructive acti
 
 ## How activation works
 
-1. **Installed, not invoked.** Nothing happens. `SKILL.md` sets `disable-model-invocation: true`, so the model never sees the skill and never applies the rules on its own.
+1. **Installed, not invoked.** Nothing happens. In Claude Code, `SKILL.md` sets `disable-model-invocation: true`, so the model never sees the skill and never applies the rules on its own. Codex is the exception: its manifest allows implicit invocation, so it may apply the skill to a task that clearly benefits (see the README).
 2. **You type `/i-have-adhd`.** Rules on for that session. "stop adhd mode" or "normal mode" turns them off.
 3. **You touch `~/.claude/.i-have-adhd-always`** (Claude Code). A `SessionStart` hook loads the full ruleset from message one, every session.
 4. **You add the always-on snippet above** (other harnesses). Keeps the core rules in your agent's persistent context.
 
-No middle ground. If you did not turn it on, it is off.
+No middle ground outside Codex: if you did not turn it on, it is off.
 
 ## Troubleshooting
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -485,12 +485,12 @@ Exceptions: explain fully when asked to explain. Confirm before destructive acti
 
 ## How activation works
 
-1. **Installed, not invoked.** Nothing happens. In Claude Code, `SKILL.md` sets `disable-model-invocation: true`, so the model never sees the skill and never applies the rules on its own. Codex is the exception: its manifest allows implicit invocation, so it may apply the skill to a task that clearly benefits (see the README).
+1. **Installed, not invoked.** In Claude Code, nothing happens: `SKILL.md` sets `disable-model-invocation: true`, so the model never sees the skill and never applies the rules on its own. That flag is Claude Code's own; Codex ships with implicit invocation allowed (see the README), and harnesses that implement the open Agent Skills spec load every skill's description at startup and may activate the skill themselves.
 2. **You type `/i-have-adhd`.** Rules on for that session. "stop adhd mode" or "normal mode" turns them off.
 3. **You touch `~/.claude/.i-have-adhd-always`** (Claude Code). A `SessionStart` hook loads the full ruleset from message one, every session.
 4. **You add the always-on snippet above** (other harnesses). Keeps the core rules in your agent's persistent context.
 
-No middle ground outside Codex: if you did not turn it on, it is off.
+In Claude Code, no middle ground: if you did not turn it on, it is off.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Fixes #54

## Problem

"How activation works" step 1 claims, for all harnesses:

> `SKILL.md` sets `disable-model-invocation: true`, so the model never sees the skill and never applies the rules on its own.

and closes with "No middle ground. If you did not turn it on, it is off."

Two problems with the universal claim:

1. **Codex:** the repo ships the opposite policy — `skills/i-have-adhd/agents/openai.yaml` sets `allow_implicit_invocation: true`, and the README documents it: *"The skill can also be invoked implicitly when Codex sees a task that benefits from it."* INSTALL.md and the README contradict each other.
2. **Spec-compliant harnesses (Pi, Zed, Hermes):** `disable-model-invocation` is a Claude Code field, not part of the open Agent Skills specification — the spec's frontmatter is `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools` ([agentskills.io/specification](https://agentskills.io/specification)), and its loading model is that every skill's description loads at startup and the agent decides when to activate. A harness that implements the spec has no reason to honor the Claude-Code-only flag, so the skill may self-activate there as well.

## Change

Two lines in `INSTALL.md`: step 1 states the guarantee where it actually holds (Claude Code), names Codex's explicit implicit-invocation policy, and notes that spec-implementing harnesses may activate the skill themselves; the closing line becomes "In Claude Code, no middle ground: if you did not turn it on, it is off."

(The alternative — flipping `allow_implicit_invocation` to `false` — would change documented Codex behavior, so the config is untouched.)

## Verify

```bash
grep -n "allow_implicit_invocation" skills/i-have-adhd/agents/openai.yaml   # true
grep -n "In Claude Code, no middle ground" INSTALL.md                       # scoped claim present
```

Spec cross-check: the Agent Skills specification defines no `disable-model-invocation` field, so the guarantee is claimed only for Claude Code, which does implement it. No remaining cross-file contradiction.