### PR TITLE
Add Kimi Code CLI plugin manifest (kimi.plugin.json)

### DIFF
--- a/kimi.plugin.json
+++ b/kimi.plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "i-have-adhd",
+  "version": "1.0.0",
+  "description": "Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible.",
+  "license": "MIT",
+  "homepage": "https://github.com/ayghri/i-have-adhd",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "I Have ADHD",
+    "shortDescription": "ADHD-friendly output shaping for Kimi Code CLI"
+  }
+}

--- a/kimi.plugin.json
+++ b/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "i-have-adhd",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible.",
   "license": "MIT",
   "homepage": "https://github.com/ayghri/i-have-adhd",


### PR DESCRIPTION
## What

Adds a root `kimi.plugin.json` manifest so the package installs natively as a [Kimi Code CLI plugin](https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html):

```
/plugins install https://github.com/ayghri/i-have-adhd
```

## How it works

Kimi Code CLI discovers plugin skills via a root `kimi.plugin.json` (or `.kimi-plugin/plugin.json`) whose `skills` field points at directories containing `SKILL.md`. The existing `skills/i-have-adhd/` tree is reused **unchanged** — this PR adds one file, no behavior changes for other hosts.

After installing, users trigger the skill manually with `/skill:i-have-adhd` (matching the skill's `disable-model-invocation: true`).

## Verified

- [x] Manifest parses and satisfies Kimi Code's required fields (`name` pattern, `skills` within plugin root)
- [x] Same content tested as a locally installed Kimi Code plugin (`/plugins install <path>` + `/reload`)