### PR TITLE
Fix plugin load failure: drop redundant manifest.hooks declaration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,6 +5,5 @@
   "author": {
     "name": "Ayoub G.",
     "url": "https://github.com/ayghri"
-  },
-  "hooks": "./hooks/hooks.json"
+  }
 }


### PR DESCRIPTION
## Problem

Installing the plugin in Claude Code (user scope) succeeds, but `claude plugin list` reports it as **failed to load**:

```
Hook load failed: Duplicate hooks file detected: ./hooks/hooks.json
resolves to already-loaded file .../hooks/hooks.json. The standard
hooks/hooks.json is loaded automatically, so manifest.hooks should only
reference additional hook files.
```

Claude Code auto-loads the standard `hooks/hooks.json`. Because `.claude-plugin/plugin.json` *also* declares `"hooks": "./hooks/hooks.json"`, the same file is registered twice and the whole plugin fails to load — so neither the `SessionStart` hook nor the skill are available.

## Fix

Remove the redundant `"hooks"` key from `.claude-plugin/plugin.json`. `manifest.hooks` should only reference *additional* hook files beyond the standard path.

## Verification

With the line removed, `claude plugin list` goes from `✘ failed to load` to `✔ enabled`, and the `SessionStart` hook still loads from the standard `hooks/hooks.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)