### PR TITLE
Register the SessionStart hook in the plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,5 +5,6 @@
   "author": {
     "name": "Ayoub G.",
     "url": "https://github.com/ayghri"
-  }
+  },
+  "hooks": "./hooks/hooks.json"
 }


### PR DESCRIPTION
## Problem

Always-on mode never activates. `hooks/hooks.json` correctly defines the `SessionStart` hook that runs `hooks/always-on.sh`, but Claude Code only loads a plugin's hooks file when the manifest points at it. `.claude-plugin/plugin.json` has no `hooks` key, so the file is never read.

The failure is silent: the opt-in flag is set, the script is correct, and nothing happens.

## Fix

One line in `.claude-plugin/plugin.json`:

```json
"hooks": "./hooks/hooks.json"
```

## Verification

On Windows 11 / Claude Code, with `~/.claude/.i-have-adhd-always` present:

- Before: no ADHD ruleset in the session-start context.
- `sh hooks/always-on.sh` run directly: exit 0, emits the full ruleset (~6.6 KB) — so the script and the flag were both fine.
- After adding the `hooks` key to the installed plugin's manifest: the ruleset is injected at session start as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)