### PR TITLE
feat: pi always-on hook via extension

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -285,7 +285,24 @@ Or delete `~/.pi/agent/skills/i-have-adhd`.
 
 ### Always-on (optional)
 
-Add to your project `AGENTS.md`:
+Pi has no hooks.json, so the Claude `SessionStart` hook has no direct equivalent — but an extension behaves the same way: it loads the full ruleset at the start of every session, no `/skill:i-have-adhd` needed. Install the extension once, then toggle it with a flag file:
+
+```bash
+cp extensions/i-have-adhd-always.ts ~/.pi/agent/extensions/
+touch ~/.pi/agent/.i-have-adhd-always     # always-on for every session
+```
+
+Restart pi (or `/reload`). The extension only fires when the flag file exists, so installing it changes nothing by itself. Honors `$PI_CODING_AGENT_DIR` if you've moved your config dir. "stop adhd mode" still turns it off for the current session.
+
+Back to on-demand:
+
+```bash
+rm ~/.pi/agent/.i-have-adhd-always
+```
+
+The flag needs the installed SKILL.md: the extension looks in the repo layout first, then in `~/.pi/agent/skills/` (where the install above puts it). If it can't find either, it warns once and does nothing.
+
+No extensions? Paste the condensed rules into your project `AGENTS.md`:
 
 ```markdown
 ## Output style
@@ -560,7 +577,8 @@ Exceptions: explain fully when asked to explain. Confirm before destructive acti
 1. **Installed, not invoked.** In Claude Code, nothing happens: `SKILL.md` sets `disable-model-invocation: true`, so the model never sees the skill and never applies the rules on its own. That flag is Claude Code's own; Codex ships with implicit invocation allowed (see the README), and harnesses that implement the open Agent Skills spec load every skill's description at startup and may activate the skill themselves.
 2. **You type `/i-have-adhd`.** Rules on for that session. "stop adhd mode" or "normal mode" turns them off.
 3. **You touch `~/.claude/.i-have-adhd-always`** (Claude Code). A `SessionStart` hook loads the full ruleset from message one, every session.
-4. **You add the always-on snippet above** (other harnesses). Keeps the core rules in your agent's persistent context.
+4. **You touch `~/.pi/agent/.i-have-adhd-always`** (Pi). The always-on extension loads the full ruleset into the system prompt from message one, every session.
+5. **You add the always-on snippet above** (other harnesses). Keeps the core rules in your agent's persistent context.
 
 In Claude Code, no middle ground: if you did not turn it on, it is off.
 

--- a/extensions/i-have-adhd-always.ts
+++ b/extensions/i-have-adhd-always.ts
@@ -1,0 +1,72 @@
+/**
+ * Always-on i-have-adhd for pi — pi's equivalent of Claude Code's SessionStart hook.
+ *
+ * Pi has no hooks.json; the extension system is the equivalent mechanism. When the
+ * flag file $PI_CODING_AGENT_DIR/.i-have-adhd-always (default ~/.pi/agent/.i-have-adhd-always)
+ * exists, this extension appends the full i-have-adhd ruleset to the system prompt
+ * of every turn, so the rules apply from message one in every session.
+ *
+ * The hook only fires when the flag file exists, so installing the extension changes
+ * nothing by itself. "stop adhd mode" still turns it off for the current session.
+ *
+ * Install: copy to ~/.pi/agent/extensions/ (global, all projects) or .pi/extensions/
+ * (project-local), then /reload or restart pi.
+ * Turn on:  touch ~/.pi/agent/.i-have-adhd-always
+ * Turn off: rm ~/.pi/agent/.i-have-adhd-always
+ *
+ * Mirrors hooks/always-on.sh: pure no-op unless the flag exists, never blocks
+ * session start.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+// Strip a leading YAML frontmatter block (--- ... --- at the very top of file).
+function stripFrontmatter(md: string): string {
+	const lines = md.split("\n");
+	if (lines[0]?.trim() !== "---") return md;
+	const end = lines.slice(1).findIndex((line) => line.trim() === "---");
+	return end === -1 ? md : lines.slice(end + 2).join("\n");
+}
+
+export default function iHaveAdhdAlways(pi: ExtensionAPI) {
+	let ruleset = "";
+
+	pi.on("session_start", async (_event, ctx) => {
+		const configDir = process.env.PI_CODING_AGENT_DIR ?? path.join(os.homedir(), ".pi", "agent");
+		const flagPath = path.join(configDir, ".i-have-adhd-always");
+
+		ruleset = "";
+		if (!fs.existsSync(flagPath)) return;
+
+		// The extension ships as a single file, so it can't assume its own directory
+		// contains the repo. Check the repo layout first (clone / in-place install),
+		// then the pi-global skill install (~/.pi/agent/skills/).
+		const candidates = [
+			path.join(__dirname, "..", "skills", "i-have-adhd", "SKILL.md"),
+			path.join(configDir, "skills", "i-have-adhd", "SKILL.md"),
+		];
+		const skillPath = candidates.find((p) => fs.existsSync(p));
+		if (!skillPath) {
+			ctx.ui.notify(
+				"i-have-adhd always-on: SKILL.md not found (install the skill first)",
+				"warning",
+			);
+			return;
+		}
+
+		const body = stripFrontmatter(fs.readFileSync(skillPath, "utf8"));
+		ruleset =
+			"ADHD MODE ACTIVE (always-on). The ruleset below applies to every response. " +
+			`"stop adhd mode" turns it off for this session; delete ${flagPath} to turn always-on off for good.\n\n` +
+			body;
+	});
+
+	// Re-appended every turn so it survives /reload, resume, and fork; pi resets the
+	// system prompt to the base each turn unless an extension returns a replacement.
+	pi.on("before_agent_start", async (event) => {
+		if (!ruleset) return;
+		return { systemPrompt: `${event.systemPrompt}\n\n${ruleset}` };
+	});
+}


### PR DESCRIPTION
## What

Pi has no hooks.json like Claude Code, so the `SessionStart` hook has no direct equivalent — the extension system is the mechanism. This PR adds `extensions/i-have-adhd-always.ts`, a pi extension that mirrors `hooks/always-on.sh`:

- When `$PI_CODING_AGENT_DIR/.i-have-adhd-always` (default `~/.pi/agent/.i-have-adhd-always`) exists, it appends the full `SKILL.md` ruleset to the system prompt of every turn, so the rules apply from message one in every session — same UX as `touch ~/.claude/.i-have-adhd-always`.
- Pure no-op without the flag; installing the extension changes nothing by itself.
- Resolves `SKILL.md` from the repo layout (in-place install) or `~/.pi/agent/skills/` (the `npx skills add` install), strips frontmatter like `always-on.sh` does.
- `"stop adhd mode"` still turns it off for the current session.

Also updates INSTALL.md (Pi section + "How activation works").

## Why the system-prompt hook, not message injection

`before_agent_start`'s `message` return re-injects every turn (context pollution); `sessionManager.appendMessage` on the live session is undocumented/read-only-by-docs. Returning `systemPrompt` from `before_agent_start` is the documented, idempotent pattern (pi's own `claude-rules.ts`/`pirate.ts` examples) and survives startup/resume/reload/fork identically.

## Verified

Ran headless (`pi -p`) with a scratch `PI_CODING_AGENT_DIR`:
- flag present → ruleset injected into the system prompt, frontmatter stripped
- flag absent → no injection

## Notes

- No CI change: the repo's workflows only cover the Claude plugin paths.
- The condensed `AGENTS.md` snippet stays in the Pi section as the no-extension fallback.
