### PR TITLE
docs: clarify task list overflow handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ A skill for your coding assistant that stops it from burying the answer. Action 
 6. Specific time estimates (minutes, not "a bit").
 7. Make wins visible.
 8. Matter-of-fact errors.
-9. Cap lists at 5 items.
+9. Cap task lists at 5 items; retain relevant items in reserve.
 10. No preamble. No recap. No closers.
 
 ## Tune it

--- a/skills/i-have-adhd/SKILL.md
+++ b/skills/i-have-adhd/SKILL.md
@@ -100,9 +100,9 @@ Never use "Uh oh," "Oh no," or "There seems to be a problem." State cause and fi
 Bad: "Uh oh, the test is failing. There seems to be an issue..."
 Good: "Test fails at `auth.spec.ts:42`: expected 200, got 401. Cause: missing auth header. Fix: add `Authorization: Bearer ${token}` to the request."
 
-### 9. Cap lists at 5 items
+### 9. Cap task lists at 5
 
-If a list grows past five, split into "do now" vs "later," or "must" vs "nice to have." Five items ranked beats ten unranked.
+For task lists, show up to five items most relevant to the current request. Retain other relevant items in reserve instead of discarding them, and surface reserved items as context changes. If the reader requests an exhaustive list, show all items grouped for readability.
 
 ### 10. No preamble, no recap, no closing pleasantries
 


### PR DESCRIPTION
﻿## Summary
- clarify that the five-item cap applies to task lists
- retain relevant overflow items in reserve instead of discarding them
- describe how to surface the reserve and handle exhaustive-list requests

## Validation
- `python -m pytest -q` (12 passed; 1 existing Windows shell-runner failure because `sh` is unavailable)
- `git diff --check`

Fixes #96
