### PR TITLE
port skill to Google Antigravity

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,94 +1,48 @@
-# Install i-have-adhd
+# Install i-have-adhd for Antigravity
 
-One skill. Claude Code, Codex, Antigravity, and any harness that reads agent skills.
+Ten skill został stworzony z myślą o systemie Antigravity i pozwala sformatować odpowiedzi asystenta w sposób dostosowany dla osób z ADHD.
 
-<details>
-<summary><strong>Claude Code</strong></summary>
+## Instalacja
 
-### Install
+### Metoda 1: Instalator skryptowy (Rekomendowana)
 
-```bash
-claude plugin marketplace add ayghri/i-have-adhd
-claude plugin install i-have-adhd@i-have-adhd
-```
-
-Type `/i-have-adhd`.
-
-### Verify
+Sklonuj to repozytorium na swój dysk i uruchom dołączony skrypt instalacyjny:
 
 ```bash
-claude plugin list
+git clone https://github.com/merx666/i-have-adhd-antigravity.git
+cd i-have-adhd-antigravity
+./install.sh
 ```
+Skrypt automatycznie przekopiuje pliki do katalogu `~/.gemini/config/skills/i-have-adhd-antigravity`.
 
-### Update
+### Metoda 2: Menedżer wtyczek Antigravity
+
+Możesz zainstalować ten skill używając wbudowanego menedżera pluginów Antigravity:
 
 ```bash
-claude plugin marketplace update i-have-adhd
+agy plugin install https://github.com/merx666/i-have-adhd-antigravity
 ```
 
-### Uninstall
+### Metoda 3: Instalacja Ręczna
+
+Jeśli wolisz zrobić to ręcznie, skopiuj odpowiedni folder do konfiguracji Gemini:
 
 ```bash
-claude plugin uninstall i-have-adhd
-claude plugin marketplace remove i-have-adhd
+git clone https://github.com/merx666/i-have-adhd-antigravity.git
+mkdir -p ~/.gemini/config/skills
+cp -R i-have-adhd-antigravity/skills/i-have-adhd ~/.gemini/config/skills/i-have-adhd-antigravity
 ```
 
-Or keep it installed and turn it off: `claude plugin disable i-have-adhd`.
+---
 
-### Always-on (optional)
+## Jak aktywować
 
-A `SessionStart` hook loads the full ruleset at the start of every session, no `/i-have-adhd` needed:
+W nowej sesji w Antigravity wpisz `/i-have-adhd` aby aktywować tryb dla danej konwersacji. 
+Aby wyłączyć, wpisz "stop adhd mode".
 
-```bash
-touch ~/.claude/.i-have-adhd-always
-```
+### Zawsze włączony (Opcjonalnie)
 
-Back to on-demand:
-
-```bash
-rm ~/.claude/.i-have-adhd-always
-```
-
-The hook only fires when the flag file exists, so installing the plugin changes nothing by itself. Honors `$CLAUDE_CONFIG_DIR` if you've moved your config dir. "stop adhd mode" still turns it off for the current session.
-
-</details>
-
-<details>
-<summary><strong>Codex</strong></summary>
-
-### Install
-
-```bash
-codex plugin marketplace add ayghri/i-have-adhd --ref main
-codex plugin add i-have-adhd@i-have-adhd
-```
-
-Type `$i-have-adhd`.
-
-### Verify
-
-```bash
-codex plugin list
-```
-
-### Update
-
-```bash
-codex plugin marketplace upgrade i-have-adhd
-codex plugin remove i-have-adhd
-codex plugin add i-have-adhd@i-have-adhd
-```
-
-### Uninstall
-
-```bash
-codex plugin remove i-have-adhd
-codex plugin marketplace remove i-have-adhd
-```
-
-### Always-on (optional)
-
-Add to `~/.codex/AGENTS.md`:
+Dodaj poniższy fragment do pliku `~/.gemini/GEMINI.md`, aby reguły działały domyślnie od pierwszej wiadomości:
 
 ```markdown
 ## Output style
@@ -109,408 +63,14 @@ The reader has ADHD. Shape every response so it can be acted on:
 Exceptions: explain fully when asked to explain. Confirm before destructive actions. After three failed fixes, stop and name the doubtful assumption. If the request is ambiguous, ask one short question.
 ```
 
-</details>
+---
 
 <details>
-<summary><strong>Zed</strong></summary>
+<summary><strong>Inne systemy (Claude Code, Codex, Zed, Hermes, Pi, itp.)</strong></summary>
 
-Zed's Agent reads Agent Skills natively: the same `SKILL.md`, no conversion. (Zed's older "Rules" were replaced by Skills plus `AGENTS.md` instructions.)
-
-### Install
-
-In the Agent Panel, open the Skills manager and choose **Create skill from URL** (also in the command palette as `agent: create skill from url`), then paste:
-
-```
-https://github.com/ayghri/i-have-adhd/blob/main/skills/i-have-adhd/SKILL.md
-```
-
-Save it in **User** scope for every project, or **Project** scope for one. Then type `/i-have-adhd` in the Agent Panel.
-
-Prefer the filesystem? Clone the repo and drop the skill folder into your user skills directory:
-
+Repozytorium to może być także zainstalowane we frameworkach opartych o standard Agent Skills. Użyj ogólnych narzędzi do instalacji skilli (np. `npx skills add merx666/i-have-adhd-antigravity`). W przypadku Claude Code:
 ```bash
-git clone https://github.com/ayghri/i-have-adhd
-cp -R i-have-adhd/skills/i-have-adhd ~/.config/zed/skills/
+claude plugin marketplace add merx666/i-have-adhd-antigravity
+claude plugin install i-have-adhd@i-have-adhd-antigravity
 ```
-
-### Verify
-
-Open the Skills manager in the Agent Panel and confirm `i-have-adhd` is listed. Or type `/` and confirm it appears.
-
-### Update
-
-Re-import from the same URL (overwrites), or re-copy the folder after `git pull`.
-
-### Uninstall
-
-Remove `i-have-adhd` from the Skills manager, or delete `~/.config/zed/skills/i-have-adhd`.
-
-### Always-on (optional)
-
-Add to your personal `~/.config/zed/AGENTS.md`:
-
-```markdown
-## Output style
-
-The reader has ADHD. Shape every response so it can be acted on:
-
-1. Lead with the answer or next action: command, path, or snippet first.
-2. Number multi-step work; one bounded action per step.
-3. End with one next action doable in under two minutes.
-4. Finish the current issue before raising a new one.
-5. Restate progress each turn ("step 3 of 5 done").
-6. Give time estimates in concrete units, never "a bit".
-7. After a change, show what now works.
-8. Errors: state location, cause, and fix. No drama.
-9. Cap lists at 5 items.
-10. No preamble, no recaps, no closers.
-
-Exceptions: explain fully when asked to explain. Confirm before destructive actions. After three failed fixes, stop and name the doubtful assumption. If the request is ambiguous, ask one short question.
-```
-
 </details>
-
-<details>
-<summary><strong>Hermes</strong></summary>
-
-### Install
-
-```bash
-hermes skills install ayghri/i-have-adhd/skills/i-have-adhd
-```
-
-Type `/i-have-adhd`. The skill installs into `~/.hermes/skills/` and is exposed as a slash command at the next session start.
-
-Prefer to browse first? Add this repo as a skill source (a "tap"), then search and install:
-
-```bash
-hermes skills tap add ayghri/i-have-adhd
-hermes skills search adhd
-hermes skills install ayghri/i-have-adhd/skills/i-have-adhd
-```
-
-### Verify
-
-```bash
-hermes skills list
-```
-
-### Update
-
-```bash
-hermes skills update i-have-adhd
-```
-
-### Uninstall
-
-```bash
-hermes skills uninstall i-have-adhd
-```
-
-Or remove the tap too: `hermes skills tap remove ayghri/i-have-adhd`.
-
-### Always-on (optional)
-
-Add to the `AGENTS.md` in your working directory (Hermes loads it per workdir), or to your persona `SOUL.md` for every session:
-
-```markdown
-## Output style
-
-The reader has ADHD. Shape every response so it can be acted on:
-
-1. Lead with the answer or next action: command, path, or snippet first.
-2. Number multi-step work; one bounded action per step.
-3. End with one next action doable in under two minutes.
-4. Finish the current issue before raising a new one.
-5. Restate progress each turn ("step 3 of 5 done").
-6. Give time estimates in concrete units, never "a bit".
-7. After a change, show what now works.
-8. Errors: state location, cause, and fix. No drama.
-9. Cap lists at 5 items.
-10. No preamble, no recaps, no closers.
-
-Exceptions: explain fully when asked to explain. Confirm before destructive actions. After three failed fixes, stop and name the doubtful assumption. If the request is ambiguous, ask one short question.
-```
-
-</details>
-
-<details>
-<summary><strong>Pi</strong></summary>
-
-Pi implements the Agent Skills standard, so the same `SKILL.md` loads directly, no conversion. Pi's invocation differs from the others: skills are called as `/skill:<name>`.
-
-### Install
-
-```bash
-npx skills add ayghri/i-have-adhd -a pi -y
-```
-
-Prefer the filesystem? Pi discovers skills in `~/.pi/agent/skills/` and `~/.agents/skills/` (global), and `.pi/skills/` and `.agents/skills/` (project):
-
-```bash
-git clone https://github.com/ayghri/i-have-adhd
-mkdir -p ~/.pi/agent/skills
-cp -R i-have-adhd/skills/i-have-adhd ~/.pi/agent/skills/
-```
-
-Enable skill slash commands in Pi's `settings.json`:
-
-```json
-{ "enableSkillCommands": true }
-```
-
-Start a new session and type `/skill:i-have-adhd`.
-
-### Verify
-
-```bash
-npx skills list
-```
-
-Or type `/skill:` in a session and confirm `i-have-adhd` is listed.
-
-### Update
-
-```bash
-npx skills update i-have-adhd
-```
-
-Or re-copy the folder after `git pull`.
-
-### Uninstall
-
-```bash
-npx skills remove i-have-adhd
-```
-
-Or delete `~/.pi/agent/skills/i-have-adhd`.
-
-### Always-on (optional)
-
-Add to your project `AGENTS.md`:
-
-```markdown
-## Output style
-
-The reader has ADHD. Shape every response so it can be acted on:
-
-1. Lead with the answer or next action: command, path, or snippet first.
-2. Number multi-step work; one bounded action per step.
-3. End with one next action doable in under two minutes.
-4. Finish the current issue before raising a new one.
-5. Restate progress each turn ("step 3 of 5 done").
-6. Give time estimates in concrete units, never "a bit".
-7. After a change, show what now works.
-8. Errors: state location, cause, and fix. No drama.
-9. Cap lists at 5 items.
-10. No preamble, no recaps, no closers.
-
-Exceptions: explain fully when asked to explain. Confirm before destructive actions. After three failed fixes, stop and name the doubtful assumption. If the request is ambiguous, ask one short question.
-```
-
-</details>
-
-<details>
-<summary><strong>Gemini CLI</strong></summary>
-
-Gemini CLI has no plugin marketplace, so there are two native routes: a **custom command** (opt-in, off until you invoke it) or an **extension** (always-on once installed). The command route matches this skill's default posture; pick it unless you want the rules on every session.
-
-### Install (command, opt-in)
-
-```bash
-mkdir -p ~/.gemini/commands
-curl -fsSL https://raw.githubusercontent.com/ayghri/i-have-adhd/main/skills/i-have-adhd/agents/gemini.toml \
-  -o ~/.gemini/commands/i-have-adhd.toml
-```
-
-Start a new session, type `/i-have-adhd`. It stays on for that session.
-
-### Install (extension, always-on)
-
-```bash
-gemini extensions install https://github.com/ayghri/i-have-adhd
-```
-
-The extension loads `GEMINI.md`, which imports the full skill, so the rules apply from message one. `git` must be installed.
-
-### Verify
-
-```bash
-gemini extensions list          # extension route
-ls ~/.gemini/commands           # command route: i-have-adhd.toml present
-```
-
-Or type `/` in a session and confirm `i-have-adhd` is listed.
-
-### Update
-
-```bash
-gemini extensions update i-have-adhd    # extension route
-# command route: re-run the curl above
-```
-
-### Uninstall
-
-```bash
-gemini extensions uninstall i-have-adhd    # extension route
-rm ~/.gemini/commands/i-have-adhd.toml     # command route
-```
-
-</details>
-
-<details>
-<summary><strong>Antigravity (<code>agy</code>)</strong></summary>
-
-### Install
-
-```bash
-agy plugin install https://github.com/ayghri/i-have-adhd
-```
-
-### Verify
-
-```bash
-agy plugin list
-```
-
-### Update
-
-```bash
-agy plugin uninstall i-have-adhd
-agy plugin install https://github.com/ayghri/i-have-adhd
-```
-
-### Uninstall
-
-```bash
-agy plugin uninstall i-have-adhd
-```
-
-Or keep it installed and turn it off: `agy plugin disable i-have-adhd`.
-
-### Always-on (optional)
-
-Add to `~/.gemini/GEMINI.md`:
-
-```markdown
-## Output style
-
-The reader has ADHD. Shape every response so it can be acted on:
-
-1. Lead with the answer or next action: command, path, or snippet first.
-2. Number multi-step work; one bounded action per step.
-3. End with one next action doable in under two minutes.
-4. Finish the current issue before raising a new one.
-5. Restate progress each turn ("step 3 of 5 done").
-6. Give time estimates in concrete units, never "a bit".
-7. After a change, show what now works.
-8. Errors: state location, cause, and fix. No drama.
-9. Cap lists at 5 items.
-10. No preamble, no recaps, no closers.
-
-Exceptions: explain fully when asked to explain. Confirm before destructive actions. After three failed fixes, stop and name the doubtful assumption. If the request is ambiguous, ask one short question.
-```
-
-</details>
-
-<details>
-<summary><strong>Cursor, OpenCode, Amp, and any other agent-skills harness</strong></summary>
-
-Works with any harness that reads agent skills. Swap `-a <agent>` for yours.
-
-### Install
-
-```bash
-npx skills add ayghri/i-have-adhd                  # this workspace
-npx skills add ayghri/i-have-adhd -g               # all projects
-npx skills add ayghri/i-have-adhd -a cursor -y     # one agent only
-npx skills add ayghri/i-have-adhd -a opencode -y
-```
-
-New agent chat, type `/i-have-adhd`.
-
-Without the CLI, copy the skill folder into whatever path your agent scans:
-
-```bash
-git clone https://github.com/ayghri/i-have-adhd
-mkdir -p ~/.cursor/skills     # Cursor. Use .agents/skills for OpenCode, or your agent's own path
-cp -R i-have-adhd/skills/i-have-adhd ~/.cursor/skills/
-```
-
-### Verify
-
-```bash
-npx skills list
-npx skills ls -g    # if installed globally
-```
-
-### Update
-
-```bash
-npx skills update i-have-adhd
-npx skills update -g    # if installed globally
-```
-
-### Uninstall
-
-```bash
-npx skills remove i-have-adhd
-npx skills remove i-have-adhd -g    # if installed globally
-```
-
-### Always-on (optional)
-
-Paste this into your agent's persistent rules file. Cursor: **Settings → Rules → User Rules**, or a project rule under `.cursor/rules/` with `alwaysApply: true`. OpenCode: `~/.config/opencode/AGENTS.md`.
-
-```markdown
-## Output style
-
-The reader has ADHD. Shape every response so it can be acted on:
-
-1. Lead with the answer or next action: command, path, or snippet first.
-2. Number multi-step work; one bounded action per step.
-3. End with one next action doable in under two minutes.
-4. Finish the current issue before raising a new one.
-5. Restate progress each turn ("step 3 of 5 done").
-6. Give time estimates in concrete units, never "a bit".
-7. After a change, show what now works.
-8. Errors: state location, cause, and fix. No drama.
-9. Cap lists at 5 items.
-10. No preamble, no recaps, no closers.
-
-Exceptions: explain fully when asked to explain. Confirm before destructive actions. After three failed fixes, stop and name the doubtful assumption. If the request is ambiguous, ask one short question.
-```
-
-</details>
-
-## How activation works
-
-1. **Installed, not invoked.** In Claude Code, nothing happens: `SKILL.md` sets `disable-model-invocation: true`, so the model never sees the skill and never applies the rules on its own. That flag is Claude Code's own; Codex ships with implicit invocation allowed (see the README), and harnesses that implement the open Agent Skills spec load every skill's description at startup and may activate the skill themselves.
-2. **You type `/i-have-adhd`.** Rules on for that session. "stop adhd mode" or "normal mode" turns them off.
-3. **You touch `~/.claude/.i-have-adhd-always`** (Claude Code). A `SessionStart` hook loads the full ruleset from message one, every session.
-4. **You add the always-on snippet above** (other harnesses). Keeps the core rules in your agent's persistent context.
-
-In Claude Code, no middle ground: if you did not turn it on, it is off.
-
-## Troubleshooting
-
-**`/i-have-adhd` not in autocomplete.** Restart the agent. The plugin index is read at startup.
-
-**Always-on flag has no effect.** Update the plugin (`claude plugin marketplace update i-have-adhd`) and restart. Hooks are read at startup, and the flag needs the plugin version that ships `hooks/hooks.json`.
-
-**`claude plugin marketplace add` fails.** Use the `owner/repo` form. A local path must point at the repo root, not `.claude-plugin/`.
-
-**Installed but replies still preamble.** Open a new session. If it still drifts, tighten the wording in `skills/i-have-adhd/SKILL.md`.
-
-**Want different rules.** Fork, edit `skills/i-have-adhd/SKILL.md`, then swap your copy in:
-
-```bash
-claude plugin uninstall i-have-adhd            # drop the upstream copy first:
-claude plugin marketplace remove i-have-adhd   # fork and upstream share both names
-claude plugin marketplace add <your-username>/i-have-adhd
-claude plugin install i-have-adhd@i-have-adhd
-```
-
-Restart, then re-invoke `/i-have-adhd`.
-
-**Skill missing after `npx skills add`.** Start a new agent chat. Skills are indexed at session start. Confirm the folder landed where your agent scans (`~/.cursor/skills/` for Cursor, `.agents/skills/` for OpenCode) and that the frontmatter `name` matches the folder name.

--- a/README.ja.md
+++ b/README.ja.md
@@ -5,7 +5,7 @@
   <strong align="center">ADHD に配慮した出力。ADHD の診断は不要です！</strong>
 </p>
 <p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/ayghri/i-have-adhd?style=flat" alt="ライセンス"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/merx666/i-have-adhd-antigravity?style=flat" alt="ライセンス"></a>
 </p>
 
 <p align="center">
@@ -21,7 +21,7 @@
 <summary><strong>Claude Code</strong></summary>
 
 ```bash
-claude plugin marketplace add ayghri/i-have-adhd
+claude plugin marketplace add merx666/i-have-adhd-antigravity
 claude plugin install i-have-adhd@i-have-adhd
 ```
 
@@ -35,7 +35,7 @@ claude plugin install i-have-adhd@i-have-adhd
 <summary><strong>Codex</strong></summary>
 
 ```bash
-codex plugin marketplace add ayghri/i-have-adhd --ref main
+codex plugin marketplace add merx666/i-have-adhd-antigravity --ref main
 codex plugin add i-have-adhd@i-have-adhd
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <strong align="center">ADHD-friendly outputs. No ADHD diagnosis needed!</strong>
 </p>
 <p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/ayghri/i-have-adhd?style=flat" alt="License"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/merx666/i-have-adhd-antigravity?style=flat" alt="License"></a>
 </p>
 
 <p align="center">
@@ -18,10 +18,25 @@
 ## Install
 
 <details>
+<summary><strong>Google Antigravity</strong></summary>
+
+```bash
+git clone https://github.com/merx666/i-have-adhd-antigravity.git
+cd i-have-adhd-antigravity
+./install.sh
+```
+
+Or you can use the built-in plugin manager: `agy plugin install https://github.com/merx666/i-have-adhd-antigravity`.
+
+See [INSTALL.md](./INSTALL.md) for more details.
+
+</details>
+
+<details>
 <summary><strong>Claude Code</strong></summary>
 
 ```bash
-claude plugin marketplace add ayghri/i-have-adhd
+claude plugin marketplace add merx666/i-have-adhd-antigravity
 claude plugin install i-have-adhd@i-have-adhd
 ```
 
@@ -35,7 +50,7 @@ Want it on every session? `touch ~/.claude/.i-have-adhd-always` (see [INSTALL.md
 <summary><strong>Codex</strong></summary>
 
 ```bash
-codex plugin marketplace add ayghri/i-have-adhd --ref main
+codex plugin marketplace add merx666/i-have-adhd-antigravity --ref main
 codex plugin add i-have-adhd@i-have-adhd
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,7 @@
   <strong align="center">对 ADHD 友好的输出。无需确诊 ADHD！</strong>
 </p>
 <p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/ayghri/i-have-adhd?style=flat" alt="许可证"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/merx666/i-have-adhd-antigravity?style=flat" alt="许可证"></a>
 </p>
 
 <p align="center">
@@ -21,7 +21,7 @@
 <summary><strong>Claude Code</strong></summary>
 
 ```bash
-claude plugin marketplace add ayghri/i-have-adhd
+claude plugin marketplace add merx666/i-have-adhd-antigravity
 claude plugin install i-have-adhd@i-have-adhd
 ```
 
@@ -35,7 +35,7 @@ claude plugin install i-have-adhd@i-have-adhd
 <summary><strong>Codex</strong></summary>
 
 ```bash
-codex plugin marketplace add ayghri/i-have-adhd --ref main
+codex plugin marketplace add merx666/i-have-adhd-antigravity --ref main
 codex plugin add i-have-adhd@i-have-adhd
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+echo "Instalacja umiejętności i-have-adhd dla Antigravity..."
+
+TARGET_DIR="$HOME/.gemini/config/skills/i-have-adhd-antigravity"
+
+# Upewnij się, że katalog docelowy istnieje
+mkdir -p "$HOME/.gemini/config/skills"
+
+if [ -d "$TARGET_DIR" ]; then
+    echo "Katalog docelowy już istnieje. Usuwanie starej wersji..."
+    rm -rf "$TARGET_DIR"
+fi
+
+# Skopiuj zawartość skilla do folderu konfiguracyjnego
+cp -R skills/i-have-adhd "$TARGET_DIR"
+
+echo "Instalacja zakończona sukcesem!"
+echo "W nowej sesji Antigravity użyj polecenia /i-have-adhd aby aktywować."


### PR DESCRIPTION
This commit adapts the i-have-adhd skill specifically for the Google Antigravity environment.  Changes included:
- Replaced all upstream ayghri references with the merx666 fork.
- Restructured INSTALL.md to prioritize native Antigravity installation.
- Added install.sh for simplified manual installation into ~/.gemini/config/skills/.
- Added Google Antigravity instructions to the main README.md.