### PR TITLE
fix: make skill metadata compatible with strict parsers

### DIFF
--- a/.cursor/skills/i-have-adhd/SKILL.md
+++ b/.cursor/skills/i-have-adhd/SKILL.md
@@ -4,10 +4,8 @@ description: 'Shape output for a reader with ADHD: lead with the next action, nu
 disable-model-invocation: true
 license: MIT
 metadata:
-  hermes:
-    tags: [ADHD, Output Style, Productivity, Formatting]
-    category: productivity
-    related_skills: []
+  tags: "ADHD, Output Style, Productivity, Formatting"
+  category: "productivity"
 ---
 
 # i-have-adhd

--- a/skills/i-have-adhd/SKILL.md
+++ b/skills/i-have-adhd/SKILL.md
@@ -4,10 +4,8 @@ description: 'Shape output for a reader with ADHD: lead with the next action, nu
 disable-model-invocation: true
 license: MIT
 metadata:
-  hermes:
-    tags: [ADHD, Output Style, Productivity, Formatting]
-    category: productivity
-    related_skills: []
+  tags: ADHD, Output Style, Productivity, Formatting
+  category: productivity
 ---
 
 # i-have-adhd

--- a/skills/i-have-adhd/SKILL.md
+++ b/skills/i-have-adhd/SKILL.md
@@ -4,8 +4,8 @@ description: 'Shape output for a reader with ADHD: lead with the next action, nu
 disable-model-invocation: true
 license: MIT
 metadata:
-  tags: ADHD, Output Style, Productivity, Formatting
-  category: productivity
+  tags: "ADHD, Output Style, Productivity, Formatting"
+  category: "productivity"
 ---
 
 # i-have-adhd


### PR DESCRIPTION
Flatten optional metadata values so Agent Skills clients expecting string-to-string mappings can discover the skill without frontmatter parse errors.