### PR TITLE
fix(hooks): run SessionStart correctly in Codex

### DIFF
--- a/hooks/always-on.mjs
+++ b/hooks/always-on.mjs
@@ -2,9 +2,9 @@
 // opted in by creating $CLAUDE_CONFIG_DIR/.i-have-adhd-always (default ~/.claude).
 // Never blocks session start: any failure exits 0.
 //
-// Runs under Node so it works on macOS, Linux, and Windows without depending on
-// a POSIX shell (`sh`) being on PATH. The hook uses exec form, so Claude Code
-// passes the script path directly without PowerShell or POSIX-shell parsing.
+// Runs under Node so it works on macOS, Linux, and Windows. The shared Claude
+// Code/Codex hook launches this module from the plugin-root environment rather
+// than relying on platform-specific shell expansion for the script path.
 // Native sh and PowerShell implementations remain available as fallbacks.
 
 import fs from "node:fs";

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,8 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/always-on.mjs"],
+            "command": "node -e \"const root=process.env.CLAUDE_PLUGIN_ROOT||process.env.PLUGIN_ROOT;if(root)import(require('node:url').pathToFileURL(require('node:path').join(root,'hooks','always-on.mjs')).href)\"",
             "timeout": 5,
             "statusMessage": "Checking i-have-adhd always-on flag..."
           }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"const root=process.env.CLAUDE_PLUGIN_ROOT||process.env.PLUGIN_ROOT;if(root)import(require('node:url').pathToFileURL(require('node:path').join(root,'hooks','always-on.mjs')).href)\"",
+            "command": "node -e \"(async()=>{const root=process.env.CLAUDE_PLUGIN_ROOT||process.env.PLUGIN_ROOT;if(root)await import(require('node:url').pathToFileURL(require('node:path').join(root,'hooks','always-on.mjs')).href)})().catch(()=>{})\"",
             "timeout": 5,
             "statusMessage": "Checking i-have-adhd always-on flag..."
           }

--- a/tests/test_always_on_hooks.py
+++ b/tests/test_always_on_hooks.py
@@ -53,13 +53,14 @@ class AlwaysOnHookTest(unittest.TestCase):
             env=env,
         )
 
-    def run_codex_hook(self):
+    def run_codex_hook(self, plugin_root=None):
         config = json.loads((ROOT / "hooks" / "hooks.json").read_text())
         hook = config["hooks"]["SessionStart"][0]["hooks"][0]
         env = os.environ.copy()
         env["CLAUDE_CONFIG_DIR"] = str(self.config_dir)
-        env["CLAUDE_PLUGIN_ROOT"] = str(self.plugin_root)
-        env["PLUGIN_ROOT"] = str(self.plugin_root)
+        plugin_root = plugin_root or self.plugin_root
+        env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
+        env["PLUGIN_ROOT"] = str(plugin_root)
         return subprocess.run(
             hook["command"],
             check=False,
@@ -148,14 +149,24 @@ class AlwaysOnHookTest(unittest.TestCase):
         self.assertEqual("", result.stderr)
         self.assertEqual("", result.stdout)
 
+    def test_codex_command_swallows_missing_plugin_errors(self):
+        result = self.run_codex_hook(self.plugin_root / "missing plugin")
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("", result.stderr)
+        self.assertEqual("", result.stdout)
+
     def test_hook_uses_a_shared_claude_and_codex_launcher(self):
         config = json.loads((ROOT / "hooks" / "hooks.json").read_text())
         hook = config["hooks"]["SessionStart"][0]["hooks"][0]
 
         self.assertNotIn("args", hook)
-        self.assertTrue(hook["command"].startswith('node -e "'))
-        self.assertIn("process.env.CLAUDE_PLUGIN_ROOT", hook["command"])
-        self.assertIn("process.env.PLUGIN_ROOT", hook["command"])
+        command = hook["command"]
+        self.assertRegex(command, r'^node(?: --input-type=module)? -e "')
+        self.assertIn("process.env.CLAUDE_PLUGIN_ROOT", command)
+        self.assertIn("process.env.PLUGIN_ROOT", command)
+        self.assertIn("await import", command)
+        self.assertIn(".catch", command)
 
 
 if __name__ == "__main__":

--- a/tests/test_always_on_hooks.py
+++ b/tests/test_always_on_hooks.py
@@ -14,7 +14,7 @@ class AlwaysOnHookTest(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(self.temp_dir.cleanup)
-        self.plugin_root = Path(self.temp_dir.name) / "plugin"
+        self.plugin_root = Path(self.temp_dir.name) / "plugin with spaces"
         shutil.copytree(ROOT / "hooks", self.plugin_root / "hooks")
         shutil.copytree(ROOT / "skills", self.plugin_root / "skills")
         self.config_dir = Path(self.temp_dir.name) / "claude config"
@@ -51,6 +51,30 @@ class AlwaysOnHookTest(unittest.TestCase):
             capture_output=True,
             text=True,
             env=env,
+        )
+
+    def run_codex_hook(self):
+        config = json.loads((ROOT / "hooks" / "hooks.json").read_text())
+        hook = config["hooks"]["SessionStart"][0]["hooks"][0]
+        env = os.environ.copy()
+        env["CLAUDE_CONFIG_DIR"] = str(self.config_dir)
+        env["CLAUDE_PLUGIN_ROOT"] = str(self.plugin_root)
+        env["PLUGIN_ROOT"] = str(self.plugin_root)
+        return subprocess.run(
+            hook["command"],
+            check=False,
+            capture_output=True,
+            env=env,
+            input=json.dumps(
+                {
+                    "session_id": "test-session",
+                    "cwd": str(self.plugin_root),
+                    "hook_event_name": "SessionStart",
+                    "source": "startup",
+                }
+            ),
+            shell=True,
+            text=True,
         )
 
     @staticmethod
@@ -108,15 +132,30 @@ class AlwaysOnHookTest(unittest.TestCase):
 
         self.assertEqual(1, len(set(outputs.values())))
 
-    def test_hook_uses_shell_free_node_exec_form(self):
+    def test_codex_command_runs_the_hook_instead_of_parsing_session_json(self):
+        (self.config_dir / ".i-have-adhd-always").touch()
+
+        result = self.run_codex_hook()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("", result.stderr)
+        self.assertIn("ADHD MODE ACTIVE (always-on)", result.stdout)
+
+    def test_codex_command_is_silent_without_opt_in_flag(self):
+        result = self.run_codex_hook()
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("", result.stderr)
+        self.assertEqual("", result.stdout)
+
+    def test_hook_uses_a_shared_claude_and_codex_launcher(self):
         config = json.loads((ROOT / "hooks" / "hooks.json").read_text())
         hook = config["hooks"]["SessionStart"][0]["hooks"][0]
 
-        self.assertEqual("node", hook["command"])
-        self.assertEqual(
-            ["${CLAUDE_PLUGIN_ROOT}/hooks/always-on.mjs"],
-            hook["args"],
-        )
+        self.assertNotIn("args", hook)
+        self.assertTrue(hook["command"].startswith('node -e "'))
+        self.assertIn("process.env.CLAUDE_PLUGIN_ROOT", hook["command"])
+        self.assertIn("process.env.PLUGIN_ROOT", hook["command"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Codex command hooks use the `command` field and pass the hook payload as JSON on stdin. The current hook stores the script path in `args`, so Codex launches bare `node`. Node then parses the `SessionStart` JSON as JavaScript and exits with code 1:

```text
SyntaxError: Unexpected token ':'
```

This produces `SessionStart hook (failed)` on every Codex session start, even when the always-on flag is absent.

## Fix

- Launch the module through one `node -e` command understood by both Codex and Claude Code.
- Resolve the installed plugin path inside Node from `CLAUDE_PLUGIN_ROOT` or `PLUGIN_ROOT`, avoiding platform-specific shell variable syntax.
- Preserve the existing opt-in behavior and the native shell/PowerShell fallbacks.

Codex documents plugin-root environment variables and a single command string for command hooks: https://learn.chatgpt.com/codex/hooks

## Validation

- Added a regression test that sends a real-shaped `SessionStart` JSON object on stdin.
- Covered both flag-present and flag-absent behavior with a plugin path containing spaces.
- `python3 -m unittest discover -s tests -v`: 15 tests pass.
- `claude plugin validate .`: validation passed.
