### PR TITLE
Add OpenCode support (server plugin + command + always-on)

### DIFF
--- a/.opencode/command/i-have-adhd.md
+++ b/.opencode/command/i-have-adhd.md
@@ -1,0 +1,8 @@
+---
+description: Shape output for a reader with ADHD for the rest of this session
+---
+
+Use the `i-have-adhd` skill and apply its ruleset to every response for the
+rest of this session: lead with the next action, number multi-step work,
+restate state across turns, suppress tangents, give concrete time estimates,
+and make wins visible. These rules persist until I say "stop adhd mode".

--- a/.opencode/command/i-have-adhd.md
+++ b/.opencode/command/i-have-adhd.md
@@ -5,4 +5,4 @@ description: Shape output for a reader with ADHD for the rest of this session
 Use the `i-have-adhd` skill and apply its ruleset to every response for the
 rest of this session: lead with the next action, number multi-step work,
 restate state across turns, suppress tangents, give concrete time estimates,
-and make wins visible. These rules persist until I say "stop adhd mode".
+and make wins visible. These rules persist until I say "stop adhd mode" or "normal mode".

--- a/.opencode/plugins/i-have-adhd.mjs
+++ b/.opencode/plugins/i-have-adhd.mjs
@@ -33,9 +33,13 @@ const flagPath = path.join(
 );
 
 // Read SKILL.md and strip a leading YAML frontmatter block (--- ... ---).
+// Regex and trailing-newline trim match hooks/always-on.mjs so always-on
+// injections behave identically across harnesses (see tests/test_always_on_hooks.py).
 function rulesetBody() {
-  const raw = fs.readFileSync(skillPath, 'utf8');
-  return raw.replace(/^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n/, '').trim();
+  return fs
+    .readFileSync(skillPath, 'utf8')
+    .replace(/^---[^\S\r\n]*\r?\n[\s\S]*?\r?\n---[^\S\r\n]*(?:\r?\n|$)/, '')
+    .replace(/(?:\r?\n)+$/, '');
 }
 
 export default async () => {
@@ -62,8 +66,8 @@ export default async () => {
 
       const header =
         'ADHD MODE ACTIVE (always-on). The ruleset below applies to every ' +
-        'response. "stop adhd mode" turns it off for this session; delete ' +
-        flagPath + ' to turn always-on off for good.';
+        'response. "stop adhd mode" or "normal mode" turns it off for this ' +
+        'session; delete ' + flagPath + ' to turn always-on off for good.';
       const injected = header + '\n\n' + body;
 
       if (output.system.length > 0) {

--- a/.opencode/plugins/i-have-adhd.mjs
+++ b/.opencode/plugins/i-have-adhd.mjs
@@ -1,0 +1,76 @@
+// i-have-adhd — OpenCode plugin.
+//
+// Mirrors the Claude Code / Codex behaviour for OpenCode: the skill in
+// `skills/i-have-adhd/SKILL.md` is the single source of truth for the ruleset.
+//
+//   • On demand   — registers the skills directory and a `/i-have-adhd`
+//                   command so the ruleset applies for the rest of the session.
+//   • Always-on   — when the opt-in flag file exists, the full ruleset is
+//                   appended to the system prompt every turn (the OpenCode
+//                   equivalent of the SessionStart hook in hooks/always-on.sh).
+//
+// Opt in to always-on:   touch ~/.config/opencode/.i-have-adhd-always
+// Opt back out:          rm ~/.config/opencode/.i-have-adhd-always
+//
+// Install — add to opencode.json:
+//   { "plugin": ["./.opencode/plugins/i-have-adhd.mjs"] }
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const skillsDir = path.resolve(__dirname, '../../skills');
+const skillPath = path.join(skillsDir, 'i-have-adhd', 'SKILL.md');
+
+// Always-on opt-in flag, mirroring Claude Code's ~/.claude/.i-have-adhd-always
+// but under OpenCode's config dir so the two tools stay independent.
+const flagPath = path.join(
+  process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'),
+  'opencode',
+  '.i-have-adhd-always',
+);
+
+// Read SKILL.md and strip a leading YAML frontmatter block (--- ... ---).
+function rulesetBody() {
+  const raw = fs.readFileSync(skillPath, 'utf8');
+  return raw.replace(/^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n/, '').trim();
+}
+
+export default async () => {
+  return {
+    // Make the skill discoverable (so the `skill` tool and the /i-have-adhd
+    // command can load it).
+    config: async (config) => {
+      config.skills = config.skills || {};
+      config.skills.paths = config.skills.paths || [];
+      if (!config.skills.paths.includes(skillsDir)) config.skills.paths.push(skillsDir);
+    },
+
+    // Always-on: append the ruleset to the system prompt every turn while the
+    // flag file exists. "stop adhd mode" turns it off for the session (the
+    // model honours the skill's own Persistence rules); deleting the flag
+    // turns always-on off for good.
+    'experimental.chat.system.transform': async (_input, output) => {
+      let on = false;
+      try { on = fs.existsSync(flagPath); } catch (e) {}
+      if (!on) return;
+
+      let body;
+      try { body = rulesetBody(); } catch (e) { return; }
+
+      const header =
+        'ADHD MODE ACTIVE (always-on). The ruleset below applies to every ' +
+        'response. "stop adhd mode" turns it off for this session; delete ' +
+        flagPath + ' to turn always-on off for good.';
+      const injected = header + '\n\n' + body;
+
+      if (output.system.length > 0) {
+        output.system[output.system.length - 1] += '\n\n' + injected;
+      } else {
+        output.system.push(injected);
+      }
+    },
+  };
+};

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -405,7 +405,7 @@ Start a new session and turn on ADHD-friendly output for the session:
 /i-have-adhd
 ```
 
-Rules stay on until `stop adhd mode`.
+Rules stay on until `stop adhd mode` or `normal mode`.
 
 ### Verify
 
@@ -427,7 +427,7 @@ Remove the `plugin` entry from `opencode.json`.
 touch ~/.config/opencode/.i-have-adhd-always
 ```
 
-While the flag exists, the plugin appends the full ruleset to the system prompt every turn — the OpenCode equivalent of the Claude Code `SessionStart` hook. `stop adhd mode` disables it for the current session; delete the flag to turn always-on off for good:
+While the flag exists, the plugin appends the full ruleset to the system prompt every turn — the OpenCode equivalent of the Claude Code `SessionStart` hook. `stop adhd mode` or `normal mode` disables it for the current session; delete the flag to turn always-on off for good:
 
 ```bash
 rm ~/.config/opencode/.i-have-adhd-always

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -379,6 +379,64 @@ Use slash command `/skill:i-have-adhd` to invoke the skill explicitly.
 </details>
 
 <details>
+<summary><strong>OpenCode</strong></summary>
+
+OpenCode loads this repository as a server plugin: `.opencode/plugins/i-have-adhd.mjs` registers the `skills/` entry point and the `/i-have-adhd` command, and injects the ruleset when always-on is enabled. OpenCode also reads `skills/` natively, so the skill still works even without the plugin — the plugin adds the `/i-have-adhd` command and the always-on flag.
+
+### Install
+
+Clone the repo and point OpenCode at the plugin. An absolute path shares one checkout across every project:
+
+```bash
+git clone https://github.com/ayghri/i-have-adhd ~/.config/opencode/vendor/i-have-adhd
+```
+
+Add to your `opencode.json` (global: `~/.config/opencode/opencode.json`):
+
+```json
+{ "plugin": ["/absolute/path/to/i-have-adhd/.opencode/plugins/i-have-adhd.mjs"] }
+```
+
+Or run OpenCode from the checkout — it ships a root `opencode.json` with the plugin already wired up.
+
+Start a new session and turn on ADHD-friendly output for the session:
+
+```text
+/i-have-adhd
+```
+
+Rules stay on until `stop adhd mode`.
+
+### Verify
+
+Start OpenCode, type `/`, and confirm `i-have-adhd` appears in the command list.
+
+### Update
+
+```bash
+git -C ~/.config/opencode/vendor/i-have-adhd pull
+```
+
+### Uninstall
+
+Remove the `plugin` entry from `opencode.json`.
+
+### Always-on (optional)
+
+```bash
+touch ~/.config/opencode/.i-have-adhd-always
+```
+
+While the flag exists, the plugin appends the full ruleset to the system prompt every turn — the OpenCode equivalent of the Claude Code `SessionStart` hook. `stop adhd mode` disables it for the current session; delete the flag to turn always-on off for good:
+
+```bash
+rm ~/.config/opencode/.i-have-adhd-always
+```
+
+</details>
+
+
+<details>
 <summary><strong>Pi</strong></summary>
 
 Pi discovers this repository as a native package: `extensions/` provides the session-persistent mode and `skills/` keeps the Agent Skills entry point available.
@@ -563,7 +621,7 @@ Exceptions: explain fully when asked to explain. Confirm before destructive acti
 </details>
 
 <details>
-<summary><strong>Cursor, OpenCode, Amp, and any other agent-skills harness</strong></summary>
+<summary><strong>Cursor, Amp, and any other agent-skills harness</strong></summary>
 
 Works with any harness that reads agent skills. Swap `-a <agent>` for yours.
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["./.opencode/plugins/i-have-adhd.mjs"]
+}

--- a/tests/opencode_plugin_driver.mjs
+++ b/tests/opencode_plugin_driver.mjs
@@ -1,0 +1,10 @@
+// Test driver for the OpenCode plugin. Imports the plugin at argv[2], runs its
+// `experimental.chat.system.transform` hook against an empty system prompt, and
+// prints the resulting system text so tests can assert on the injected banner.
+// Nothing is printed when the hook injects nothing (always-on flag absent).
+const pluginPath = process.argv[2];
+const { default: init } = await import(pluginPath);
+const hooks = await init();
+const output = { system: [] };
+await hooks['experimental.chat.system.transform']({}, output);
+process.stdout.write(output.system.join('\n---SEP---\n'));

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -1,0 +1,70 @@
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@unittest.skipUnless(shutil.which("node"), "node is required for the OpenCode plugin")
+class OpenCodePluginTest(unittest.TestCase):
+    """Mirror tests/test_always_on_hooks.py for the OpenCode server plugin: the
+    always-on flag gates injection, and frontmatter stripping matches the hooks."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.plugin_root = Path(self.temp_dir.name) / "plugin"
+        shutil.copytree(ROOT / ".opencode", self.plugin_root / ".opencode")
+        shutil.copytree(ROOT / "skills", self.plugin_root / "skills")
+        # The plugin reads its flag from $XDG_CONFIG_HOME/opencode/.i-have-adhd-always.
+        self.config_dir = Path(self.temp_dir.name) / "config"
+        (self.config_dir / "opencode").mkdir(parents=True)
+
+    def run_plugin(self):
+        env = os.environ.copy()
+        env["XDG_CONFIG_HOME"] = str(self.config_dir)
+        return subprocess.run(
+            [
+                "node",
+                str(ROOT / "tests" / "opencode_plugin_driver.mjs"),
+                str(self.plugin_root / ".opencode" / "plugins" / "i-have-adhd.mjs"),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def opt_in(self):
+        (self.config_dir / "opencode" / ".i-have-adhd-always").touch()
+
+    def write_skill(self, text):
+        (self.plugin_root / "skills" / "i-have-adhd" / "SKILL.md").write_text(text)
+
+    def test_silent_without_opt_in_flag(self):
+        result = self.run_plugin()
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("", result.stdout)
+
+    def test_strips_frontmatter_with_trailing_whitespace(self):
+        self.write_skill("---   \nname: fixture\n--- \t\nFixture body.\n")
+        self.opt_in()
+        result = self.run_plugin()
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertNotIn("name: fixture", result.stdout)
+        self.assertIn("\n\nFixture body.", result.stdout)
+
+    def test_keeps_content_when_frontmatter_is_unclosed(self):
+        self.write_skill("---\nname: fixture\nFixture body, fence never closed.\n")
+        self.opt_in()
+        result = self.run_plugin()
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("Fixture body, fence never closed.", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
OpenCode was previously covered only by the generic "any agent-skills harness" fallback — skill discovery worked, but there was no `/i-have-adhd` command and no always-on. This promotes OpenCode to a first-class adapter, matching the Codex/Pi layout.

## What's added
- **`.opencode/plugins/i-have-adhd.mjs`** — server plugin. Registers the `skills/` path and the `/i-have-adhd` command, and appends the ruleset to the system prompt every turn while `~/.config/opencode/.i-have-adhd-always` exists (the OpenCode equivalent of the Claude Code `SessionStart` always-on hook). Uses OpenCode's `experimental.chat.system.transform` hook.
- **`.opencode/command/i-have-adhd.md`** — on-demand session command.
- **`opencode.json`** — root entry point so OpenCode can run straight from a checkout.
- **`INSTALL.md`** — dedicated **OpenCode** `<details>` section (Install / Verify / Update / Uninstall / Always-on); removed OpenCode from the catch-all section title since it now has its own.

## Design notes
- **Single source of truth kept.** The ruleset is read from `skills/i-have-adhd/SKILL.md` at inject time with the YAML frontmatter stripped — no rule text duplicated, consistent with how the Claude/Codex hooks reuse the skill.
- **Always-on flag** lives under OpenCode's config dir (`~/.config/opencode/.i-have-adhd-always`) so the two tools stay independent, mirroring the `~/.claude/.i-have-adhd-always` convention.
- **`stop adhd mode`** still turns it off per-session via the skill's own Persistence rules.

## Testing
- Plugin loads under Node and exposes the expected hooks (`config`, `experimental.chat.system.transform`).
- Frontmatter-strip verified against the current `SKILL.md`.
- `opencode.json` validates against the schema.
