### PR TITLE
fix(claude): drop the manifest hooks key that blocks the SessionStart hook

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,6 +5,5 @@
   "author": {
     "name": "Ayoub G.",
     "url": "https://github.com/ayghri"
-  },
-  "hooks": "./hooks/hooks.json"
+  }
 }


### PR DESCRIPTION
Fixes #61.

## Problem

`.claude-plugin/plugin.json:9` declares:

```json
"hooks": "./hooks/hooks.json"
```

Claude Code already loads `hooks/hooks.json` by convention. `manifest.hooks` is for *additional* hook files beyond that standard one, so this points at an already-loaded path, trips the duplicate check, and **drops the whole hook set rather than deduplicating it**:

```
Failed to load hooks from
  ~/.claude/plugins/cache/i-have-adhd/i-have-adhd/0.1.0/hooks/hooks.json:
Duplicate hooks file detected: ./hooks/hooks.json resolves to already-loaded file
  ~/.claude/plugins/cache/i-have-adhd/i-have-adhd/0.1.0/hooks/hooks.json.
The standard hooks/hooks.json is loaded automatically, so manifest.hooks should
only reference additional hook files.
```

Since that one `SessionStart` hook is the entire mechanism on this harness, the plugin installs "successfully" and then does nothing — `always-on.js` never runs, so there is no output shaping. The skill still loads and can be invoked manually, which masks the failure.

## Fix

Delete the key. `hooks/hooks.json` keeps loading by convention.

## Verification

On a real 0.1.0 install, before the fix:

- `/reload-plugins` → `1 error during load`, hook set dropped
- worse, the failed load left the plugin **unregistered entirely** — no entry in `installed_plugins.json`, and an `.orphaned_at` marker in the cache dir

After applying this diff and reinstalling:

- `Reloaded: 7 plugins · 5 skills · 57 agents · 13 hooks` — no error
- plugin registered in `installed_plugins.json`, `.orphaned_at` cleared
- hook invoked the way Claude Code runs it, `sh -c 'node "$CLAUDE_PLUGIN_ROOT/hooks/always-on.js"'` → exit 0
- `always-on.js` correctly no-ops without the `~/.claude/.i-have-adhd-always` flag, and injects the ruleset with it

## Notes

- Root `plugin.json` (Antigravity variant) never carried a `hooks` key, so this also removes the drift between the two manifests.
- `gemini-extension.json` has no `hooks` key either — checked, nothing to change there.
- No generator or doc references `plugin.json`, so this one line is the whole fix.

Diagnosis and diff are @herman925's from #61 — they offered to send a PR but hadn't, so raising it here. Credit to them.