### PR TITLE
feat: add opt-in bionic reading mode

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,6 +12,10 @@ claude plugin install i-have-adhd@i-have-adhd
 
 Type `/i-have-adhd`.
 
+The skill also includes an opt-in visual mode. Say `enable bionic reading` to
+bold the leading part of ordinary prose words, or `normal text` to turn that
+mode off without disabling the rest of the skill.
+
 ### Verify
 
 ```bash
@@ -62,6 +66,10 @@ codex plugin add i-have-adhd@i-have-adhd
 ```
 
 Type `$i-have-adhd`.
+
+The same skill includes an opt-in visual mode. Say `enable bionic reading` to
+bold the leading part of ordinary prose words, or `normal text` to turn that
+mode off without disabling the rest of the skill.
 
 ### Verify
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,30 @@ A skill for your coding assistant that stops it from burying the answer. Action 
 9. Cap lists at 5 items.
 10. No preamble. No recap. No closers.
 
+## Optional bionic reading mode
+
+The same skill includes an opt-in bionic reading mode. It is off by default.
+After invoking `i-have-adhd`, say `enable bionic reading` to bold the leading
+part of ordinary prose words. Say `normal text` or `stop bionic mode` to turn it
+off while keeping the rest of the skill active.
+
+This is an experimental visual preference, not a treatment or an evidence-based
+claim about ADHD, reading speed, or comprehension. Code, URLs, paths, and other
+structured text stay unchanged.
+
+### Evidence
+
+The mode is opt-in because the current evidence is mixed and does not yet
+establish a general or ADHD-specific reading benefit. Relevant studies include:
+
+- [Ariyani (2023), *JOEL: Journal of Educational and Language Research*](https://garuda.kemdiktisaintek.go.id/documents/detail/4239848): reported improved classroom scores after two cycles with 30 tenth-grade students (67 to 72 average; 63% to 75% meeting the threshold). This is a positive preliminary signal, but it had no control group and cannot isolate the bionic formatting effect.
+- [Možina et al. (2025), *SAGE Open*](https://doi.org/10.1177/21582440251376158): found shorter average fixations with bionic text, but also more saccades and longer overall reading time; bionic formatting did not significantly improve comprehension or memorisation. This is a mixed eye-tracking result, not a demonstrated reading benefit.
+- [Snell (2024), *Acta Psychologica*](https://doi.org/10.1016/j.actpsy.2024.104304): found no significant reading-time difference between Bionic and normal text.
+- [Spear et al. (2025), *Attention, Perception, & Psychophysics*](https://doi.org/10.3758/s13414-025-03067-w): found no facilitation from bolding word beginnings and no benefit for the individual-difference groups tested.
+
+There is still no strong controlled evidence establishing Bionic Reading as an
+ADHD treatment or a CBT-based intervention.
+
 ## Tune it
 
 Fork, edit `skills/i-have-adhd/SKILL.md`, then swap your copy in:

--- a/skills/i-have-adhd/SKILL.md
+++ b/skills/i-have-adhd/SKILL.md
@@ -140,3 +140,31 @@ Before sending, delete:
 Then verify: if the reader reads only the first line and the last line, do they know (a) what to do next, and (b) what just happened?
 
 If yes, send.
+
+## Optional bionic reading mode
+
+Bionic reading is an experimental visual formatting preference, not a
+treatment and not a proven reading or ADHD intervention. It is off by default.
+
+Enable it only when the reader explicitly says `enable bionic reading` or
+`bionic mode`. Keep it on for the session until the reader says `disable bionic
+reading`, `normal text`, or `stop bionic mode`.
+
+When it is enabled:
+
+1. Bold the first half of **every** ordinary prose word in every paragraph,
+   bullet, and prose line. Do not bold only the first word of a line. For
+   example: `**Bion**ic **read**ing **bold**s the **firs**t half of **each**
+   word.`
+2. Use `ceil(letter_count / 2)` leading letters per word, with one-letter words
+   fully bolded when they are eligible.
+3. Keep punctuation outside the bold span when practical.
+4. Leave code, commands, file paths, URLs, identifiers, tables, diffs, YAML,
+   JSON, and existing Markdown emphasis unchanged.
+5. Do not force the formatting into headings, citations, or text where it
+   makes the meaning harder to scan.
+6. Never claim that the mode improves speed, comprehension, attention, or
+   ADHD symptoms; it is a reversible personal preference.
+
+If the reader asks for normal text, disable only this visual mode and keep the
+rest of `i-have-adhd` active.


### PR DESCRIPTION
## What changed

- Add an opt-in bionic reading mode to the existing `i-have-adhd` skill.
- Enable it with `enable bionic reading` or `bionic mode`.
- Disable it with `disable bionic reading`, `normal text`, or `stop bionic mode`.
- Keep code, commands, paths, URLs, identifiers, tables, diffs, JSON, YAML, citations, and existing emphasis unchanged.
- Document the mode in the README and installation guide.

## Design constraints

- The mode is off by default and does not change the existing ADHD output style.
- It is a reversible visual preference, not a treatment or a claim that bolding improves ADHD symptoms, reading speed, or comprehension.
- The change is implemented inside the existing skill so Claude Code, Codex, Qwen-compatible skill loading, and other Agent Skills consumers share one behavior.

## Evidence

The mode is intentionally opt-in because current evidence is mixed and does not establish a general or ADHD-specific reading benefit:

- [Ariyani (2023), *JOEL: Journal of Educational and Language Research*](https://garuda.kemdiktisaintek.go.id/documents/detail/4239848) reported improved classroom scores after two cycles with 30 tenth-grade students, but had no control group and cannot isolate the bionic formatting effect.
- [Možina et al. (2025), *SAGE Open*](https://doi.org/10.1177/21582440251376158) found shorter average fixations with bionic text, but also more saccades and longer overall reading time; comprehension and memorisation did not show a significant bionic benefit.
- [Snell (2024), *Acta Psychologica*](https://doi.org/10.1016/j.actpsy.2024.104304) found no significant reading-time difference between Bionic and normal text.
- [Spear et al. (2025), *Attention, Perception, & Psychophysics*](https://doi.org/10.3758/s13414-025-03067-w) found no facilitation from bolding word beginnings and no benefit for the individual-difference groups tested.

The positive and mixed findings justify offering this as a reversible preference, not as an ADHD treatment or a CBT-based intervention. No strong controlled ADHD-specific evidence currently establishes that claim.

## Validation

- `python3 -m pytest -q tests/test_run_evals.py` — 9 passed
- `git diff --check`
