### PR TITLE
Fix Codex plugin installation and SessionStart hook execution

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -7,9 +7,8 @@
     {
       "name": "i-have-adhd",
       "source": {
-        "source": "url",
-        "url": "https://github.com/ayghri/i-have-adhd.git",
-        "ref": "main"
+        "source": "local",
+        "path": "."
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,8 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/always-on.mjs"],
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/always-on.mjs\"",
             "timeout": 5,
             "statusMessage": "Checking i-have-adhd always-on flag..."
           }

--- a/tests/test_always_on_hooks.py
+++ b/tests/test_always_on_hooks.py
@@ -108,15 +108,15 @@ class AlwaysOnHookTest(unittest.TestCase):
 
         self.assertEqual(1, len(set(outputs.values())))
 
-    def test_hook_uses_shell_free_node_exec_form(self):
+    def test_hook_invokes_node_with_the_script_path(self):
         config = json.loads((ROOT / "hooks" / "hooks.json").read_text())
         hook = config["hooks"]["SessionStart"][0]["hooks"][0]
 
-        self.assertEqual("node", hook["command"])
         self.assertEqual(
-            ["${CLAUDE_PLUGIN_ROOT}/hooks/always-on.mjs"],
-            hook["args"],
+            'node "${CLAUDE_PLUGIN_ROOT}/hooks/always-on.mjs"',
+            hook["command"],
         )
+        self.assertNotIn("args", hook)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Problem

  The Codex marketplace entry re-cloned the plugin from `ayghri/
  i-have-adhd@main` instead of using the marketplace snapshot.
  This can load a manifest inconsistent with the selected
  marketplace revision.

  Also, the `SessionStart` hook used Claude's `command` + `args`
  form. Codex only executes the `command` string, so it ran bare
  `node`, which attempted to parse the hook JSON stdin as
  JavaScript and exited with code 1.

  ### Changes

  - Load `i-have-adhd` directly from the installed marketplace
  snapshot.
  - Pass the Node hook script as part of the Codex `command`
  string:
 [1:codex]                                                 08:44     "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/always-
    on.mjs\""

  - Update the hook manifest test to assert the cross-compatible
    command format.

  ### Verification

  ```
python3 -m unittest tests/test_always_on_hooks.py tests/
  test_run_evals.py
  Ran 13 tests
  OK
```

  Also verified in an isolated Codex home:

  ```
codex plugin marketplace add .
  codex plugin add i-have-adhd@i-have-adhd

```
  The plugin installs successfully and the SessionStart command
  exits 0.