### PR TITLE
hooks: keep the skill body when frontmatter is never closed

### DIFF
--- a/hooks/always-on.ps1
+++ b/hooks/always-on.ps1
@@ -25,7 +25,8 @@ try {
   $bodyStart = 0
 
   if ($lines.Length -gt 0 -and $lines[0] -match '^---\s*$') {
-    $bodyStart = $lines.Length
+    # Only treat the block as frontmatter when the closing delimiter exists;
+    # an unterminated fence is not frontmatter, so keep the whole file.
     for ($i = 1; $i -lt $lines.Length; $i++) {
       if ($lines[$i] -match '^---\s*$') {
         $bodyStart = $i + 1

--- a/hooks/always-on.sh
+++ b/hooks/always-on.sh
@@ -19,11 +19,19 @@ skill_path="$script_dir/../skills/i-have-adhd/SKILL.md"
 [ -f "$skill_path" ] || exit 0
 
 # Strip a leading YAML frontmatter block (--- ... --- at the very top of file).
+# An unterminated fence is not frontmatter, so the whole file is kept unless the
+# closing delimiter exists (two passes; matches the Node and PowerShell hooks).
 body=$(awk '
-  NR == 1 && $0 ~ /^---[[:space:]]*$/ { in_fm = 1; next }
-  in_fm && $0 ~ /^---[[:space:]]*$/   { in_fm = 0; next }
-  !in_fm                              { print }
-' "$skill_path") || exit 0
+  NR == FNR {
+    if (NR == 1 && $0 ~ /^---[[:space:]]*$/) { in_fm = 1; next }
+    if (in_fm && $0 ~ /^---[[:space:]]*$/)   { in_fm = 0; closed = 1 }
+    next
+  }
+  FNR == 1 { strip = closed }
+  strip && FNR == 1 && $0 ~ /^---[[:space:]]*$/ { skipping = 1; next }
+  skipping && $0 ~ /^---[[:space:]]*$/          { skipping = 0; next }
+  !skipping { print }
+' "$skill_path" "$skill_path") || exit 0
 
 printf 'ADHD MODE ACTIVE (always-on). The ruleset below applies to every response. "stop adhd mode" turns it off for this session; delete %s to turn always-on off for good.\n\n%s\n' \
   "$flag_path" "$body"

--- a/tests/test_always_on_hooks.py
+++ b/tests/test_always_on_hooks.py
@@ -81,6 +81,26 @@ class AlwaysOnHookTest(unittest.TestCase):
 
         self.assertEqual(1, len(set(outputs.values())))
 
+    def test_runtimes_keep_content_when_frontmatter_is_unclosed(self):
+        # An opening --- with no closing delimiter is not frontmatter. Keeping
+        # the whole file beats injecting a banner that promises "the ruleset
+        # below" followed by nothing.
+        skill_path = self.plugin_root / "skills" / "i-have-adhd" / "SKILL.md"
+        skill_path.write_text("---\nname: fixture\nFixture body, fence never closed.\n")
+        (self.config_dir / ".i-have-adhd-always").touch()
+        outputs = {}
+
+        for name, command in self.runtimes():
+            with self.subTest(runtime=name):
+                result = self.run_hook(command)
+                self.assertEqual(0, result.returncode)
+                self.assertEqual("", result.stderr)
+                normalized = result.stdout.replace("\r\n", "\n")
+                self.assertIn("Fixture body, fence never closed.", normalized)
+                outputs[name] = normalized
+
+        self.assertEqual(1, len(set(outputs.values())))
+
     def test_hook_uses_shell_free_node_exec_form(self):
         config = json.loads((ROOT / "hooks" / "hooks.json").read_text())
         hook = config["hooks"]["SessionStart"][0]["hooks"][0]

--- a/tests/test_always_on_hooks.py
+++ b/tests/test_always_on_hooks.py
@@ -53,6 +53,13 @@ class AlwaysOnHookTest(unittest.TestCase):
             env=env,
         )
 
+    @staticmethod
+    def normalize(stdout):
+        # The banner embeds the flag path. On Windows the sh runtime joins it
+        # with "/" while node and PowerShell join with "\"; both name the same
+        # file, so unify separators (and newlines) before comparing runtimes.
+        return stdout.replace("\r\n", "\n").replace("\\", "/")
+
     def test_hook_is_silent_without_opt_in_flag(self):
         self.assertTrue(self.runtimes(), "no hook runtime is available")
 
@@ -74,7 +81,7 @@ class AlwaysOnHookTest(unittest.TestCase):
                 result = self.run_hook(command)
                 self.assertEqual(0, result.returncode)
                 self.assertEqual("", result.stderr)
-                normalized = result.stdout.replace("\r\n", "\n")
+                normalized = self.normalize(result.stdout)
                 self.assertNotIn("name: fixture", normalized)
                 self.assertIn("\n\nFixture body.\n", normalized)
                 outputs[name] = normalized
@@ -95,7 +102,7 @@ class AlwaysOnHookTest(unittest.TestCase):
                 result = self.run_hook(command)
                 self.assertEqual(0, result.returncode)
                 self.assertEqual("", result.stderr)
-                normalized = result.stdout.replace("\r\n", "\n")
+                normalized = self.normalize(result.stdout)
                 self.assertIn("Fixture body, fence never closed.", normalized)
                 outputs[name] = normalized
 


### PR DESCRIPTION
Follow-up to #71, as requested in https://github.com/ayghri/i-have-adhd/pull/71#issuecomment-5205760730 — this is the commit that raced the merge (`795181b`), cherry-picked cleanly onto current `main`.

## Problem

The three hook runtimes disagree on a malformed `SKILL.md` whose opening `---` fence is never closed:

- **Node** (`always-on.mjs`): the regex only strips a *complete* fence, so it keeps the whole file — reasonable.
- **sh + PowerShell fallbacks**: enter frontmatter mode on line 1 and never leave. The user gets the banner promising *"The ruleset below applies to every response"* followed by **nothing**.

That breaks the parity invariant the #71 test matrix asserts, just on a different input.

## Fix

Treat an unterminated fence as not-frontmatter in all three runtimes:

- `always-on.ps1`: only strip when the closing delimiter was actually found (drop the `$bodyStart = $lines.Length` presumption).
- `always-on.sh`: two-pass awk — first pass decides whether the fence ever closes, second strips only if it did.
- `tests/test_always_on_hooks.py`: new parity case pinning all runtimes to identical output for this input, alongside the existing trailing-whitespace case.

## Verification (Windows 11)

- 4/4 tests pass under PowerShell 5.1 (node + powershell runtimes; `sh` is not on PATH for `shutil.which` here, so the sh hook was probed separately through Git bash awk 5.4 — unclosed fence keeps the body, and the #71 trailing-whitespace case still strips correctly).
- Negative control: reverting only `always-on.ps1` fails exactly the new test, with the banner-plus-empty-body output verbatim.
- Cherry-pick onto current `main` (`9a7e1f5`) applied with no conflicts; suite re-run green on this base.

AI assistance: drafted with Kiro CLI; all changes reviewed and verified by me.
