### PR TITLE
feat(pi): add pi agent extension with /i-have-adhd command

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -235,15 +235,19 @@ Exceptions: explain fully when asked to explain. Confirm before destructive acti
 <details>
 <summary><strong>Pi</strong></summary>
 
-Pi implements the Agent Skills standard, so the same `SKILL.md` loads directly, no conversion. Pi's invocation differs from the others: skills are called as `/skill:<name>`.
+Pi has two routes: a **native extension** (recommended — slash command, system-prompt injection, status bar, always-on) or a **plain skill** (manual invocation only).
 
-### Install
+### Install (extension, recommended)
 
 ```bash
-npx skills add ayghri/i-have-adhd -a pi -y
+pi install git:github.com/ayghri/i-have-adhd
 ```
 
-Prefer the filesystem? Pi discovers skills in `~/.pi/agent/skills/` and `~/.agents/skills/` (global), and `.pi/skills/` and `.agents/skills/` (project):
+Start a new session and type `/i-have-adhd`. The rules stay on for the session. Say "stop adhd mode" or "normal mode" to turn them off.
+
+### Install (skill only)
+
+Pi discovers skills in `~/.pi/agent/skills/` and `~/.agents/skills/` (global), and `.pi/skills/` and `.agents/skills/` (project):
 
 ```bash
 git clone https://github.com/ayghri/i-have-adhd
@@ -262,49 +266,53 @@ Start a new session and type `/skill:i-have-adhd`.
 ### Verify
 
 ```bash
-npx skills list
+pi list | grep i-have-adhd
 ```
 
-Or type `/skill:` in a session and confirm `i-have-adhd` is listed.
+Or type `/i-have-adhd status` in a session.
 
 ### Update
 
 ```bash
-npx skills update i-have-adhd
+pi install git:github.com/ayghri/i-have-adhd
 ```
 
-Or re-copy the folder after `git pull`.
+Or re-copy the folder after `git pull` (skill route).
 
 ### Uninstall
 
-```bash
-npx skills remove i-have-adhd
-```
+Remove the entry from `~/.pi/agent/settings.json` (extension route), or delete `~/.pi/agent/skills/i-have-adhd` (skill route).
 
-Or delete `~/.pi/agent/skills/i-have-adhd`.
+### Commands
+
+| Command | Effect |
+|---------|--------|
+| `/i-have-adhd` | Turn on for this session |
+| `/i-have-adhd off` | Turn off for this session |
+| `/i-have-adhd status` | Show current state |
+| `stop adhd mode` / `normal mode` | Natural-language deactivation |
 
 ### Always-on (optional)
 
-Add to your project `AGENTS.md`:
+Create a flag file so the rules load from message one, every session:
 
-```markdown
-## Output style
-
-The reader has ADHD. Shape every response so it can be acted on:
-
-1. Lead with the answer or next action: command, path, or snippet first.
-2. Number multi-step work; one bounded action per step.
-3. End with one next action doable in under two minutes.
-4. Finish the current issue before raising a new one.
-5. Restate progress each turn ("step 3 of 5 done").
-6. Give time estimates in concrete units, never "a bit".
-7. After a change, show what now works.
-8. Errors: state location, cause, and fix. No drama.
-9. Cap lists at 5 items.
-10. No preamble, no recaps, no closers.
-
-Exceptions: explain fully when asked to explain. Confirm before destructive actions. After three failed fixes, stop and name the doubtful assumption. If the request is ambiguous, ask one short question.
+```bash
+touch ~/.pi/.i-have-adhd-always
 ```
+
+Or set an environment variable:
+
+```bash
+export I_HAVE_ADHD_ALWAYS=1
+```
+
+Back to on-demand:
+
+```bash
+rm ~/.pi/.i-have-adhd-always
+```
+
+The flag only fires on session start; "stop adhd mode" still turns it off for the current session. Explicitly turning off persists for the session even with the flag file set.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ Then type `$i-have-adhd` to apply the output style explicitly. The skill can als
 
 </details>
 
+<details>
+<summary><strong>Pi</strong></summary>
+
+```bash
+pi install git:github.com/ayghri/i-have-adhd
+```
+
+Then type `/i-have-adhd`. The rules inject into every response for the session. Say "stop adhd mode" to turn them off.
+
+Want it on every session? `touch ~/.pi/.i-have-adhd-always` (see [INSTALL.md](./INSTALL.md)).
+
+</details>
+
 Install instructions for other coding agents live in [INSTALL.md](./INSTALL.md).
 
 ## What it does

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "i-have-adhd",
+  "version": "0.1.0",
+  "description": "ADHD-friendly output shaping for AI agents. Action-first, numbered steps, no preamble or closers.",
+  "keywords": ["pi-package", "pi", "skills", "adhd", "output-style", "productivity"],
+  "license": "MIT",
+  "author": {
+    "name": "Ayoub G.",
+    "url": "https://github.com/ayghri"
+  },
+  "homepage": "https://github.com/ayghri/i-have-adhd",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ayghri/i-have-adhd.git"
+  },
+  "type": "module",
+  "scripts": {
+    "test": "node --test ./pi-extension/test/*.test.js"
+  },
+  "pi": {
+    "extensions": ["./pi-extension/index.js"],
+    "skills": ["./skills"]
+  }
+}

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -1,0 +1,222 @@
+// i-have-adhd — Pi agent extension
+//
+// Registers /i-have-adhd as a native slash command, injects the full ruleset
+// into the system prompt when active, shows a status-bar indicator, and
+// supports always-on via a flag file (~/.pi/.i-have-adhd-always).
+//
+// "stop adhd mode" or "normal mode" turns it off for the session.
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SKILL_PATH = join(__dirname, "..", "skills", "i-have-adhd", "SKILL.md");
+
+// -- Helpers --
+
+/**
+ * Strip YAML frontmatter (--- ... ---) from the top of a Markdown file.
+ * Returns the body as-is if no frontmatter is present.
+ */
+function stripFrontmatter(text) {
+  return String(text || "").replace(/^---[\s\S]*?---\s*/, "");
+}
+
+/**
+ * Read the SKILL.md body (without frontmatter).
+ * Falls back to a compact ruleset if the file is unreadable.
+ */
+function getInstructions() {
+  try {
+    return stripFrontmatter(readFileSync(SKILL_PATH, "utf8"));
+  } catch {
+    return getFallbackInstructions();
+  }
+}
+
+function getFallbackInstructions() {
+  return [
+    "ADHD MODE ACTIVE.",
+    "",
+    "The reader has ADHD. Output is not just brief; it is shaped so an ADHD brain can act on it.",
+    "",
+    "## Rules",
+    "",
+    "1. Lead with the next action. The first line is something the reader can do.",
+    "2. Number multi-step tasks. One bounded action per step.",
+    "3. End with one concrete next action doable in under two minutes.",
+    "4. Suppress tangents. Finish the first issue before raising a second.",
+    '5. Restate state every turn ("Step 3 of 5 done: ... Next: ...").',
+    "6. Give specific time estimates (minutes, not \"a bit\").",
+    "7. Make completed work visible in concrete terms.",
+    '8. Matter-of-fact tone for errors: cause, then fix. No "uh oh".',
+    "9. Cap lists at 5 items.",
+    "10. No preamble, no recap, no closing pleasantries.",
+    "",
+    'Turn off: "stop adhd mode" or "normal mode".',
+  ].join("\n");
+}
+
+/**
+ * "stop adhd mode" / "normal mode" turn the rules off, but only as a standalone
+ * command. Matching the phrase anywhere in the message turned it off mid-task
+ * for ordinary requests — so require the whole message to be the command,
+ * ignoring case and trailing punctuation.
+ */
+function isDeactivationCommand(text) {
+  const t = String(text || "").trim().toLowerCase().replace(/[.!?\s]+$/, "");
+  return t === "stop adhd mode" || t === "normal mode";
+}
+
+/**
+ * Check for the always-on flag file.
+ * Resolution order:
+ *   1. I_HAVE_ADHD_ALWAYS env var (truthy = always on)
+ *   2. ~/.pi/.i-have-adhd-always flag file
+ */
+function isAlwaysOn() {
+  const env = process.env.I_HAVE_ADHD_ALWAYS;
+  if (env !== undefined) {
+    const v = env.trim().toLowerCase();
+    return v !== "" && v !== "0" && v !== "false" && v !== "no";
+  }
+  try {
+    readFileSync(join(homedir(), ".pi", ".i-have-adhd-always"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the session's active state from persisted entries.
+ */
+function resolveSessionActive(entries) {
+  if (!Array.isArray(entries)) return null;
+  for (let i = entries.length - 1; i >= 0; i -= 1) {
+    const entry = entries[i];
+    if (entry?.type !== "custom" || entry?.customType !== "adhd-mode") continue;
+    return entry?.data?.active === true;
+  }
+  return null;
+}
+
+export { isDeactivationCommand, isAlwaysOn, getInstructions, stripFrontmatter };
+
+export default function adhdExtension(pi) {
+  let isActive = false;
+  let lastCtx = null;
+
+  // -- Status bar --
+  function syncStatus(ctx) {
+    if (ctx) lastCtx = ctx;
+    const c = ctx || lastCtx;
+    if (!c?.ui?.setStatus) return;
+    let theme;
+    try {
+      theme = c.ui.theme;
+      if (!theme?.fg) return;
+    } catch {
+      return;
+    }
+    if (!isActive) {
+      c.ui.setStatus("i-have-adhd", "");
+      return;
+    }
+    const indicator = theme.fg("accent", "●");
+    c.ui.setStatus(
+      "i-have-adhd",
+      indicator + " " + theme.fg("muted", "adhd: ") + theme.fg("text", "ON"),
+    );
+  }
+
+  const setActive = (active, ctx) => {
+    isActive = active;
+    pi.appendEntry("adhd-mode", { active });
+    syncStatus(ctx);
+  };
+
+  // -- /i-have-adhd command --
+  pi.registerCommand("i-have-adhd", {
+    description:
+      "Toggle ADHD-friendly output. Commands: on, off, status. No args = on.",
+    handler: async (args, ctx) => {
+      const normalized = String(args || "").trim().toLowerCase();
+
+      if (normalized === "status") {
+        ctx?.ui?.notify?.(
+          `i-have-adhd: ${isActive ? "ON" : "OFF"} • always-on: ${isAlwaysOn() ? "yes" : "no"}`,
+          "info",
+        );
+        return;
+      }
+
+      if (normalized === "off" || normalized === "stop") {
+        setActive(false, ctx);
+        ctx?.ui?.notify?.("ADHD mode OFF. Back to default style.", "info");
+        return;
+      }
+
+      // No args or "on" → activate
+      if (normalized === "" || normalized === "on") {
+        setActive(true, ctx);
+        ctx?.ui?.notify?.(
+          "ADHD mode ON. Rules apply to every response. Say \"stop adhd mode\" to turn off.",
+          "info",
+        );
+        return;
+      }
+
+      ctx?.ui?.notify?.(
+        "Unknown command. Use: /i-have-adhd on | off | status",
+        "warning",
+      );
+    },
+  });
+
+  // -- Deactivation via natural language --
+  pi.on("input", async (event) => {
+    if (event?.source === "extension") return;
+    const text = String(event?.text || "");
+    if (isActive && isDeactivationCommand(text)) {
+      setActive(false);
+    }
+  });
+
+  // -- Session start: check always-on --
+  pi.on("session_start", async (_event, ctx) => {
+    const entries =
+      ctx?.sessionManager?.getBranch?.() || ctx?.sessionManager?.getEntries?.() || [];
+    const persisted = resolveSessionActive(entries);
+
+    // Persisted explicit choice wins; otherwise check always-on flag
+    isActive = persisted !== null ? persisted : isAlwaysOn();
+    syncStatus(ctx);
+
+    if (isActive) {
+      ctx?.ui?.notify?.(
+        `i-have-adhd: ${persisted !== null ? "resumed" : "always-on"}. Say "stop adhd mode" to turn off.`,
+        "info",
+      );
+    }
+  });
+
+  pi.on("agent_start", async (_event, ctx) => {
+    syncStatus(ctx);
+  });
+
+  pi.on("agent_end", async (_event, ctx) => {
+    syncStatus(ctx);
+  });
+
+  // -- Inject rules into system prompt --
+  pi.on("before_agent_start", async (event) => {
+    if (!isActive) return;
+    const base = event?.systemPrompt ? `${event.systemPrompt}\n\n` : "";
+    return {
+      systemPrompt: `${base}ADHD MODE ACTIVE — i-have-adhd\n\n${getInstructions()}`,
+    };
+  });
+}

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -1,0 +1,305 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import adhdExtension, {
+  isDeactivationCommand,
+  stripFrontmatter,
+} from "../index.js";
+
+// -- Test harness --
+
+function createPiHarness() {
+  const events = new Map();
+  const commands = new Map();
+  const appendedEntries = [];
+  const sentUserMessages = [];
+
+  const pi = {
+    on(eventName, handler) {
+      events.set(eventName, handler);
+    },
+    registerCommand(name, options) {
+      commands.set(name, options);
+    },
+    appendEntry(customType, data) {
+      appendedEntries.push({ customType, data });
+    },
+    sendUserMessage(text, options) {
+      sentUserMessages.push({ text, options });
+    },
+  };
+
+  adhdExtension(pi);
+  return { events, commands, appendedEntries, sentUserMessages };
+}
+
+function createCommandContext(overrides = {}) {
+  return {
+    isIdle: () => true,
+    sessionManager: { getEntries: () => [] },
+    ui: { notify() {} },
+    ...overrides,
+  };
+}
+
+function withTempHome(fn) {
+  const tempHome = mkdtempSync(join(tmpdir(), "adhd-test-"));
+  const previousHome = process.env.HOME;
+  const previousAlways = process.env.I_HAVE_ADHD_ALWAYS;
+  process.env.HOME = tempHome;
+  delete process.env.I_HAVE_ADHD_ALWAYS;
+
+  return Promise.resolve()
+    .then(() => fn(tempHome))
+    .finally(() => {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousAlways === undefined) delete process.env.I_HAVE_ADHD_ALWAYS;
+      else process.env.I_HAVE_ADHD_ALWAYS = previousAlways;
+      rmSync(tempHome, { recursive: true, force: true });
+    });
+}
+
+// -- Tests --
+
+test("extension registers /i-have-adhd command", () => {
+  const { commands } = createPiHarness();
+  assert.deepEqual([...commands.keys()], ["i-have-adhd"]);
+});
+
+test("/i-have-adhd activates and injects instructions", async () => {
+  await withTempHome(async () => {
+    const { commands, events, appendedEntries } = createPiHarness();
+    const ctx = createCommandContext();
+
+    // session_start with no flag file → inactive
+    await events.get("session_start")({}, ctx);
+    const beforeOff = await events.get("before_agent_start")(
+      { systemPrompt: "BASE" },
+      ctx,
+    );
+    assert.equal(beforeOff, undefined);
+
+    // Turn on
+    await commands.get("i-have-adhd").handler("", ctx);
+    assert.deepEqual(appendedEntries.at(-1), {
+      customType: "adhd-mode",
+      data: { active: true },
+    });
+
+    // Should now inject into system prompt
+    const result = await events.get("before_agent_start")(
+      { systemPrompt: "BASE" },
+      ctx,
+    );
+    assert.ok(result.systemPrompt.includes("ADHD MODE ACTIVE"));
+    assert.ok(result.systemPrompt.includes("BASE"));
+    assert.ok(result.systemPrompt.includes("Lead with the next action"));
+  });
+});
+
+test("/i-have-adhd off deactivates", async () => {
+  await withTempHome(async () => {
+    const { commands, events, appendedEntries } = createPiHarness();
+    const ctx = createCommandContext();
+
+    await commands.get("i-have-adhd").handler("", ctx); // on
+    await commands.get("i-have-adhd").handler("off", ctx); // off
+
+    assert.deepEqual(appendedEntries.at(-1), {
+      customType: "adhd-mode",
+      data: { active: false },
+    });
+
+    const result = await events.get("before_agent_start")(
+      { systemPrompt: "BASE" },
+      ctx,
+    );
+    assert.equal(result, undefined);
+  });
+});
+
+test("/i-have-adhd status shows state", async () => {
+  await withTempHome(async () => {
+    const { commands } = createPiHarness();
+    let notified = null;
+    const ctx = createCommandContext({
+      ui: { notify(msg) { notified = msg; } },
+    });
+
+    await commands.get("i-have-adhd").handler("status", ctx);
+    assert.ok(notified.includes("OFF"));
+  });
+});
+
+test("always-on flag file activates on session start", async () => {
+  await withTempHome(async (tempHome) => {
+    // Create the flag file
+    mkdirSync(join(tempHome, ".pi"), { recursive: true });
+    writeFileSync(join(tempHome, ".pi", ".i-have-adhd-always"), "");
+
+    const { events } = createPiHarness();
+    const ctx = createCommandContext();
+
+    await events.get("session_start")({}, ctx);
+
+    const result = await events.get("before_agent_start")(
+      { systemPrompt: "BASE" },
+      ctx,
+    );
+    assert.ok(result.systemPrompt.includes("ADHD MODE ACTIVE"));
+  });
+});
+
+test("always-on env var activates on session start", async () => {
+  await withTempHome(async () => {
+    process.env.I_HAVE_ADHD_ALWAYS = "1";
+
+    const { events } = createPiHarness();
+    const ctx = createCommandContext();
+
+    await events.get("session_start")({}, ctx);
+
+    const result = await events.get("before_agent_start")(
+      { systemPrompt: "BASE" },
+      ctx,
+    );
+    assert.ok(result.systemPrompt.includes("ADHD MODE ACTIVE"));
+  });
+});
+
+test("persisted session state is restored", async () => {
+  await withTempHome(async () => {
+    const { events } = createPiHarness();
+    const ctx = createCommandContext({
+      sessionManager: {
+        getEntries: () => [
+          { type: "custom", customType: "adhd-mode", data: { active: true } },
+        ],
+      },
+    });
+
+    await events.get("session_start")({}, ctx);
+
+    const result = await events.get("before_agent_start")(
+      { systemPrompt: "BASE" },
+      ctx,
+    );
+    assert.ok(result.systemPrompt.includes("ADHD MODE ACTIVE"));
+  });
+});
+
+test("persisted off state is restored even with always-on flag", async () => {
+  await withTempHome(async (tempHome) => {
+    mkdirSync(join(tempHome, ".pi"), { recursive: true });
+    writeFileSync(join(tempHome, ".pi", ".i-have-adhd-always"), "");
+
+    const { events } = createPiHarness();
+    const ctx = createCommandContext({
+      sessionManager: {
+        getEntries: () => [
+          { type: "custom", customType: "adhd-mode", data: { active: false } },
+        ],
+      },
+    });
+
+    await events.get("session_start")({}, ctx);
+
+    const result = await events.get("before_agent_start")(
+      { systemPrompt: "BASE" },
+      ctx,
+    );
+    assert.equal(result, undefined); // persisted off wins over always-on
+  });
+});
+
+test('"stop adhd mode" deactivates via input event', async () => {
+  await withTempHome(async () => {
+    const { commands, events, appendedEntries } = createPiHarness();
+    const ctx = createCommandContext();
+
+    await commands.get("i-have-adhd").handler("", ctx); // on
+    assert.equal(appendedEntries.at(-1).data.active, true);
+
+    // Simulate user typing "stop adhd mode"
+    await events.get("input")({ text: "stop adhd mode" });
+
+    assert.equal(appendedEntries.at(-1).data.active, false);
+  });
+});
+
+test('"normal mode" deactivates via input event', async () => {
+  await withTempHome(async () => {
+    const { commands, events } = createPiHarness();
+    const ctx = createCommandContext();
+
+    await commands.get("i-have-adhd").handler("", ctx); // on
+    await events.get("input")({ text: "normal mode" });
+
+    const result = await events.get("before_agent_start")(
+      { systemPrompt: "BASE" },
+      ctx,
+    );
+    assert.equal(result, undefined);
+  });
+});
+
+test("deactivation command in mid-sentence does NOT deactivate", async () => {
+  await withTempHome(async () => {
+    const { commands, events } = createPiHarness();
+    const ctx = createCommandContext();
+
+    await commands.get("i-have-adhd").handler("", ctx); // on
+    await events.get("input")({ text: "add a normal mode toggle to the settings" });
+
+    const result = await events.get("before_agent_start")(
+      { systemPrompt: "BASE" },
+      ctx,
+    );
+    assert.ok(result.systemPrompt.includes("ADHD MODE ACTIVE"));
+  });
+});
+
+test("input event from extension source is ignored", async () => {
+  await withTempHome(async () => {
+    const { commands, events, appendedEntries } = createPiHarness();
+    const ctx = createCommandContext();
+
+    await commands.get("i-have-adhd").handler("", ctx); // on
+    const countBefore = appendedEntries.length;
+
+    await events.get("input")({ source: "extension", text: "stop adhd mode" });
+
+    assert.equal(appendedEntries.length, countBefore); // no new entry
+  });
+});
+
+// -- Pure function tests --
+
+test("isDeactivationCommand matches exact phrases", () => {
+  assert.equal(isDeactivationCommand("stop adhd mode"), true);
+  assert.equal(isDeactivationCommand("Stop ADHD Mode"), true);
+  assert.equal(isDeactivationCommand("normal mode"), true);
+  assert.equal(isDeactivationCommand("normal mode."), true);
+  assert.equal(isDeactivationCommand("stop adhd mode!"), true);
+});
+
+test("isDeactivationCommand rejects mid-sentence usage", () => {
+  assert.equal(isDeactivationCommand("add a normal mode toggle"), false);
+  assert.equal(isDeactivationCommand("how do I stop adhd mode from running"), false);
+  assert.equal(isDeactivationCommand(""), false);
+  assert.equal(isDeactivationCommand(null), false);
+});
+
+test("stripFrontmatter removes YAML frontmatter", () => {
+  const withFm = "---\nname: test\ndescription: hi\n---\n# Body\nText";
+  assert.equal(stripFrontmatter(withFm), "# Body\nText");
+
+  const withoutFm = "# Body\nText";
+  assert.equal(stripFrontmatter(withoutFm), "# Body\nText");
+
+  assert.equal(stripFrontmatter(""), "");
+});


### PR DESCRIPTION
## What

Adds a native Pi agent extension so i-have-adhd works on Pi the same way ponytail does — slash command, system-prompt injection, status bar, always-on.

## Why

Pi discovers skills via `/skill:<name>`, but the extension adds a native `/i-have-adhd` command and injects the full ruleset into the system prompt when active — matching the UX of Claude Code's `/i-have-adhd` and ponytail's `/ponytail`.

## Changes

| File | What |
|------|------|
| `package.json` | Root package.json with `pi.extensions` and `pi.skills` fields — pi uses this to discover the extension entry point |
| `pi-extension/index.js` | Extension entry: registers `/i-have-adhd` command (on/off/status), injects SKILL.md into system prompt via `before_agent_start`, status bar indicator, always-on via `~/.pi/.i-have-adhd-always` flag file or `I_HAVE_ADHD_ALWAYS` env var, natural-language deactivation ("stop adhd mode" / "normal mode") |
| `pi-extension/test/extension.test.js` | 15 tests: command registration, activation/deactivation, system-prompt injection, always-on flag, session state persistence, deactivation edge cases |
| `INSTALL.md` | Pi section rewritten: extension install (recommended) + skill-only (alternative), command table, always-on instructions |
| `README.md` | Add Pi collapse section with one-line install |

## How it works

```
/i-have-adhd          → setActive(true) → appendEntry → status bar: ● adhd: ON
before_agent_start    → reads SKILL.md, strips frontmatter, injects into systemPrompt
stop adhd mode        → input event → isDeactivationCommand → setActive(false)
session_start         → restore persisted state, else check always-on flag
```

## Design notes

- Modeled after ponytail's pi-extension, simplified to on/off (no intensity levels)
- Zero external dependencies — reads SKILL.md at runtime, no build step
- `package.json` `"pi": { "extensions": ["./pi-extension/index.js"] }` is the discovery mechanism (same as ponytail and pi-insight)

## Test

```bash
cd pi-extension && node --test ./test/*.test.js
# 15 tests, 0 fail
```

Install locally:

```bash
pi install ~/projects/i-have-adhd
# new session → /i-have-adhd → ● adhd: ON
```