### PR TITLE
feat: add native Qwen Code extension support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,6 +52,50 @@ The hook only fires when the flag file exists, so installing the plugin changes 
 </details>
 
 <details>
+<summary><strong>Qwen Code</strong></summary>
+
+### Install
+
+```bash
+qwen extensions install ayghri/i-have-adhd
+```
+
+Qwen Code supports the GitHub shorthand and installs the repository as a
+native extension. The extension discovers the skill under `skills/`.
+
+Type `/i-have-adhd` to invoke the skill explicitly. Installing the extension
+does not change output until the skill is invoked, matching the project's
+on-demand behavior in Claude Code and Codex.
+
+### Verify
+
+```bash
+qwen extensions list
+```
+
+Then start a new Qwen Code session and run:
+
+```text
+/skills
+```
+
+Confirm that `i-have-adhd` appears in the list.
+
+### Update
+
+```bash
+qwen extensions update i-have-adhd
+```
+
+### Uninstall
+
+```bash
+qwen extensions uninstall i-have-adhd
+```
+
+</details>
+
+<details>
 <summary><strong>Codex</strong></summary>
 
 ### Install

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ Then type `$i-have-adhd` to apply the output style explicitly. The skill can als
 
 </details>
 
+<details>
+<summary><strong>Qwen Code</strong></summary>
+
+```bash
+qwen extensions install ayghri/i-have-adhd
+```
+
+Qwen Code discovers the `i-have-adhd` skill from `skills/`. Type
+`/i-have-adhd` to invoke the full skill explicitly.
+
+</details>
+
 Install instructions for other coding agents live in [INSTALL.md](./INSTALL.md).
 
 ## What it does

--- a/qwen-extension.json
+++ b/qwen-extension.json
@@ -1,0 +1,6 @@
+{
+  "name": "i-have-adhd",
+  "version": "0.1.0",
+  "description": "ADHD-friendly output shaping for Qwen Code: action first, numbered steps, no tangents, and visible progress.",
+  "skills": "skills"
+}


### PR DESCRIPTION
## What changed

- Add a native `qwen-extension.json` manifest for Qwen Code.
- Expose the existing `i-have-adhd` skill through the extension's `skills/` directory.
- Document install, verification, update, and uninstall commands in the README and install guide.

## Why

Qwen Code can load extensions with Agent Skills, but the repository did not currently advertise or package a native Qwen Code entrypoint. This keeps the existing Claude Code, Codex, Gemini, and other integrations intact while adding the Qwen-native path without changing the existing on-demand behavior.

## Validation

- `python3 -m pytest -q tests/test_run_evals.py` — 9 passed
- `node -e "JSON.parse(...)" qwen-extension.json` — valid JSON
- `qwen extensions link /tmp/i-have-adhd.3qBfGG` — Qwen recognized the manifest, context file, and skill before the interactive confirmation
- `git diff --check`
