### PR TITLE
docs(i18n): fix broken LICENSE badge link in Korean README

### DIFF
--- a/.github/readme/README.ko.md
+++ b/.github/readme/README.ko.md
@@ -5,7 +5,7 @@
   <strong align="center">ADHD 친화 출력. ADHD 진단은 필요 없어요!</strong>
 </p>
 <p align="center">
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/ayghri/i-have-adhd?style=flat" alt="License"></a>
+  <a href="/LICENSE"><img src="https://img.shields.io/github/license/ayghri/i-have-adhd?style=flat" alt="License"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## What

Fixes the LICENSE badge link in `.github/readme/README.ko.md`: `LICENSE` → `/LICENSE`.

## Why

After the translated readmes moved to `.github/readme/`, the relative `LICENSE` link in the Korean readme resolves to `.github/readme/LICENSE`, which 404s. The other translations (ja, zh-CN, vi) already use the root-absolute `/LICENSE`.

Replaces #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)