### PR TITLE
Harden the ruleset sync pipeline: one source of truth, CI-verified parity

### DIFF
--- a/.github/install/INSTALL.ja.md
+++ b/.github/install/INSTALL.ja.md
@@ -379,76 +379,81 @@ Kimi Code セッションで `/plugins` を実行し、**I Have ADHD** にカー
 <details>
 <summary><strong>Pi</strong></summary>
 
-Pi は Agent Skills 標準を実装しているため、同じ `SKILL.md` を変換なしで直接読み込めます。呼び出し方法は他と異なり、スキルは `/skill:<name>` で呼び出します。
+Pi はこのリポジトリをネイティブパッケージとして検出します。`extensions/` がセッション永続モードを提供し、`skills/` が Agent Skills のエントリーポイントを提供します。
 
 ### インストール
 
 ```bash
-npx skills add ayghri/i-have-adhd -a pi -y
+pi install https://github.com/ayghri/i-have-adhd
 ```
 
-ファイルシステムを使う場合、Pi は `~/.pi/agent/skills/` と `~/.agents/skills/`（グローバル）、`.pi/skills/` と `.agents/skills/`（プロジェクト）からスキルを検出します：
+新しい Pi セッションを開始します。現在のセッションで ADHD 向け出力を切り替えます：
+
+```text
+/i-have-adhd
+```
+
+モードが有効な間、フッターに `● ADHD ON` と表示されます。もう一度コマンドを実行するとオフになります。明示的に指定することもできます：
+
+```text
+/i-have-adhd on
+/i-have-adhd off
+stop adhd mode
+```
+
+Claude Code のフックと同様、この拡張はルールセットをリクエストごとにシステムプロンプトへ書き込む代わりに、会話に一度だけ追加し、コンパクションでルールセットが失われた後も再度追加します。
+
+既存の Agent Skills コマンドはエイリアスとして引き続き使えます：
+
+```text
+/skill:i-have-adhd
+```
+
+デフォルトでモードを有効にした状態で新しい Pi セッションを開始します：
 
 ```bash
-git clone https://github.com/ayghri/i-have-adhd
-mkdir -p ~/.pi/agent/skills
-cp -R i-have-adhd/skills/i-have-adhd ~/.pi/agent/skills/
+pi --adhd
 ```
-
-Pi の `settings.json` でスキルのスラッシュコマンドを有効にします：
-
-```json
-{ "enableSkillCommands": true }
-```
-
-新しいセッションを開始して `/skill:i-have-adhd` と入力します。
 
 ### 確認
 
 ```bash
-npx skills list
+pi list
 ```
 
-または、セッションで `/skill:` と入力し、`i-have-adhd` が一覧にあることを確認します。
+GitHub パッケージが一覧にあることを確認し、`/i-have-adhd` と入力してフッターに `● ADHD ON` が表示されることを確認します。
 
 ### 更新
 
 ```bash
-npx skills update i-have-adhd
+pi update https://github.com/ayghri/i-have-adhd
 ```
 
-または、`git pull` の後にフォルダーを再度コピーします。
+または、`pi update --extensions` で固定されていないすべての Pi パッケージを更新します。
 
 ### アンインストール
 
 ```bash
-npx skills remove i-have-adhd
+pi remove https://github.com/ayghri/i-have-adhd
 ```
-
-または、`~/.pi/agent/skills/i-have-adhd` を削除します。
 
 ### 常時有効（任意）
 
-プロジェクトの `AGENTS.md` に追加します：
+Pi のエージェント設定ディレクトリにフラグファイルを作成します：
 
-```markdown
-## 出力スタイル
-
-読み手には ADHD があります。すぐ行動に移せるよう、すべての回答を次のように構成してください：
-
-1. 回答または次の行動から始める。コマンド、パス、スニペットを先に示す。
-2. 複数手順の作業には番号を付け、1 ステップにつき 1 つの明確な行動にする。
-3. 2 分以内にできる次の行動を 1 つ示して終える。
-4. 新しい問題を挙げる前に、現在の問題を終わらせる。
-5. 各ターンで進捗を言い直す（「5 ステップ中 3 ステップ完了」）。
-6. 所要時間は具体的な単位で示し、「少し」とは言わない。
-7. 変更後は、何が動くようになったかを示す。
-8. エラーは場所、原因、修正方法を淡々と示す。
-9. リストは最大 5 項目にする。
-10. 前置き、要約、締めの言葉を入れない。
-
-例外：説明を求められた場合は十分に説明する。破壊的な操作の前には確認する。修正に 3 回失敗したら止まり、疑わしい前提を明示する。依頼が曖昧なら短い質問を 1 つする。
+```bash
+touch ~/.pi/agent/.i-have-adhd-always
 ```
+
+この拡張は、新規・再開・フォーク・再読み込みのいずれのセッションでもこのフラグを確認します。現在のセッションで保存された選択はこのデフォルトより優先されるため、「stop adhd mode」を実行すればそのセッションでは無効のままになります。
+
+オンデマンドに戻す場合：
+
+```bash
+rm ~/.pi/agent/.i-have-adhd-always
+```
+
+`PI_CODING_AGENT_DIR` が設定されている場合は、代わりにそのディレクトリに `.i-have-adhd-always` を置いてください。フラグを変更した後は `/reload` を実行するか、新しいセッションを開始してください。
 
 </details>
 

--- a/.github/install/INSTALL.ko.md
+++ b/.github/install/INSTALL.ko.md
@@ -379,76 +379,81 @@ Kimi Code 세션에서 `/plugins`를 실행하고 **I Have ADHD**에 커서를 �
 <details>
 <summary><strong>Pi</strong></summary>
 
-Pi는 Agent Skills 표준을 구현하므로 같은 `SKILL.md`를 변환 없이 직접 불러옵니다. 호출 방식은 다른 도구와 달리 `/skill:<name>` 형식입니다.
+Pi는 이 저장소를 네이티브 패키지로 인식합니다. `extensions/`가 세션 지속 모드를 제공하고, `skills/`가 Agent Skills 진입점을 계속 제공합니다.
 
 ### 설치
 
 ```bash
-npx skills add ayghri/i-have-adhd -a pi -y
+pi install https://github.com/ayghri/i-have-adhd
 ```
 
-파일 시스템 방식을 선호한다면 Pi는 `~/.pi/agent/skills/`와 `~/.agents/skills/`(전역), `.pi/skills/`와 `.agents/skills/`(프로젝트)에서 스킬을 찾습니다:
+새 Pi 세션을 시작하세요. 현재 세션에서 ADHD 친화적 출력을 켜고 끕니다:
+
+```text
+/i-have-adhd
+```
+
+모드가 활성화된 동안 하단에 `● ADHD ON`이 표시됩니다. 명령을 다시 실행하면 꺼지며, 명시적으로 지정할 수도 있습니다:
+
+```text
+/i-have-adhd on
+/i-have-adhd off
+stop adhd mode
+```
+
+Claude Code 훅과 마찬가지로, 이 확장은 매 요청마다 시스템 프롬프트를 다시 쓰는 대신 대화에 규칙을 한 번만 추가하고, 컴팩션으로 규칙이 사라지면 다시 추가합니다.
+
+기존 Agent Skills 명령도 별칭으로 계속 사용할 수 있습니다:
+
+```text
+/skill:i-have-adhd
+```
+
+기본적으로 모드가 켜진 상태로 새 Pi 세션을 시작합니다:
 
 ```bash
-git clone https://github.com/ayghri/i-have-adhd
-mkdir -p ~/.pi/agent/skills
-cp -R i-have-adhd/skills/i-have-adhd ~/.pi/agent/skills/
+pi --adhd
 ```
-
-Pi의 `settings.json`에서 스킬 슬래시 명령을 활성화하세요:
-
-```json
-{ "enableSkillCommands": true }
-```
-
-새 세션을 시작하고 `/skill:i-have-adhd`를 입력하세요.
 
 ### 확인
 
 ```bash
-npx skills list
+pi list
 ```
 
-또는 세션에서 `/skill:`을 입력하고 `i-have-adhd`가 목록에 있는지 확인하세요.
+GitHub 패키지가 목록에 있는지 확인한 다음 `/i-have-adhd`를 입력하고 하단에 `● ADHD ON`이 표시되는지 확인하세요.
 
 ### 업데이트
 
 ```bash
-npx skills update i-have-adhd
+pi update https://github.com/ayghri/i-have-adhd
 ```
 
-또는 `git pull` 후 폴더를 다시 복사하세요.
+또는 `pi update --extensions`로 버전 고정이 없는 모든 Pi 패키지를 업데이트하세요.
 
 ### 제거
 
 ```bash
-npx skills remove i-have-adhd
+pi remove https://github.com/ayghri/i-have-adhd
 ```
-
-또는 `~/.pi/agent/skills/i-have-adhd`를 삭제하세요.
 
 ### 항상 활성화(선택 사항)
 
-프로젝트의 `AGENTS.md`에 추가하세요:
+Pi의 에이전트 설정 디렉터리에 플래그 파일을 만드세요:
 
-```markdown
-## 출력 스타일
-
-읽는 사람은 ADHD가 있습니다. 모든 답변을 바로 실행할 수 있도록 구성하세요:
-
-1. 답이나 다음 행동부터 제시하세요. 명령어, 경로 또는 코드 조각을 먼저 보여 주세요.
-2. 여러 단계의 작업에는 번호를 붙이고, 단계마다 범위가 명확한 행동 하나만 두세요.
-3. 2분 안에 할 수 있는 다음 행동 하나로 끝내세요.
-4. 새 문제를 꺼내기 전에 현재 문제를 마무리하세요.
-5. 매 턴마다 진행 상황을 다시 알려 주세요("5단계 중 3단계 완료").
-6. 시간은 구체적인 단위로 예상하고 "조금"이라고 하지 마세요.
-7. 변경 후에는 이제 무엇이 작동하는지 보여 주세요.
-8. 오류는 위치, 원인, 해결 방법을 담담하게 알려 주세요.
-9. 목록은 최대 5개 항목으로 제한하세요.
-10. 서론, 요약, 마무리 인사를 넣지 마세요.
-
-예외: 설명을 요청받으면 충분히 설명하세요. 파괴적인 작업 전에는 확인하세요. 세 번의 수정이 실패하면 멈추고 의심되는 가정을 밝히세요. 요청이 모호하면 짧은 질문 하나를 하세요.
+```bash
+touch ~/.pi/agent/.i-have-adhd-always
 ```
+
+이 확장은 새로 시작, 재개, 포크, 다시 불러온 모든 세션에서 이 플래그를 확인합니다. 현재 세션에서 저장된 선택은 이 기본값보다 우선하므로, "stop adhd mode"를 실행하면 해당 세션에서는 계속 비활성화됩니다.
+
+필요할 때만 켜는 방식으로 돌아가려면:
+
+```bash
+rm ~/.pi/agent/.i-have-adhd-always
+```
+
+`PI_CODING_AGENT_DIR`가 설정되어 있다면 `.i-have-adhd-always`를 그 디렉터리에 대신 두세요. 플래그를 변경한 후에는 `/reload`를 실행하거나 새 세션을 시작하세요.
 
 </details>
 

--- a/.github/install/INSTALL.pt-BR.md
+++ b/.github/install/INSTALL.pt-BR.md
@@ -379,76 +379,81 @@ Em uma sessão do Kimi Code, execute `/plugins`, posicione o cursor em **I Have 
 <details>
 <summary><strong>Pi</strong></summary>
 
-O Pi implementa o padrão Agent Skills, portanto o mesmo `SKILL.md` é carregado diretamente, sem conversão. A invocação no Pi é diferente: as skills são chamadas como `/skill:<name>`.
+O Pi identifica este repositório como um pacote nativo: `extensions/` fornece o modo persistente de sessão e `skills/` mantém o ponto de entrada do Agent Skills disponível.
 
 ### Instalar
 
 ```bash
-npx skills add ayghri/i-have-adhd -a pi -y
+pi install https://github.com/ayghri/i-have-adhd
 ```
 
-Prefere usar o sistema de arquivos? O Pi encontra skills em `~/.pi/agent/skills/` e `~/.agents/skills/` (global), e em `.pi/skills/` e `.agents/skills/` (projeto):
+Inicie uma nova sessão do Pi. Ative ou desative a saída amigável para TDAH na sessão atual:
+
+```text
+/i-have-adhd
+```
+
+O rodapé mostra `● ADHD ON` enquanto o modo está ativo. Execute o comando novamente para desativar, ou seja explícito:
+
+```text
+/i-have-adhd on
+/i-have-adhd off
+stop adhd mode
+```
+
+Assim como o hook do Claude Code, a extensão adiciona o conjunto de regras à conversa uma única vez, em vez de reescrever o prompt do sistema a cada solicitação, e o adiciona novamente depois que a compactação o descarta.
+
+O comando Agent Skills existente continua disponível como alias:
+
+```text
+/skill:i-have-adhd
+```
+
+Inicie uma nova sessão do Pi com o modo ativado por padrão:
 
 ```bash
-git clone https://github.com/ayghri/i-have-adhd
-mkdir -p ~/.pi/agent/skills
-cp -R i-have-adhd/skills/i-have-adhd ~/.pi/agent/skills/
+pi --adhd
 ```
-
-Ative os comandos de barra de skills no `settings.json` do Pi:
-
-```json
-{ "enableSkillCommands": true }
-```
-
-Inicie uma nova sessão e digite `/skill:i-have-adhd`.
 
 ### Verificar
 
 ```bash
-npx skills list
+pi list
 ```
 
-Ou digite `/skill:` em uma sessão e confirme que `i-have-adhd` aparece na lista.
+Confirme que o pacote do GitHub aparece na lista, digite `/i-have-adhd` e verifique se `● ADHD ON` aparece no rodapé.
 
 ### Atualizar
 
 ```bash
-npx skills update i-have-adhd
+pi update https://github.com/ayghri/i-have-adhd
 ```
 
-Ou copie a pasta novamente após `git pull`.
+Ou atualize todos os pacotes Pi sem versão fixada com `pi update --extensions`.
 
 ### Desinstalar
 
 ```bash
-npx skills remove i-have-adhd
+pi remove https://github.com/ayghri/i-have-adhd
 ```
-
-Ou exclua `~/.pi/agent/skills/i-have-adhd`.
 
 ### Sempre ativo (opcional)
 
-Adicione ao `AGENTS.md` do projeto:
+Crie um arquivo de sinalização no diretório de configuração do agente do Pi:
 
-```markdown
-## Estilo de resposta
-
-A pessoa que lê tem TDAH. Estruture cada resposta para que ela possa agir:
-
-1. Comece pela resposta ou próxima ação: comando, caminho ou trecho de código primeiro.
-2. Numere trabalhos com várias etapas; uma ação bem delimitada por etapa.
-3. Termine com uma próxima ação que possa ser feita em menos de dois minutos.
-4. Conclua o problema atual antes de levantar outro.
-5. Reafirme o progresso a cada turno ("etapa 3 de 5 concluída").
-6. Dê estimativas de tempo em unidades concretas, nunca "um pouco".
-7. Após uma alteração, mostre o que agora funciona.
-8. Erros: informe local, causa e correção, sem drama.
-9. Limite listas a 5 itens.
-10. Sem preâmbulo, recapitulação ou despedida.
-
-Exceções: explique por completo quando pedirem. Confirme antes de ações destrutivas. Após três tentativas de correção sem sucesso, pare e identifique a suposição duvidosa. Se o pedido for ambíguo, faça uma pergunta curta.
+```bash
+touch ~/.pi/agent/.i-have-adhd-always
 ```
+
+A extensão verifica esse arquivo em toda sessão nova, retomada, bifurcada ou recarregada. Uma escolha salva para a sessão atual tem prioridade sobre esse padrão, então "stop adhd mode" mantém essa sessão desativada.
+
+Para voltar ao modo sob demanda:
+
+```bash
+rm ~/.pi/agent/.i-have-adhd-always
+```
+
+Se `PI_CODING_AGENT_DIR` estiver definida, coloque `.i-have-adhd-always` nesse diretório. Execute `/reload` ou inicie uma nova sessão após alterar o arquivo de sinalização.
 
 </details>
 

--- a/.github/install/INSTALL.vi.md
+++ b/.github/install/INSTALL.vi.md
@@ -379,76 +379,81 @@ Trong phiên Kimi Code, chạy `/plugins`, đưa con trỏ đến **I Have ADHD*
 <details>
 <summary><strong>Pi</strong></summary>
 
-Pi triển khai chuẩn Agent Skills nên tải trực tiếp cùng một `SKILL.md`, không cần chuyển đổi. Cách gọi của Pi khác các công cụ khác: skill được gọi bằng `/skill:<name>`.
+Pi nhận diện repository này như một gói gốc: `extensions/` cung cấp chế độ tồn tại xuyên phiên, còn `skills/` vẫn giữ điểm vào Agent Skills.
 
 ### Cài đặt
 
 ```bash
-npx skills add ayghri/i-have-adhd -a pi -y
+pi install https://github.com/ayghri/i-have-adhd
 ```
 
-Muốn dùng hệ thống tệp? Pi tìm skill trong `~/.pi/agent/skills/` và `~/.agents/skills/` (toàn cục), cùng `.pi/skills/` và `.agents/skills/` (dự án):
+Bắt đầu phiên Pi mới. Bật/tắt đầu ra thân thiện với ADHD cho phiên hiện tại:
+
+```text
+/i-have-adhd
+```
+
+Thanh chân trang hiển thị `● ADHD ON` khi chế độ đang bật. Chạy lại lệnh để tắt, hoặc chỉ định rõ:
+
+```text
+/i-have-adhd on
+/i-have-adhd off
+stop adhd mode
+```
+
+Giống như hook của Claude Code, tiện ích này thêm bộ quy tắc vào cuộc hội thoại một lần thay vì viết lại system prompt ở mỗi yêu cầu, và thêm lại sau khi việc nén (compaction) làm mất nó.
+
+Lệnh Agent Skills hiện có vẫn dùng được như một bí danh:
+
+```text
+/skill:i-have-adhd
+```
+
+Bắt đầu phiên Pi mới với chế độ bật theo mặc định:
 
 ```bash
-git clone https://github.com/ayghri/i-have-adhd
-mkdir -p ~/.pi/agent/skills
-cp -R i-have-adhd/skills/i-have-adhd ~/.pi/agent/skills/
+pi --adhd
 ```
-
-Bật lệnh gạch chéo cho skill trong `settings.json` của Pi:
-
-```json
-{ "enableSkillCommands": true }
-```
-
-Bắt đầu phiên mới và gõ `/skill:i-have-adhd`.
 
 ### Xác minh
 
 ```bash
-npx skills list
+pi list
 ```
 
-Hoặc gõ `/skill:` trong một phiên và xác nhận `i-have-adhd` có trong danh sách.
+Xác nhận gói GitHub có trong danh sách, sau đó gõ `/i-have-adhd` và kiểm tra `● ADHD ON` xuất hiện ở thanh chân trang.
 
 ### Cập nhật
 
 ```bash
-npx skills update i-have-adhd
+pi update https://github.com/ayghri/i-have-adhd
 ```
 
-Hoặc sao chép lại thư mục sau `git pull`.
+Hoặc cập nhật mọi gói Pi chưa ghim phiên bản bằng `pi update --extensions`.
 
 ### Gỡ cài đặt
 
 ```bash
-npx skills remove i-have-adhd
+pi remove https://github.com/ayghri/i-have-adhd
 ```
-
-Hoặc xóa `~/.pi/agent/skills/i-have-adhd`.
 
 ### Luôn bật (không bắt buộc)
 
-Thêm vào `AGENTS.md` của dự án:
+Tạo một tệp cờ trong thư mục cấu hình agent của Pi:
 
-```markdown
-## Phong cách đầu ra
-
-Người đọc có ADHD. Hãy định dạng mọi phản hồi để họ có thể hành động ngay:
-
-1. Bắt đầu bằng câu trả lời hoặc hành động tiếp theo: ưu tiên lệnh, đường dẫn hoặc đoạn mã.
-2. Đánh số công việc nhiều bước; mỗi bước chỉ có một hành động rõ ràng.
-3. Kết thúc bằng một hành động tiếp theo có thể làm trong chưa đến hai phút.
-4. Hoàn tất vấn đề hiện tại trước khi nêu vấn đề mới.
-5. Nhắc lại tiến độ ở mỗi lượt ("đã xong bước 3/5").
-6. Ước tính thời gian bằng đơn vị cụ thể, không nói "một chút".
-7. Sau khi thay đổi, hãy cho biết điều gì hiện đã hoạt động.
-8. Với lỗi, nêu vị trí, nguyên nhân và cách sửa một cách khách quan.
-9. Giới hạn danh sách ở 5 mục.
-10. Không mở đầu, không tóm tắt lại, không lời kết.
-
-Ngoại lệ: giải thích đầy đủ khi được yêu cầu. Xác nhận trước thao tác phá hủy dữ liệu. Sau ba lần sửa thất bại, dừng lại và nêu giả định đáng ngờ. Nếu yêu cầu mơ hồ, hãy hỏi một câu ngắn.
+```bash
+touch ~/.pi/agent/.i-have-adhd-always
 ```
+
+Tiện ích kiểm tra tệp cờ này ở mọi phiên mới, tiếp tục, phân nhánh hoặc tải lại. Lựa chọn đã lưu cho phiên hiện tại được ưu tiên hơn giá trị mặc định này, nên "stop adhd mode" vẫn giữ phiên đó ở trạng thái tắt.
+
+Để trở lại chế độ bật khi cần:
+
+```bash
+rm ~/.pi/agent/.i-have-adhd-always
+```
+
+Nếu đã đặt `PI_CODING_AGENT_DIR`, hãy đặt `.i-have-adhd-always` trong thư mục đó thay thế. Chạy `/reload` hoặc bắt đầu phiên mới sau khi thay đổi tệp cờ.
 
 </details>
 

--- a/.github/install/INSTALL.zh-CN.md
+++ b/.github/install/INSTALL.zh-CN.md
@@ -379,76 +379,81 @@ hermes skills uninstall i-have-adhd
 <details>
 <summary><strong>Pi</strong></summary>
 
-Pi 实现了 Agent Skills 标准，因此可直接加载同一个 `SKILL.md`，无需转换。Pi 的调用方式不同：使用 `/skill:<name>` 调用技能。
+Pi 会将此仓库识别为原生软件包：`extensions/` 提供会话持久模式，`skills/` 继续提供 Agent Skills 入口。
 
 ### 安装
 
 ```bash
-npx skills add ayghri/i-have-adhd -a pi -y
+pi install https://github.com/ayghri/i-have-adhd
 ```
 
-偏好文件系统方式？Pi 会在 `~/.pi/agent/skills/` 和 `~/.agents/skills/`（全局），以及 `.pi/skills/` 和 `.agents/skills/`（项目）中发现技能：
+启动新的 Pi 会话。为当前会话切换 ADHD 友好输出：
+
+```text
+/i-have-adhd
+```
+
+模式启用期间，页脚会显示 `● ADHD ON`。再次运行该命令即可关闭，也可以显式指定：
+
+```text
+/i-have-adhd on
+/i-have-adhd off
+stop adhd mode
+```
+
+与 Claude Code 的钩子类似，该扩展只在会话中添加一次规则，而不是每次请求都重写系统提示词，并在压缩（compaction）导致规则丢失后重新添加。
+
+现有的 Agent Skills 命令仍可作为别名使用：
+
+```text
+/skill:i-have-adhd
+```
+
+以默认启用该模式的方式启动新的 Pi 会话：
 
 ```bash
-git clone https://github.com/ayghri/i-have-adhd
-mkdir -p ~/.pi/agent/skills
-cp -R i-have-adhd/skills/i-have-adhd ~/.pi/agent/skills/
+pi --adhd
 ```
-
-在 Pi 的 `settings.json` 中启用技能斜杠命令：
-
-```json
-{ "enableSkillCommands": true }
-```
-
-开始新会话并输入 `/skill:i-have-adhd`。
 
 ### 验证
 
 ```bash
-npx skills list
+pi list
 ```
 
-也可以在会话中输入 `/skill:`，确认列表中有 `i-have-adhd`。
+确认列表中包含该 GitHub 软件包，然后输入 `/i-have-adhd` 并检查页脚是否显示 `● ADHD ON`。
 
 ### 更新
 
 ```bash
-npx skills update i-have-adhd
+pi update https://github.com/ayghri/i-have-adhd
 ```
 
-也可以在 `git pull` 后重新复制该文件夹。
+也可以用 `pi update --extensions` 更新所有未锁定版本的 Pi 软件包。
 
 ### 卸载
 
 ```bash
-npx skills remove i-have-adhd
+pi remove https://github.com/ayghri/i-have-adhd
 ```
-
-也可以删除 `~/.pi/agent/skills/i-have-adhd`。
 
 ### 始终启用（可选）
 
-添加到项目的 `AGENTS.md`：
+在 Pi 的代理配置目录中创建一个标志文件：
 
-```markdown
-## 输出风格
-
-读者有 ADHD。请让每条回复都便于立即执行：
-
-1. 先给出答案或下一步行动：命令、路径或代码片段优先。
-2. 为多步骤工作编号；每一步只包含一个明确的行动。
-3. 最后给出一个能在两分钟内完成的下一步行动。
-4. 先解决当前问题，再提出新问题。
-5. 每轮重述进度（“5 步中的第 3 步已完成”）。
-6. 用具体单位估算时间，绝不说“一会儿”。
-7. 修改后说明现在可以正常工作的内容。
-8. 出错时说明位置、原因和修复方法，不夸大。
-9. 列表最多包含 5 项。
-10. 不要前言、回顾或结束语。
-
-例外：用户要求解释时应充分说明。执行破坏性操作前先确认。连续三次修复失败后停止，并指出可疑的假设。请求含糊时只问一个简短问题。
+```bash
+touch ~/.pi/agent/.i-have-adhd-always
 ```
+
+该扩展会在每次新建、恢复、分叉或重新加载的会话中检查此标志。当前会话中已保存的选择优先于此默认值，因此 "stop adhd mode" 仍会让该会话保持关闭。
+
+恢复为按需启用：
+
+```bash
+rm ~/.pi/agent/.i-have-adhd-always
+```
+
+如果设置了 `PI_CODING_AGENT_DIR`，请改为将 `.i-have-adhd-always` 放在该目录下。更改标志后，请运行 `/reload` 或开始新会话。
 
 </details>
 

--- a/.github/readme/README.pt-BR.md
+++ b/.github/readme/README.pt-BR.md
@@ -79,7 +79,7 @@ Faça um fork, edite `skills/i-have-adhd/SKILL.md` e troque pela sua cópia:
 ```bash
 claude plugin uninstall i-have-adhd            # remova a cópia do upstream primeiro:
 claude plugin marketplace remove i-have-adhd   # fork e upstream compartilham o mesmo nome
-claude plugin marketplace add <seu-usuario>/i-have-adhd
+claude plugin marketplace add <your-username>/i-have-adhd
 claude plugin install i-have-adhd@i-have-adhd
 ```
 

--- a/.github/readme/README.vi.md
+++ b/.github/readme/README.vi.md
@@ -79,7 +79,7 @@ Fork repo, chỉnh sửa `skills/i-have-adhd/SKILL.md`, sau đó chuyển sang d
 ```bash
 claude plugin uninstall i-have-adhd            # gỡ bản chính trước:
 claude plugin marketplace remove i-have-adhd   # bản fork và bản chính dùng chung tên
-claude plugin marketplace add <username-của-bạn>/i-have-adhd
+claude plugin marketplace add <your-username>/i-have-adhd
 claude plugin install i-have-adhd@i-have-adhd
 ```
 

--- a/.github/workflows/gemini-command-sync.yml
+++ b/.github/workflows/gemini-command-sync.yml
@@ -1,11 +1,11 @@
 name: gemini command in sync
 
-# Fails if skills/i-have-adhd/agents/gemini.toml drifts from the canonical
-# skills/i-have-adhd/SKILL.md ruleset it is rendered from.
+# Fails if skills/i-have-adhd/agents/gemini.toml drifts from
+# skills/i-have-adhd/rules.md, the parsed ruleset it is rendered from.
 on:
   pull_request:
     paths:
-      - skills/i-have-adhd/SKILL.md
+      - skills/i-have-adhd/rules.md
       - skills/i-have-adhd/agents/gemini.toml
       - scripts/render_gemini_command.py
       - .github/workflows/gemini-command-sync.yml
@@ -17,5 +17,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Fail if gemini.toml is out of sync with SKILL.md
+      - name: Fail if gemini.toml is out of sync with rules.md
         run: python3 scripts/render_gemini_command.py --check

--- a/.github/workflows/gemini-command-sync.yml
+++ b/.github/workflows/gemini-command-sync.yml
@@ -1,0 +1,21 @@
+name: gemini command in sync
+
+# Fails if skills/i-have-adhd/agents/gemini.toml drifts from the canonical
+# skills/i-have-adhd/SKILL.md ruleset it is rendered from.
+on:
+  pull_request:
+    paths:
+      - skills/i-have-adhd/SKILL.md
+      - skills/i-have-adhd/agents/gemini.toml
+      - scripts/render_gemini_command.py
+      - .github/workflows/gemini-command-sync.yml
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail if gemini.toml is out of sync with SKILL.md
+        run: python3 scripts/render_gemini_command.py --check

--- a/.github/workflows/i18n-parity-check.yml
+++ b/.github/workflows/i18n-parity-check.yml
@@ -1,0 +1,30 @@
+name: install/readme translations in sync
+
+# Fails if a translated INSTALL.*.md or README.*.md drifts in structure from
+# the English source: different heading levels, different code blocks, or
+# code blocks whose commands (not just comments) differ.
+on:
+  pull_request:
+    paths:
+      - INSTALL.md
+      - README.md
+      - .github/install/**
+      - .github/readme/**
+      - scripts/check_i18n_parity.py
+      - .github/workflows/i18n-parity-check.yml
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Check translated INSTALL.md and README.md match the English structure
+        run: python3 scripts/check_i18n_parity.py

--- a/.github/workflows/manifest-sync.yml
+++ b/.github/workflows/manifest-sync.yml
@@ -1,0 +1,33 @@
+name: manifests in sync
+
+# Fails if any harness manifest drifts from the shared fields in
+# package.json (name, version, description, license, homepage, author).
+# No CLI install required: this is a plain Python check.
+on:
+  pull_request:
+    paths:
+      - package.json
+      - kimi.plugin.json
+      - plugin.json
+      - .claude-plugin/plugin.json
+      - .claude-plugin/marketplace.json
+      - .codex-plugin/plugin.json
+      - .agents/plugins/marketplace.json
+      - gemini-extension.json
+      - qwen-extension.json
+      - scripts/render_manifests.py
+      - tests/test_manifests.py
+      - .github/workflows/manifest-sync.yml
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Fail if any manifest is out of sync with package.json
+        run: python -m unittest tests.test_manifests -v

--- a/.github/workflows/pi-load-check.yml
+++ b/.github/workflows/pi-load-check.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - extensions/**
       - skills/**
+      - tests/**
       - package.json
       - scripts/check_pi_extension.py
       - .github/workflows/pi-load-check.yml
@@ -25,6 +26,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+      - name: Run in-process state machine tests
+        run: node --experimental-strip-types --test tests/state-machine.test.ts
       - name: Install Pi
         run: npm install -g --ignore-scripts @earendil-works/pi-coding-agent
       - name: Verify the Pi package, commands, status, and persisted mode

--- a/.github/workflows/rules-sync-check.yml
+++ b/.github/workflows/rules-sync-check.yml
@@ -1,0 +1,39 @@
+name: rules.md in sync
+
+# Fails if skills/i-have-adhd/rules.md drifts from the output of
+# scripts/generate_rules.mjs. rules.md is the single parsed copy of the
+# ruleset body; the four injection adapters (hooks/always-on.mjs,
+# hooks/always-on.sh, hooks/always-on.ps1, extensions/i-have-adhd.ts) read
+# it directly instead of each parsing SKILL.md's frontmatter themselves.
+on:
+  pull_request:
+    paths:
+      - skills/i-have-adhd/SKILL.md
+      - skills/i-have-adhd/rules.md
+      - scripts/generate_rules.mjs
+      - .github/workflows/rules-sync-check.yml
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Regenerate rules.md and fail on drift
+        run: |
+          cp skills/i-have-adhd/rules.md /tmp/rules.md.committed
+          node scripts/generate_rules.mjs
+          cmp skills/i-have-adhd/rules.md /tmp/rules.md.committed || {
+            echo "::error::rules.md is out of sync. Run: node scripts/generate_rules.mjs"
+            exit 1
+          }

--- a/.github/workflows/rules-sync-check.yml
+++ b/.github/workflows/rules-sync-check.yml
@@ -2,9 +2,10 @@ name: rules.md in sync
 
 # Fails if skills/i-have-adhd/rules.md drifts from the output of
 # scripts/generate_rules.mjs. rules.md is the single parsed copy of the
-# ruleset body; the four injection adapters (hooks/always-on.mjs,
-# hooks/always-on.sh, hooks/always-on.ps1, extensions/i-have-adhd.ts) read
-# it directly instead of each parsing SKILL.md's frontmatter themselves.
+# ruleset body; the five entry points (hooks/always-on.mjs,
+# hooks/always-on.sh, hooks/always-on.ps1, extensions/i-have-adhd.ts,
+# scripts/render_gemini_command.py) read it directly instead of each parsing
+# SKILL.md's frontmatter themselves.
 on:
   pull_request:
     paths:
@@ -29,11 +30,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: Regenerate rules.md and fail on drift
-        run: |
-          cp skills/i-have-adhd/rules.md /tmp/rules.md.committed
-          node scripts/generate_rules.mjs
-          cmp skills/i-have-adhd/rules.md /tmp/rules.md.committed || {
-            echo "::error::rules.md is out of sync. Run: node scripts/generate_rules.mjs"
-            exit 1
-          }
+      - name: Fail if rules.md is out of sync with SKILL.md
+        run: node scripts/generate_rules.mjs --check

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,42 @@
+name: unit tests
+
+# Runs the full Python unittest suite. Each drift-check workflow runs only
+# the module for its own artifact (manifest-sync.yml runs test_manifests,
+# plugin-load-check.yml runs test_always_on_hooks), which left
+# test_generate_rules.py and test_run_evals.py running nowhere. This
+# workflow is the guarantee that no test module is dead in CI, so a new
+# tests/test_*.py must be added to the module list below.
+on:
+  pull_request:
+    paths:
+      - scripts/**
+      - tests/**
+      - evals/**
+      - hooks/**
+      - skills/**
+      - package.json
+      - .github/workflows/unit-tests.yml
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      # test_generate_rules.py shells out to generate_rules.mjs, so node is
+      # part of the test environment, not just the drift-check workflows.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Run the unit test suite
+        run: python -m unittest tests.test_always_on_hooks tests.test_manifests tests.test_generate_rules tests.test_run_evals -v

--- a/extensions/i-have-adhd.ts
+++ b/extensions/i-have-adhd.ts
@@ -8,12 +8,12 @@ import {
 } from "@earendil-works/pi-coding-agent";
 
 const EXTENSION_DIR = dirname(fileURLToPath(import.meta.url));
-const SKILL_PATH = join(
+const RULES_PATH = join(
   EXTENSION_DIR,
   "..",
   "skills",
   "i-have-adhd",
-  "SKILL.md",
+  "rules.md",
 );
 const STATE_ENTRY_TYPE = "i-have-adhd-state";
 const RULES_MESSAGE_TYPE = "i-have-adhd-rules";
@@ -30,30 +30,23 @@ type AdhdModeState = {
   enabled: boolean;
 };
 
-function stripFrontmatter(content: string): string {
-  return content
-    .replace(
-      /^---[^\S\r\n]*\r?\n[\s\S]*?\r?\n---[^\S\r\n]*(?:\r?\n|$)/,
-      "",
-    )
-    .trim();
-}
-
+// rules.md is generated from SKILL.md by scripts/generate_rules.mjs, which
+// is the single place frontmatter parsing happens. Read it verbatim here.
 function loadRules(): string {
   let content: string;
 
   try {
-    content = readFileSync(SKILL_PATH, "utf8");
+    content = readFileSync(RULES_PATH, "utf8");
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     throw new Error(
-      `Unable to load i-have-adhd rules from ${SKILL_PATH}: ${reason}`,
+      `Unable to load i-have-adhd rules from ${RULES_PATH}: ${reason}`,
     );
   }
 
-  const rules = stripFrontmatter(content);
+  const rules = content.trim();
   if (!rules) {
-    throw new Error(`The i-have-adhd rules file is empty: ${SKILL_PATH}`);
+    throw new Error(`The i-have-adhd rules file is empty: ${RULES_PATH}`);
   }
 
   return rules;

--- a/extensions/i-have-adhd.ts
+++ b/extensions/i-have-adhd.ts
@@ -6,6 +6,16 @@ import {
   type ExtensionAPI,
   type ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
+import {
+  AdhdMode,
+  DISABLED_MESSAGE_TYPE,
+  RULES_MESSAGE_TYPE,
+  STATE_ENTRY_TYPE,
+  isStopPhrase,
+  latestEnabledState,
+  rulesActiveInContext,
+  type Effect,
+} from "./state-machine.ts";
 
 const EXTENSION_DIR = dirname(fileURLToPath(import.meta.url));
 const RULES_PATH = join(
@@ -15,20 +25,12 @@ const RULES_PATH = join(
   "i-have-adhd",
   "rules.md",
 );
-const STATE_ENTRY_TYPE = "i-have-adhd-state";
-const RULES_MESSAGE_TYPE = "i-have-adhd-rules";
-const DISABLED_MESSAGE_TYPE = "i-have-adhd-disabled";
 const STATUS_KEY = "i-have-adhd";
 const DISABLE_CONFIRMATION = "ADHD mode disabled.";
-const STOP_PHRASES = new Set(["stop adhd mode", "normal mode"]);
 const RULES_HEADER =
   'ADHD MODE ACTIVE. The ruleset below applies to every response until turned off. "stop adhd mode" or "normal mode" turns it off for this session.';
 const DISABLED_NOTICE =
   "ADHD MODE OFF. Ignore the i-have-adhd ruleset injected earlier in this conversation and return to your default response style.";
-
-type AdhdModeState = {
-  enabled: boolean;
-};
 
 // rules.md is generated from SKILL.md by scripts/generate_rules.mjs, which
 // is the single place frontmatter parsing happens. Read it verbatim here.
@@ -52,52 +54,12 @@ function loadRules(): string {
   return rules;
 }
 
-function getSavedState(ctx: ExtensionContext): boolean | undefined {
-  let savedState: boolean | undefined;
-
-  for (const entry of ctx.sessionManager.getBranch()) {
-    if (entry.type !== "custom" || entry.customType !== STATE_ENTRY_TYPE) {
-      continue;
-    }
-
-    const data = entry.data as Partial<AdhdModeState> | undefined;
-    if (typeof data?.enabled === "boolean") {
-      savedState = data.enabled;
-    }
-  }
-
-  return savedState;
-}
-
-/**
- * Whether the rules are still live in the context the model actually receives.
- *
- * Only the newest marker counts: a later "disabled" notice cancels an earlier
- * ruleset, and compaction drops summarized entries so the ruleset has to be
- * injected again.
- */
-function rulesAreInContext(ctx: ExtensionContext): boolean {
-  let active = false;
-
-  for (const entry of ctx.sessionManager.buildContextEntries()) {
-    if (entry.type !== "custom_message") continue;
-
-    if (entry.customType === RULES_MESSAGE_TYPE) {
-      active = true;
-    } else if (entry.customType === DISABLED_MESSAGE_TYPE) {
-      active = false;
-    }
-  }
-
-  return active;
-}
-
 export default function iHaveAdhdExtension(pi: ExtensionAPI) {
   const rules = loadRules();
   const alwaysOnFlag = join(getAgentDir(), ".i-have-adhd-always");
-  let enabled = false;
+  const mode = new AdhdMode();
 
-  const updateStatus = (ctx: ExtensionContext): void => {
+  const updateStatus = (ctx: ExtensionContext, enabled: boolean): void => {
     if (!enabled) {
       ctx.ui.setStatus(STATUS_KEY, undefined);
       return;
@@ -109,52 +71,79 @@ export default function iHaveAdhdExtension(pi: ExtensionAPI) {
   };
 
   /**
+   * Apply the pure state machine's effects to the pi harness. All decisions
+   * live in extensions/state-machine.ts; this switch is mechanical glue.
+   */
+  const applyEffects = (ctx: ExtensionContext, effects: Effect[]): void => {
+    for (const effect of effects) {
+      switch (effect.kind) {
+        case "inject-rules":
+          pi.sendMessage(
+            {
+              customType: RULES_MESSAGE_TYPE,
+              content: `${RULES_HEADER}\n\n${rules}`,
+              display: false,
+            },
+            { triggerTurn: false },
+          );
+          break;
+        case "inject-disabled":
+          pi.sendMessage(
+            {
+              customType: DISABLED_MESSAGE_TYPE,
+              content: DISABLED_NOTICE,
+              display: false,
+            },
+            { triggerTurn: false },
+          );
+          break;
+        case "persist-state":
+          pi.appendEntry(STATE_ENTRY_TYPE, { enabled: effect.enabled });
+          break;
+        case "set-status":
+          updateStatus(ctx, effect.enabled);
+          break;
+        case "notify":
+          ctx.ui.notify(effect.message, "info");
+          break;
+      }
+    }
+  };
+
+  /**
    * Keep the conversation in sync with the current mode, the way the Claude Code
    * SessionStart hook does: inject the ruleset once, never per request.
    */
   const syncContext = (ctx: ExtensionContext): void => {
-    const injected = rulesAreInContext(ctx);
-
-    if (enabled && !injected) {
-      pi.sendMessage(
-        {
-          customType: RULES_MESSAGE_TYPE,
-          content: `${RULES_HEADER}\n\n${rules}`,
-          display: false,
-        },
-        { triggerTurn: false },
-      );
-      return;
-    }
-
-    if (!enabled && injected) {
-      pi.sendMessage(
-        {
-          customType: DISABLED_MESSAGE_TYPE,
-          content: DISABLED_NOTICE,
-          display: false,
-        },
-        { triggerTurn: false },
-      );
-    }
+    applyEffects(
+      ctx,
+      mode.sync(rulesActiveInContext(ctx.sessionManager.buildContextEntries())),
+    );
   };
 
   const restoreState = (ctx: ExtensionContext): void => {
-    const savedState = getSavedState(ctx);
+    const savedState = latestEnabledState(ctx.sessionManager.getBranch());
     const enabledByDefault =
       pi.getFlag("adhd") === true || existsSync(alwaysOnFlag);
 
-    enabled = savedState ?? enabledByDefault;
-    updateStatus(ctx);
-    syncContext(ctx);
+    applyEffects(
+      ctx,
+      mode.restore(
+        savedState,
+        enabledByDefault,
+        rulesActiveInContext(ctx.sessionManager.buildContextEntries()),
+      ),
+    );
   };
 
   const setEnabled = (nextEnabled: boolean, ctx: ExtensionContext): void => {
-    enabled = nextEnabled;
-    pi.appendEntry(STATE_ENTRY_TYPE, { enabled } satisfies AdhdModeState);
-    updateStatus(ctx);
-    syncContext(ctx);
-    ctx.ui.notify(`ADHD mode ${enabled ? "enabled" : "disabled"}`, "info");
+    applyEffects(
+      ctx,
+      mode.setEnabled(
+        nextEnabled,
+        rulesActiveInContext(ctx.sessionManager.buildContextEntries()),
+      ),
+    );
   };
 
   pi.registerFlag("adhd", {
@@ -169,7 +158,7 @@ export default function iHaveAdhdExtension(pi: ExtensionAPI) {
       const argument = args.trim().toLowerCase();
 
       if (argument === "") {
-        setEnabled(!enabled, ctx);
+        setEnabled(!mode.enabled, ctx);
         return;
       }
 
@@ -197,7 +186,7 @@ export default function iHaveAdhdExtension(pi: ExtensionAPI) {
       return { action: "handled" };
     }
 
-    if (enabled && STOP_PHRASES.has(input)) {
+    if (mode.enabled && isStopPhrase(input)) {
       setEnabled(false, ctx);
 
       if (ctx.hasUI) {

--- a/extensions/state-machine.ts
+++ b/extensions/state-machine.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure state machine for the i-have-adhd extension.
+ *
+ * Deliberately imports nothing from pi or node: every decision the extension
+ * makes about mode, injection, and persistence lives here, so it can be
+ * exercised in-process with `node --test` (see tests/state-machine.test.ts)
+ * without booting the pi harness or having pi installed. The extension in
+ * i-have-adhd.ts stays a thin executor that applies the effects.
+ */
+
+export const STATE_ENTRY_TYPE = "i-have-adhd-state";
+export const RULES_MESSAGE_TYPE = "i-have-adhd-rules";
+export const DISABLED_MESSAGE_TYPE = "i-have-adhd-disabled";
+
+export const STOP_PHRASES = new Set(["stop adhd mode", "normal mode"]);
+
+export type Entry = {
+  type: string;
+  customType?: string;
+  data?: unknown;
+};
+
+export function isStopPhrase(input: string): boolean {
+  return STOP_PHRASES.has(input);
+}
+
+/** Newest persisted mode wins; entries with a non-boolean payload are ignored. */
+export function latestEnabledState(entries: readonly Entry[]): boolean | undefined {
+  let saved: boolean | undefined;
+
+  for (const entry of entries) {
+    if (entry.type !== "custom" || entry.customType !== STATE_ENTRY_TYPE) {
+      continue;
+    }
+    const data = entry.data as { enabled?: unknown } | undefined;
+    if (typeof data?.enabled === "boolean") {
+      saved = data.enabled;
+    }
+  }
+
+  return saved;
+}
+
+/**
+ * Whether the rules are still live in the context the model actually receives.
+ *
+ * Only the newest marker counts: a later "disabled" notice cancels an earlier
+ * ruleset, and compaction drops summarized entries so the ruleset has to be
+ * injected again.
+ */
+export function rulesActiveInContext(entries: readonly Entry[]): boolean {
+  let active = false;
+
+  for (const entry of entries) {
+    if (entry.type !== "custom_message") continue;
+
+    if (entry.customType === RULES_MESSAGE_TYPE) {
+      active = true;
+    } else if (entry.customType === DISABLED_MESSAGE_TYPE) {
+      active = false;
+    }
+  }
+
+  return active;
+}
+
+export type Effect =
+  | { kind: "inject-rules" }
+  | { kind: "inject-disabled" }
+  | { kind: "persist-state"; enabled: boolean }
+  | { kind: "set-status"; enabled: boolean }
+  | { kind: "notify"; message: string };
+
+/**
+ * The session's mode plus the effects each transition must have, so the pi
+ * adapter stays a thin executor and every decision is testable in isolation.
+ */
+export class AdhdMode {
+  enabled: boolean = false;
+
+  /** Restore the saved mode (or the default) and bring the context in sync. */
+  restore(
+    saved: boolean | undefined,
+    enabledByDefault: boolean,
+    rulesActive: boolean,
+  ): Effect[] {
+    this.enabled = saved ?? enabledByDefault;
+    return this.sync(rulesActive);
+  }
+
+  /** Reconcile the context with the current mode, e.g. after compaction. */
+  sync(rulesActive: boolean): Effect[] {
+    const effects: Effect[] = [{ kind: "set-status", enabled: this.enabled }];
+
+    if (this.enabled && !rulesActive) {
+      effects.push({ kind: "inject-rules" });
+    } else if (!this.enabled && rulesActive) {
+      effects.push({ kind: "inject-disabled" });
+    }
+
+    return effects;
+  }
+
+  /** Toggle the mode on or off, persisting the change and syncing the context. */
+  setEnabled(next: boolean, rulesActive: boolean): Effect[] {
+    this.enabled = next;
+    return [
+      { kind: "persist-state", enabled: next },
+      ...this.sync(rulesActive),
+      { kind: "notify", message: `ADHD mode ${next ? "enabled" : "disabled"}` },
+    ];
+  }
+}

--- a/hooks/always-on.mjs
+++ b/hooks/always-on.mjs
@@ -9,6 +9,10 @@
 //
 // Reads skills/i-have-adhd/rules.md verbatim: frontmatter parsing happens
 // once, at build time, in scripts/generate_rules.mjs.
+//
+// The banner text is shared with the other two runtimes via banner.txt
+// (line 1 = prefix, line 2 = suffix) instead of being hand-authored three
+// times, once per runtime's string-escaping dialect.
 
 import fs from "node:fs";
 import os from "node:os";
@@ -22,18 +26,22 @@ try {
   // Only fire when the user has opted in.
   if (!fs.existsSync(flagPath)) process.exit(0);
 
-  // Resolve rules.md relative to this script's own location, not a trusted env var.
+  // Resolve rules.md and banner.txt relative to this script's own location,
+  // not a trusted env var.
   const scriptDir = path.dirname(fileURLToPath(import.meta.url));
   const rulesPath = path.join(scriptDir, "..", "skills", "i-have-adhd", "rules.md");
   if (!fs.existsSync(rulesPath)) process.exit(0);
 
   const body = fs.readFileSync(rulesPath, "utf8").replace(/(?:\r?\n)+$/, "");
+  const bannerTemplate = fs
+    .readFileSync(path.join(scriptDir, "banner.txt"), "utf8")
+    .replace(/(?:\r?\n)+$/, "");
+  const token = "{{FLAG_PATH}}";
+  const tokenIndex = bannerTemplate.indexOf(token);
+  const banner =
+    bannerTemplate.slice(0, tokenIndex) + flagPath + bannerTemplate.slice(tokenIndex + token.length);
 
-  process.stdout.write(
-    "ADHD MODE ACTIVE (always-on). The ruleset below applies to every response. " +
-      '"stop adhd mode" turns it off for this session; ' +
-      `delete ${flagPath} to turn always-on off for good.\n\n${body}\n`,
-  );
+  process.stdout.write(`${banner}\n\n${body}\n`);
 } catch {
   // Never block session start.
   process.exit(0);

--- a/hooks/always-on.mjs
+++ b/hooks/always-on.mjs
@@ -6,6 +6,9 @@
 // a POSIX shell (`sh`) being on PATH. The hook uses exec form, so Claude Code
 // passes the script path directly without PowerShell or POSIX-shell parsing.
 // Native sh and PowerShell implementations remain available as fallbacks.
+//
+// Reads skills/i-have-adhd/rules.md verbatim: frontmatter parsing happens
+// once, at build time, in scripts/generate_rules.mjs.
 
 import fs from "node:fs";
 import os from "node:os";
@@ -19,19 +22,12 @@ try {
   // Only fire when the user has opted in.
   if (!fs.existsSync(flagPath)) process.exit(0);
 
-  // Resolve SKILL.md relative to this script's own location, not a trusted env var.
+  // Resolve rules.md relative to this script's own location, not a trusted env var.
   const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-  const skillPath = path.join(scriptDir, "..", "skills", "i-have-adhd", "SKILL.md");
-  if (!fs.existsSync(skillPath)) process.exit(0);
+  const rulesPath = path.join(scriptDir, "..", "skills", "i-have-adhd", "rules.md");
+  if (!fs.existsSync(rulesPath)) process.exit(0);
 
-  // Strip a leading YAML frontmatter block (--- ... --- at the very top of file).
-  const body = fs
-    .readFileSync(skillPath, "utf8")
-    .replace(
-      /^---[^\S\r\n]*\r?\n[\s\S]*?\r?\n---[^\S\r\n]*(?:\r?\n|$)/,
-      "",
-    )
-    .replace(/(?:\r?\n)+$/, "");
+  const body = fs.readFileSync(rulesPath, "utf8").replace(/(?:\r?\n)+$/, "");
 
   process.stdout.write(
     "ADHD MODE ACTIVE (always-on). The ruleset below applies to every response. " +

--- a/hooks/always-on.ps1
+++ b/hooks/always-on.ps1
@@ -2,6 +2,9 @@
 # i-have-adhd ruleset when the user has opted in by creating
 # $CLAUDE_CONFIG_DIR/.i-have-adhd-always (default ~/.claude).
 # Never blocks session start: any failure exits 0.
+#
+# Reads skills/i-have-adhd/rules.md verbatim: frontmatter parsing happens
+# once, at build time, in scripts/generate_rules.mjs.
 
 try {
   $claudeDir = if ($env:CLAUDE_CONFIG_DIR) {
@@ -16,30 +19,12 @@ try {
   }
 
   $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-  $skillPath = Join-Path $scriptDir "../skills/i-have-adhd/SKILL.md"
-  if (-not (Test-Path -LiteralPath $skillPath -PathType Leaf)) {
+  $rulesPath = Join-Path $scriptDir "../skills/i-have-adhd/rules.md"
+  if (-not (Test-Path -LiteralPath $rulesPath -PathType Leaf)) {
     exit 0
   }
 
-  $lines = [System.IO.File]::ReadAllLines($skillPath)
-  $bodyStart = 0
-
-  if ($lines.Length -gt 0 -and $lines[0] -match '^---\s*$') {
-    # Only treat the block as frontmatter when the closing delimiter exists;
-    # an unterminated fence is not frontmatter, so keep the whole file.
-    for ($i = 1; $i -lt $lines.Length; $i++) {
-      if ($lines[$i] -match '^---\s*$') {
-        $bodyStart = $i + 1
-        break
-      }
-    }
-  }
-
-  $body = if ($bodyStart -lt $lines.Length) {
-    [string]::Join([Environment]::NewLine, $lines[$bodyStart..($lines.Length - 1)])
-  } else {
-    ""
-  }
+  $body = [System.IO.File]::ReadAllText($rulesPath).TrimEnd("`r", "`n")
 
   $banner = 'ADHD MODE ACTIVE (always-on). The ruleset below applies to every response. ' +
     '"stop adhd mode" turns it off for this session; delete '

--- a/hooks/always-on.ps1
+++ b/hooks/always-on.ps1
@@ -5,6 +5,11 @@
 #
 # Reads skills/i-have-adhd/rules.md verbatim: frontmatter parsing happens
 # once, at build time, in scripts/generate_rules.mjs.
+#
+# The banner text is shared with the other two runtimes via banner.txt,
+# which carries a {{FLAG_PATH}} placeholder that each runtime splices its
+# own flag path into, instead of being hand-authored three times, once per
+# runtime's string-escaping dialect.
 
 try {
   $claudeDir = if ($env:CLAUDE_CONFIG_DIR) {
@@ -26,9 +31,11 @@ try {
 
   $body = [System.IO.File]::ReadAllText($rulesPath).TrimEnd("`r", "`n")
 
-  $banner = 'ADHD MODE ACTIVE (always-on). The ruleset below applies to every response. ' +
-    '"stop adhd mode" turns it off for this session; delete '
-  [Console]::Out.Write($banner + $flagPath + " to turn always-on off for good.`n`n" + $body + "`n")
+  $bannerTemplate = [System.IO.File]::ReadAllText((Join-Path $scriptDir "banner.txt")).TrimEnd("`r", "`n")
+  $token = "{{FLAG_PATH}}"
+  $tokenIndex = $bannerTemplate.IndexOf($token)
+  $banner = $bannerTemplate.Substring(0, $tokenIndex) + $flagPath + $bannerTemplate.Substring($tokenIndex + $token.Length)
+  [Console]::Out.Write($banner + "`n`n" + $body + "`n")
 } catch {
   # Never block session start.
   exit 0

--- a/hooks/always-on.sh
+++ b/hooks/always-on.sh
@@ -5,6 +5,9 @@
 #
 # POSIX fallback for environments where the default Node hook cannot run. It
 # works with sh on macOS/Linux and Git Bash on Windows without a Node install.
+#
+# Reads skills/i-have-adhd/rules.md verbatim: frontmatter parsing happens
+# once, at build time, in scripts/generate_rules.mjs.
 
 claude_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 flag_path="$claude_dir/.i-have-adhd-always"
@@ -13,25 +16,12 @@ flag_path="$claude_dir/.i-have-adhd-always"
 [ -f "$flag_path" ] || exit 0
 
 # $0 is the absolute script path substituted into hooks.json by Claude Code,
-# so resolve SKILL.md relative to it instead of trusting an exported env var.
+# so resolve rules.md relative to it instead of trusting an exported env var.
 script_dir=$(dirname -- "$0")
-skill_path="$script_dir/../skills/i-have-adhd/SKILL.md"
-[ -f "$skill_path" ] || exit 0
+rules_path="$script_dir/../skills/i-have-adhd/rules.md"
+[ -f "$rules_path" ] || exit 0
 
-# Strip a leading YAML frontmatter block (--- ... --- at the very top of file).
-# An unterminated fence is not frontmatter, so the whole file is kept unless the
-# closing delimiter exists (two passes; matches the Node and PowerShell hooks).
-body=$(awk '
-  NR == FNR {
-    if (NR == 1 && $0 ~ /^---[[:space:]]*$/) { in_fm = 1; next }
-    if (in_fm && $0 ~ /^---[[:space:]]*$/)   { in_fm = 0; closed = 1 }
-    next
-  }
-  FNR == 1 { strip = closed }
-  strip && FNR == 1 && $0 ~ /^---[[:space:]]*$/ { skipping = 1; next }
-  skipping && $0 ~ /^---[[:space:]]*$/          { skipping = 0; next }
-  !skipping { print }
-' "$skill_path" "$skill_path") || exit 0
+body=$(cat "$rules_path") || exit 0
 
 printf 'ADHD MODE ACTIVE (always-on). The ruleset below applies to every response. "stop adhd mode" turns it off for this session; delete %s to turn always-on off for good.\n\n%s\n' \
   "$flag_path" "$body"

--- a/hooks/always-on.sh
+++ b/hooks/always-on.sh
@@ -8,6 +8,11 @@
 #
 # Reads skills/i-have-adhd/rules.md verbatim: frontmatter parsing happens
 # once, at build time, in scripts/generate_rules.mjs.
+#
+# The banner text is shared with the other two runtimes via banner.txt,
+# which carries a {{FLAG_PATH}} placeholder that each runtime splices its
+# own flag path into, instead of being hand-authored three times, once per
+# runtime's string-escaping dialect.
 
 claude_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 flag_path="$claude_dir/.i-have-adhd-always"
@@ -16,12 +21,20 @@ flag_path="$claude_dir/.i-have-adhd-always"
 [ -f "$flag_path" ] || exit 0
 
 # $0 is the absolute script path substituted into hooks.json by Claude Code,
-# so resolve rules.md relative to it instead of trusting an exported env var.
+# so resolve rules.md and banner.txt relative to it instead of trusting an
+# exported env var.
 script_dir=$(dirname -- "$0")
 rules_path="$script_dir/../skills/i-have-adhd/rules.md"
+banner_path="$script_dir/banner.txt"
 [ -f "$rules_path" ] || exit 0
 
 body=$(cat "$rules_path") || exit 0
+# Splice the flag path into the shared template at the literal
+# {{FLAG_PATH}} token. Quoted parts of a pattern match literally in POSIX
+# sh, so a flag path full of special characters cannot break the split.
+banner_template=$(cat "$banner_path") || exit 0
+token='{{FLAG_PATH}}'
+banner_prefix=${banner_template%%"$token"*}
+banner_suffix=${banner_template#*"$token"}
 
-printf 'ADHD MODE ACTIVE (always-on). The ruleset below applies to every response. "stop adhd mode" turns it off for this session; delete %s to turn always-on off for good.\n\n%s\n' \
-  "$flag_path" "$body"
+printf '%s%s%s\n\n%s\n' "$banner_prefix" "$flag_path" "$banner_suffix" "$body"

--- a/hooks/banner.txt
+++ b/hooks/banner.txt
@@ -1,0 +1,1 @@
+ADHD MODE ACTIVE (always-on). The ruleset below applies to every response. "stop adhd mode" turns it off for this session; delete {{FLAG_PATH}} to turn always-on off for good.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "private": true,
   "keywords": ["pi-package"],
   "scripts": {
-    "generate:rules": "node scripts/generate_rules.mjs"
+    "generate:rules": "node scripts/generate_rules.mjs",
+    "test": "node --test tests/state-machine.test.ts"
   },
   "pi": {
     "extensions": ["./extensions/i-have-adhd.ts"],

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "homepage": "https://github.com/ayghri/i-have-adhd",
   "private": true,
   "keywords": ["pi-package"],
+  "scripts": {
+    "generate:rules": "node scripts/generate_rules.mjs"
+  },
   "pi": {
     "extensions": ["./extensions/i-have-adhd.ts"],
     "skills": ["./skills"]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible.",
   "license": "MIT",
   "homepage": "https://github.com/ayghri/i-have-adhd",
+  "author": {
+    "name": "Ayoub G.",
+    "url": "https://github.com/ayghri"
+  },
   "private": true,
   "keywords": ["pi-package"],
   "scripts": {

--- a/scripts/check_i18n_parity.py
+++ b/scripts/check_i18n_parity.py
@@ -9,7 +9,12 @@ translated; commands are not. This script does not try to translate or
 restructure anything -- it only asserts that a translated file has the same
 shape as the English source:
 
-  1. Same sequence of heading levels (heading *text* is expected to differ).
+  1. Same sequence of structure markers: heading levels and the <summary>
+     openers that delimit each harness's <details> section (heading and
+     summary *text* is expected to differ, so only the shape is compared).
+     Without the summary markers a whole harness section could go missing
+     from a translation unnoticed, since those sections use <summary>
+     rather than headings.
   2. Same sequence of fenced code blocks, by info-string language.
   3. For non-prose code blocks (bash/sh/text/json/...), the same command
      content line-for-line, ignoring inline "# ..." comments (those may be
@@ -30,10 +35,22 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
-# (english source, directory holding the translated files, glob for suffix)
-GROUPS = [
-    (ROOT / "INSTALL.md", ROOT / ".github" / "install", "INSTALL"),
-    (ROOT / "README.md", ROOT / ".github" / "readme", "README"),
+
+@dataclass(frozen=True)
+class Pair:
+    """An English source and the directory of translations to hold to its shape."""
+
+    english: Path
+    translated_dir: Path
+    stem: str
+
+    def translations(self) -> list[Path]:
+        return sorted(self.translated_dir.glob(f"{self.stem}.*.md"))
+
+
+PAIRS = [
+    Pair(ROOT / "INSTALL.md", ROOT / ".github" / "install", "INSTALL"),
+    Pair(ROOT / "README.md", ROOT / ".github" / "readme", "README"),
 ]
 
 # Fenced code blocks in this language are prose (e.g. the translated
@@ -41,7 +58,12 @@ GROUPS = [
 PROSE_LANGS = {"markdown"}
 
 HEADING_RE = re.compile(r"^(#{1,6})\s+\S")
-FENCE_RE = re.compile(r"^```(\S*)\s*$")
+# CommonMark allows a fence to be indented by up to three spaces, e.g. inside
+# a list item. Anchoring at column 0 silently skipped those.
+FENCE_RE = re.compile(r"^ {0,3}```(\S*)\s*$")
+# Each harness gets a <details> block whose <summary> is its only title; these
+# sections carry no heading, so they are invisible to HEADING_RE.
+SUMMARY_RE = re.compile(r"^\s*<summary>")
 
 
 @dataclass
@@ -51,34 +73,41 @@ class CodeBlock:
     lines: list[str]
 
 
-def parse(path: Path) -> tuple[list[int], list[CodeBlock]]:
-    """Return (heading levels outside code fences, code blocks in order)."""
-    heading_levels: list[int] = []
+def parse(path: Path) -> tuple[list[str], list[CodeBlock]]:
+    """Return (structure markers outside code fences, code blocks in order).
+
+    A marker is ``h<level>`` for a Markdown heading or ``section`` for a
+    <summary> opener. Raises ValueError on an unterminated fence, which would
+    otherwise swallow the rest of the file without a word.
+    """
+    structure: list[str] = []
     blocks: list[CodeBlock] = []
-    in_fence = False
     current: CodeBlock | None = None
 
     for lineno, raw in enumerate(path.read_text(encoding="utf8").splitlines(), 1):
         fence = FENCE_RE.match(raw)
         if fence:
-            if not in_fence:
-                in_fence = True
+            if current is None:
                 current = CodeBlock(line=lineno, lang=fence.group(1), lines=[])
             else:
-                in_fence = False
-                assert current is not None
                 blocks.append(current)
                 current = None
             continue
-        if in_fence:
-            assert current is not None
+        if current is not None:
             current.lines.append(raw)
             continue
-        m = HEADING_RE.match(raw)
-        if m:
-            heading_levels.append(len(m.group(1)))
+        heading = HEADING_RE.match(raw)
+        if heading:
+            structure.append(f"h{len(heading.group(1))}")
+        elif SUMMARY_RE.match(raw):
+            structure.append("section")
 
-    return heading_levels, blocks
+    if current is not None:
+        raise ValueError(
+            f"{path}:{current.line}: code fence is never closed"
+        )
+
+    return structure, blocks
 
 
 def strip_comment(line: str) -> str:
@@ -94,16 +123,43 @@ def strip_comment(line: str) -> str:
     return "".join(out).rstrip()
 
 
+def _first_divergence(
+    en_path: Path,
+    en_structure: list[str],
+    other_path: Path,
+    other_structure: list[str],
+) -> str:
+    """Describe the first marker that differs, so the whole list need not be read."""
+    for i, (en_marker, other_marker) in enumerate(zip(en_structure, other_structure)):
+        if en_marker != other_marker:
+            return (
+                f"marker #{i + 1} is {en_marker!r} in {en_path.name} but "
+                f"{other_marker!r} in {other_path.name}"
+            )
+
+    shared = min(len(en_structure), len(other_structure))
+    longer, longer_path = (
+        (en_structure, en_path)
+        if len(en_structure) > len(other_structure)
+        else (other_structure, other_path)
+    )
+    return (
+        f"the first {shared} markers agree; {longer_path.name} then has an "
+        f"extra {longer[shared]!r}"
+    )
+
+
 def compare(en_path: Path, other_path: Path) -> list[str]:
     errors: list[str] = []
-    en_headings, en_blocks = parse(en_path)
-    other_headings, other_blocks = parse(other_path)
+    en_structure, en_blocks = parse(en_path)
+    other_structure, other_blocks = parse(other_path)
 
-    if en_headings != other_headings:
+    if en_structure != other_structure:
         errors.append(
-            f"heading structure differs: {en_path.name} has {len(en_headings)} "
-            f"headings {en_headings}, {other_path.name} has {len(other_headings)} "
-            f"headings {other_headings}"
+            f"structure differs: {en_path.name} has {len(en_structure)} markers "
+            f"(headings + <details> sections), {other_path.name} has "
+            f"{len(other_structure)}. First divergence: "
+            + _first_divergence(en_path, en_structure, other_path, other_structure)
         )
 
     if len(en_blocks) != len(other_blocks):
@@ -144,26 +200,35 @@ def compare(en_path: Path, other_path: Path) -> list[str]:
 def main() -> int:
     all_errors: list[str] = []
 
-    for en_path, translated_dir, stem in GROUPS:
-        if not en_path.exists():
-            all_errors.append(f"missing source file: {en_path}")
+    for pair in PAIRS:
+        if not pair.english.exists():
+            all_errors.append(f"missing source file: {pair.english}")
             continue
-        translated_files = sorted(translated_dir.glob(f"{stem}.*.md"))
+        translated_files = pair.translations()
         if not translated_files:
-            all_errors.append(f"no translated files found under {translated_dir}")
+            all_errors.append(
+                f"no translated files found under {pair.translated_dir}"
+            )
             continue
         for other_path in translated_files:
-            errors = compare(en_path, other_path)
+            try:
+                errors = compare(pair.english, other_path)
+            except ValueError as error:
+                errors = [str(error)]
             if errors:
-                all_errors.append(f"--- {other_path.relative_to(ROOT)} vs {en_path.relative_to(ROOT)} ---")
+                all_errors.append(
+                    f"--- {other_path.relative_to(ROOT)} vs "
+                    f"{pair.english.relative_to(ROOT)} ---"
+                )
                 all_errors.extend(errors)
 
     if all_errors:
         print("i18n parity check failed:\n", file=sys.stderr)
         print("\n".join(all_errors), file=sys.stderr)
         print(
-            "\nHeading structure and code blocks must match the English source "
-            "(prose and comments may be translated; commands may not).",
+            "\nStructure (headings and <details> sections) and code blocks must "
+            "match the English source (prose and comments may be translated; "
+            "commands may not).",
             file=sys.stderr,
         )
         return 1

--- a/scripts/check_i18n_parity.py
+++ b/scripts/check_i18n_parity.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Check that translated INSTALL.md / README.md files stay in structural sync
+with their English source.
+
+INSTALL.md and README.md are duplicated by hand into five languages each
+(.github/install/INSTALL.{ja,ko,pt-BR,vi,zh-CN}.md and
+.github/readme/README.{ja,ko,pt-BR,vi,zh-CN}.md). Prose is meant to be
+translated; commands are not. This script does not try to translate or
+restructure anything -- it only asserts that a translated file has the same
+shape as the English source:
+
+  1. Same sequence of heading levels (heading *text* is expected to differ).
+  2. Same sequence of fenced code blocks, by info-string language.
+  3. For non-prose code blocks (bash/sh/text/json/...), the same command
+     content line-for-line, ignoring inline "# ..." comments (those may be
+     translated) and ignoring language differences inside a
+     ```markdown ... ``` block (that fence is prose meant for translation,
+     e.g. the "Output style" ruleset snippet).
+
+Run directly to check every known pair; exits non-zero and prints every
+mismatch found if any pair has drifted.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# (english source, directory holding the translated files, glob for suffix)
+GROUPS = [
+    (ROOT / "INSTALL.md", ROOT / ".github" / "install", "INSTALL"),
+    (ROOT / "README.md", ROOT / ".github" / "readme", "README"),
+]
+
+# Fenced code blocks in this language are prose (e.g. the translated
+# "Output style" ruleset snippet), not commands -- skip content comparison.
+PROSE_LANGS = {"markdown"}
+
+HEADING_RE = re.compile(r"^(#{1,6})\s+\S")
+FENCE_RE = re.compile(r"^```(\S*)\s*$")
+
+
+@dataclass
+class CodeBlock:
+    line: int
+    lang: str
+    lines: list[str]
+
+
+def parse(path: Path) -> tuple[list[int], list[CodeBlock]]:
+    """Return (heading levels outside code fences, code blocks in order)."""
+    heading_levels: list[int] = []
+    blocks: list[CodeBlock] = []
+    in_fence = False
+    current: CodeBlock | None = None
+
+    for lineno, raw in enumerate(path.read_text(encoding="utf8").splitlines(), 1):
+        fence = FENCE_RE.match(raw)
+        if fence:
+            if not in_fence:
+                in_fence = True
+                current = CodeBlock(line=lineno, lang=fence.group(1), lines=[])
+            else:
+                in_fence = False
+                assert current is not None
+                blocks.append(current)
+                current = None
+            continue
+        if in_fence:
+            assert current is not None
+            current.lines.append(raw)
+            continue
+        m = HEADING_RE.match(raw)
+        if m:
+            heading_levels.append(len(m.group(1)))
+
+    return heading_levels, blocks
+
+
+def strip_comment(line: str) -> str:
+    """Drop a trailing '# ...' comment (may legitimately be translated)."""
+    out = []
+    in_backtick = False
+    for ch in line:
+        if ch == "`":
+            in_backtick = not in_backtick
+        if ch == "#" and not in_backtick:
+            break
+        out.append(ch)
+    return "".join(out).rstrip()
+
+
+def compare(en_path: Path, other_path: Path) -> list[str]:
+    errors: list[str] = []
+    en_headings, en_blocks = parse(en_path)
+    other_headings, other_blocks = parse(other_path)
+
+    if en_headings != other_headings:
+        errors.append(
+            f"heading structure differs: {en_path.name} has {len(en_headings)} "
+            f"headings {en_headings}, {other_path.name} has {len(other_headings)} "
+            f"headings {other_headings}"
+        )
+
+    if len(en_blocks) != len(other_blocks):
+        errors.append(
+            f"code block count differs: {en_path.name} has {len(en_blocks)} "
+            f"fenced blocks, {other_path.name} has {len(other_blocks)}"
+        )
+
+    for i, (en_block, other_block) in enumerate(zip(en_blocks, other_blocks)):
+        if en_block.lang != other_block.lang:
+            errors.append(
+                f"code block #{i + 1} language differs: "
+                f"{en_path.name}:{en_block.line} is `{en_block.lang}`, "
+                f"{other_path.name}:{other_block.line} is `{other_block.lang}`"
+            )
+            continue
+        if en_block.lang in PROSE_LANGS:
+            continue
+        if len(en_block.lines) != len(other_block.lines):
+            errors.append(
+                f"code block #{i + 1} ({en_block.lang}) line count differs: "
+                f"{en_path.name}:{en_block.line} has {len(en_block.lines)} lines, "
+                f"{other_path.name}:{other_block.line} has {len(other_block.lines)}"
+            )
+            continue
+        for j, (en_line, other_line) in enumerate(zip(en_block.lines, other_block.lines)):
+            if strip_comment(en_line) != strip_comment(other_line):
+                errors.append(
+                    f"code block #{i + 1} ({en_block.lang}) line {j + 1} differs "
+                    f"(ignoring trailing comments):\n"
+                    f"    {en_path.name}:{en_block.line + j + 1}: {en_line!r}\n"
+                    f"    {other_path.name}:{other_block.line + j + 1}: {other_line!r}"
+                )
+
+    return errors
+
+
+def main() -> int:
+    all_errors: list[str] = []
+
+    for en_path, translated_dir, stem in GROUPS:
+        if not en_path.exists():
+            all_errors.append(f"missing source file: {en_path}")
+            continue
+        translated_files = sorted(translated_dir.glob(f"{stem}.*.md"))
+        if not translated_files:
+            all_errors.append(f"no translated files found under {translated_dir}")
+            continue
+        for other_path in translated_files:
+            errors = compare(en_path, other_path)
+            if errors:
+                all_errors.append(f"--- {other_path.relative_to(ROOT)} vs {en_path.relative_to(ROOT)} ---")
+                all_errors.extend(errors)
+
+    if all_errors:
+        print("i18n parity check failed:\n", file=sys.stderr)
+        print("\n".join(all_errors), file=sys.stderr)
+        print(
+            "\nHeading structure and code blocks must match the English source "
+            "(prose and comments may be translated; commands may not).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("INSTALL.md and README.md translations match the English source structure.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_pi_extension.py
+++ b/scripts/check_pi_extension.py
@@ -9,24 +9,17 @@ import queue
 import subprocess
 import tempfile
 import threading
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
 RPC_TIMEOUT_SECONDS = 30
-SHARED_MANIFEST_FIELDS = ("name", "version", "description", "license", "homepage")
 
 
 def validate_package_manifest() -> None:
     package = json.loads((ROOT / "package.json").read_text(encoding="utf8"))
-    kimi = json.loads((ROOT / "kimi.plugin.json").read_text(encoding="utf8"))
-
-    for field in SHARED_MANIFEST_FIELDS:
-        assert package.get(field) == kimi.get(field), (
-            f"package.json and kimi.plugin.json disagree on {field}"
-        )
-
     assert package.get("pi") == {
         "extensions": ["./extensions/i-have-adhd.ts"],
         "skills": ["./skills"],
@@ -118,6 +111,149 @@ class RpcClient:
             raise RuntimeError(f"Pi RPC exited with {return_code}: {stderr}")
 
 
+def _status_texts(events: list[dict[str, Any]]) -> list[str | None]:
+    return [
+        event.get("statusText")
+        for event in events
+        if event.get("type") == "extension_ui_request"
+        and event.get("method") == "setStatus"
+        and event.get("statusKey") == "i-have-adhd"
+    ]
+
+
+def _message_count(entries: list[dict[str, Any]], custom_type: str) -> int:
+    return sum(
+        1
+        for entry in entries
+        if entry.get("type") == "custom_message" and entry.get("customType") == custom_type
+    )
+
+
+def _latest_enabled(entries: list[dict[str, Any]]) -> bool | None:
+    states = [
+        entry.get("data", {}).get("enabled")
+        for entry in entries
+        if entry.get("type") == "custom" and entry.get("customType") == "i-have-adhd-state"
+    ]
+    if not states:
+        return None
+    if not isinstance(states[-1], bool):
+        raise AssertionError("Persisted i-have-adhd state is not a boolean")
+    return states[-1]
+
+
+def _passthrough_seen(entries: list[dict[str, Any]]) -> bool:
+    return any(
+        entry.get("type") == "custom"
+        and entry.get("customType") == "passthrough-probe"
+        and entry.get("data", {}).get("seen") is True
+        for entry in entries
+    )
+
+
+def write_reload_probe(agent_dir: str) -> tuple[Path, Path]:
+    """Write the extension used to drive /reload and passthrough-input probes."""
+    probe_path = Path(agent_dir, "reload-probe.ts")
+    passthrough_flag = Path(agent_dir, "passthrough-probe-enabled")
+    source = """import { existsSync } from "node:fs";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+const passthroughProbeFlag = __PASSTHROUGH_PROBE_FLAG__;
+export default function (pi: ExtensionAPI) {
+  pi.registerCommand("reload-probe", {
+    description: "Reload Pi for smoke testing",
+    handler: async (_args, ctx) => { await ctx.reload(); },
+  });
+  pi.on("input", async (event) => {
+    if (!existsSync(passthroughProbeFlag) || event.text.trim().toLowerCase() !== "normal mode") {
+      return { action: "continue" };
+    }
+    pi.appendEntry("passthrough-probe", { seen: true });
+    return { action: "handled" };
+  });
+}
+"""
+    probe_path.write_text(
+        source.replace("__PASSTHROUGH_PROBE_FLAG__", json.dumps(str(passthrough_flag))),
+        encoding="utf8",
+    )
+    return probe_path, passthrough_flag
+
+
+@dataclass
+class SessionState:
+    rules_count: int
+    disabled_count: int
+    enabled: bool | None
+    passthrough_seen: bool
+
+
+class Session:
+    """A Pi RPC session, speaking in ADHD-mode terms: toggle, injection, stop phrase.
+
+    Wraps the raw request/response/event protocol of `RpcClient` so callers
+    describe behaviour instead of restating the wire format.
+    """
+
+    def __init__(self, client: RpcClient) -> None:
+        self._client = client
+        self._request_count = 0
+        self._last_events: list[dict[str, Any]] = []
+
+    def _request(self, command: dict[str, Any]) -> dict[str, Any]:
+        self._request_count += 1
+        request_id = f"{command['type']}-{self._request_count}"
+        response, self._last_events = self._client.request(request_id, command)
+        return response
+
+    @property
+    def status(self) -> str | None:
+        texts = _status_texts(self._last_events)
+        return texts[-1] if texts else None
+
+    @property
+    def triggered_agent(self) -> bool:
+        return any(event.get("type") == "agent_start" for event in self._last_events)
+
+    def commands(self) -> set[str]:
+        response = self._request({"type": "get_commands"})
+        return {command["name"] for command in response["data"]["commands"]}
+
+    def prompt(self, message: str) -> bool:
+        response = self._request({"type": "prompt", "message": message})
+        return response["success"]
+
+    def toggle(self) -> bool:
+        return self.prompt("/i-have-adhd")
+
+    def explicit_off(self) -> bool:
+        return self.prompt("/i-have-adhd off")
+
+    def skill_alias(self) -> bool:
+        return self.prompt("/skill:i-have-adhd")
+
+    def reload(self) -> bool:
+        return self.prompt("/reload-probe")
+
+    def stop_phrase(self) -> bool:
+        return self.prompt("normal mode")
+
+    def get_state(self) -> None:
+        self._request({"type": "get_state"})
+
+    def state(self) -> SessionState:
+        response = self._request({"type": "get_entries"})
+        entries = response["data"]["entries"]
+        return SessionState(
+            rules_count=_message_count(entries, "i-have-adhd-rules"),
+            disabled_count=_message_count(entries, "i-have-adhd-disabled"),
+            enabled=_latest_enabled(entries),
+            passthrough_seen=_passthrough_seen(entries),
+        )
+
+    def close(self) -> None:
+        self._client.close()
+
+
 def build_isolated_env(agent_dir: str) -> dict[str, str]:
     env = {
         key: value
@@ -135,37 +271,6 @@ def build_isolated_env(agent_dir: str) -> dict[str, str]:
     return env
 
 
-def status_texts(events: list[dict[str, Any]]) -> list[str | None]:
-    return [
-        event.get("statusText")
-        for event in events
-        if event.get("type") == "extension_ui_request"
-        and event.get("method") == "setStatus"
-        and event.get("statusKey") == "i-have-adhd"
-    ]
-
-
-def message_count(entries_response: dict[str, Any], custom_type: str) -> int:
-    return sum(
-        1
-        for entry in entries_response["data"]["entries"]
-        if entry.get("type") == "custom_message"
-        and entry.get("customType") == custom_type
-    )
-
-
-def latest_enabled(entries_response: dict[str, Any]) -> bool:
-    states = [
-        entry.get("data", {}).get("enabled")
-        for entry in entries_response["data"]["entries"]
-        if entry.get("type") == "custom"
-        and entry.get("customType") == "i-have-adhd-state"
-    ]
-    if not states or not isinstance(states[-1], bool):
-        raise AssertionError("No persisted i-have-adhd state found")
-    return states[-1]
-
-
 def main() -> None:
     validate_package_manifest()
 
@@ -180,151 +285,75 @@ def main() -> None:
             text=True,
         )
 
-        reload_probe = Path(agent_dir, "reload-probe.ts")
-        passthrough_probe_flag = Path(agent_dir, "passthrough-probe-enabled")
-        reload_probe_source = """import { existsSync } from \"node:fs\";
-import type { ExtensionAPI } from \"@earendil-works/pi-coding-agent\";
-const passthroughProbeFlag = __PASSTHROUGH_PROBE_FLAG__;
-export default function (pi: ExtensionAPI) {
-  pi.registerCommand(\"reload-probe\", {
-    description: \"Reload Pi for smoke testing\",
-    handler: async (_args, ctx) => { await ctx.reload(); },
-  });
-  pi.on(\"input\", async (event) => {
-    if (!existsSync(passthroughProbeFlag) || event.text.trim().toLowerCase() !== \"normal mode\") {
-      return { action: \"continue\" };
-    }
-    pi.appendEntry(\"passthrough-probe\", { seen: true });
-    return { action: \"handled\" };
-  });
-}
-"""
-        reload_probe.write_text(
-            reload_probe_source.replace(
-                "__PASSTHROUGH_PROBE_FLAG__",
-                json.dumps(str(passthrough_probe_flag)),
-            ),
-            encoding="utf8",
-        )
-
-        client = RpcClient(
-            env,
-            "--no-session",
-            "-e",
-            str(reload_probe),
-            "--adhd",
+        reload_probe, passthrough_probe_flag = write_reload_probe(agent_dir)
+        session = Session(
+            RpcClient(env, "--no-session", "-e", str(reload_probe), "--adhd")
         )
         try:
-            commands, startup_events = client.request("commands", {"type": "get_commands"})
-            command_names = {command["name"] for command in commands["data"]["commands"]}
-            assert "i-have-adhd" in command_names
-            assert "skill:i-have-adhd" in command_names
-            assert any("ADHD ON" in (text or "") for text in status_texts(startup_events))
+            commands = session.commands()
+            assert "i-have-adhd" in commands
+            assert "skill:i-have-adhd" in commands
+            assert session.status and "ADHD ON" in session.status
 
-            entries, _ = client.request("entries-startup", {"type": "get_entries"})
-            assert message_count(entries, "i-have-adhd-rules") == 1
-            assert message_count(entries, "i-have-adhd-disabled") == 0
+            state = session.state()
+            assert state.rules_count == 1
+            assert state.disabled_count == 0
 
-            reloaded, reload_events = client.request(
-                "reload-enabled",
-                {"type": "prompt", "message": "/reload-probe"},
-            )
-            assert reloaded["success"] is True
-            assert any("ADHD ON" in (text or "") for text in status_texts(reload_events))
+            assert session.reload() is True
+            assert session.status and "ADHD ON" in session.status
 
-            entries, _ = client.request("entries-reloaded", {"type": "get_entries"})
-            assert message_count(entries, "i-have-adhd-rules") == 1, (
-                "Rules were injected twice for one active session"
-            )
+            state = session.state()
+            assert state.rules_count == 1, "Rules were injected twice for one active session"
 
-            toggled_off, toggle_off_events = client.request(
-                "toggle-off",
-                {"type": "prompt", "message": "/i-have-adhd"},
-            )
-            assert toggled_off["success"] is True
-            assert None in status_texts(toggle_off_events)
+            assert session.toggle() is True
+            assert session.status is None
 
-            entries, _ = client.request("entries-toggled-off", {"type": "get_entries"})
-            assert latest_enabled(entries) is False
-            assert message_count(entries, "i-have-adhd-disabled") == 1
+            state = session.state()
+            assert state.enabled is False
+            assert state.disabled_count == 1
 
-            reloaded, reload_events = client.request(
-                "reload-disabled",
-                {"type": "prompt", "message": "/reload-probe"},
-            )
-            assert reloaded["success"] is True
-            assert not any("ADHD ON" in (text or "") for text in status_texts(reload_events))
+            assert session.reload() is True
+            assert session.status is None
 
-            entries, _ = client.request("entries-reload-disabled", {"type": "get_entries"})
-            assert message_count(entries, "i-have-adhd-rules") == 1
-            assert message_count(entries, "i-have-adhd-disabled") == 1
+            state = session.state()
+            assert state.rules_count == 1
+            assert state.disabled_count == 1
 
-            toggled_on, toggle_on_events = client.request(
-                "toggle-on",
-                {"type": "prompt", "message": "/i-have-adhd"},
-            )
-            assert toggled_on["success"] is True
-            assert any("ADHD ON" in (text or "") for text in status_texts(toggle_on_events))
+            assert session.toggle() is True
+            assert session.status and "ADHD ON" in session.status
 
-            entries, _ = client.request("entries-toggled-on", {"type": "get_entries"})
-            assert latest_enabled(entries) is True
-            assert message_count(entries, "i-have-adhd-rules") == 2
+            state = session.state()
+            assert state.enabled is True
+            assert state.rules_count == 2
 
-            explicit_off, _ = client.request(
-                "explicit-off",
-                {"type": "prompt", "message": "/i-have-adhd off"},
-            )
-            assert explicit_off["success"] is True
+            assert session.explicit_off() is True
 
-            skill, skill_events = client.request(
-                "skill-alias",
-                {"type": "prompt", "message": "/skill:i-have-adhd"},
-            )
-            assert skill["success"] is True
-            assert not any(event.get("type") == "agent_start" for event in skill_events)
+            assert session.skill_alias() is True
+            assert not session.triggered_agent
 
-            entries, _ = client.request("entries-enabled", {"type": "get_entries"})
-            assert latest_enabled(entries) is True
-            assert message_count(entries, "i-have-adhd-rules") == 3
+            state = session.state()
+            assert state.enabled is True
+            assert state.rules_count == 3
 
-            stopped, stop_events = client.request(
-                "stop-phrase",
-                {"type": "prompt", "message": "normal mode"},
-            )
-            assert stopped["success"] is True
-            assert None in status_texts(stop_events)
+            assert session.stop_phrase() is True
+            assert session.status is None
 
-            entries, _ = client.request("entries-stopped", {"type": "get_entries"})
-            assert latest_enabled(entries) is False
+            state = session.state()
+            assert state.enabled is False
 
             passthrough_probe_flag.touch()
-            passthrough, _ = client.request(
-                "disabled-passthrough",
-                {"type": "prompt", "message": "normal mode"},
-            )
-            assert passthrough["success"] is True
+            assert session.prompt("normal mode") is True
 
-            entries, _ = client.request("entries-passthrough", {"type": "get_entries"})
-            assert any(
-                entry.get("type") == "custom"
-                and entry.get("customType") == "passthrough-probe"
-                and entry.get("data", {}).get("seen") is True
-                for entry in entries["data"]["entries"]
-            ), "Disabled mode swallowed ordinary input"
+            state = session.state()
+            assert state.passthrough_seen, "Disabled mode swallowed ordinary input"
         finally:
-            client.close()
+            session.close()
 
         Path(agent_dir, ".i-have-adhd-always").touch()
-        always_on = RpcClient(env, "--no-session")
+        always_on = Session(RpcClient(env, "--no-session"))
         try:
-            _, always_on_events = always_on.request(
-                "always-on",
-                {"type": "get_state"},
-            )
-            assert any(
-                "ADHD ON" in (text or "")
-                for text in status_texts(always_on_events)
-            )
+            always_on.get_state()
+            assert always_on.status and "ADHD ON" in always_on.status
         finally:
             always_on.close()
 

--- a/scripts/check_pi_extension.py
+++ b/scripts/check_pi_extension.py
@@ -18,14 +18,6 @@ ROOT = Path(__file__).resolve().parents[1]
 RPC_TIMEOUT_SECONDS = 30
 
 
-def validate_package_manifest() -> None:
-    package = json.loads((ROOT / "package.json").read_text(encoding="utf8"))
-    assert package.get("pi") == {
-        "extensions": ["./extensions/i-have-adhd.ts"],
-        "skills": ["./skills"],
-    }
-
-
 class RpcClient:
     def __init__(self, env: dict[str, str], *args: str) -> None:
         self.stderr_file = tempfile.TemporaryFile(mode="w+t")
@@ -207,8 +199,18 @@ class Session:
 
     @property
     def status(self) -> str | None:
+        """The status the last command reported: text, or None if it cleared it.
+
+        Every command asserted on below is expected to report status, so a
+        command that emitted no setStatus at all is a failure rather than a
+        cleared status - otherwise `status is None` would pass vacuously.
+        """
         texts = _status_texts(self._last_events)
-        return texts[-1] if texts else None
+        if not texts:
+            raise AssertionError(
+                "expected a setStatus event for i-have-adhd, got none"
+            )
+        return texts[-1]
 
     @property
     def triggered_agent(self) -> bool:
@@ -272,8 +274,6 @@ def build_isolated_env(agent_dir: str) -> dict[str, str]:
 
 
 def main() -> None:
-    validate_package_manifest()
-
     with tempfile.TemporaryDirectory(prefix="i-have-adhd-pi-") as agent_dir:
         env = build_isolated_env(agent_dir)
         subprocess.run(

--- a/scripts/generate_rules.mjs
+++ b/scripts/generate_rules.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// Regenerates skills/i-have-adhd/rules.md from skills/i-have-adhd/SKILL.md.
+//
+// This is the one place that parses the SKILL.md frontmatter. The four
+// injection adapters (hooks/always-on.mjs, hooks/always-on.sh,
+// hooks/always-on.ps1, extensions/i-have-adhd.ts) just read the generated
+// rules.md verbatim, so a frontmatter-parsing bug only needs fixing here.
+//
+// Run after editing SKILL.md. CI fails if the checked-in rules.md drifts
+// from this script's output (.github/workflows/rules-sync-check.yml).
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const skillPath = path.join(scriptDir, "..", "skills", "i-have-adhd", "SKILL.md");
+const rulesPath = path.join(scriptDir, "..", "skills", "i-have-adhd", "rules.md");
+
+// Strip a leading YAML frontmatter block (--- ... --- at the very top of
+// file). An unterminated fence is not frontmatter, so the whole file is
+// kept unless the closing delimiter exists.
+function stripFrontmatter(content) {
+  return content
+    .replace(/^---[^\S\r\n]*\r?\n[\s\S]*?\r?\n---[^\S\r\n]*(?:\r?\n|$)/, "")
+    .replace(/(?:\r?\n)+$/, "");
+}
+
+const source = fs.readFileSync(skillPath, "utf8");
+const rules = stripFrontmatter(source);
+
+if (!rules) {
+  throw new Error(`Stripping frontmatter left no content: ${skillPath}`);
+}
+
+fs.writeFileSync(rulesPath, `${rules}\n`);

--- a/scripts/generate_rules.mjs
+++ b/scripts/generate_rules.mjs
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 // Regenerates skills/i-have-adhd/rules.md from skills/i-have-adhd/SKILL.md.
 //
-// This is the one place that parses the SKILL.md frontmatter. The four
-// injection adapters (hooks/always-on.mjs, hooks/always-on.sh,
-// hooks/always-on.ps1, extensions/i-have-adhd.ts) just read the generated
-// rules.md verbatim, so a frontmatter-parsing bug only needs fixing here.
+// This is the one place that parses the SKILL.md frontmatter. The five
+// entry points (hooks/always-on.mjs, hooks/always-on.sh,
+// hooks/always-on.ps1, extensions/i-have-adhd.ts,
+// scripts/render_gemini_command.py) just read the generated rules.md
+// verbatim, so a frontmatter-parsing bug only needs fixing here.
 //
-// Run after editing SKILL.md. CI fails if the checked-in rules.md drifts
-// from this script's output (.github/workflows/rules-sync-check.yml).
+// Run after editing SKILL.md. Pass --check to verify the checked-in
+// rules.md matches without writing it, the same --check convention
+// scripts/render_gemini_command.py and scripts/render_manifests.py use.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -33,4 +35,20 @@ if (!rules) {
   throw new Error(`Stripping frontmatter left no content: ${skillPath}`);
 }
 
-fs.writeFileSync(rulesPath, `${rules}\n`);
+const rendered = `${rules}\n`;
+
+if (process.argv.slice(2).includes("--check")) {
+  const current = fs.existsSync(rulesPath)
+    ? fs.readFileSync(rulesPath, "utf8")
+    : null;
+  if (current !== rendered) {
+    console.error(
+      `${rulesPath} is out of sync with ${skillPath}.\n` +
+        "Run: node scripts/generate_rules.mjs",
+    );
+    process.exit(1);
+  }
+  console.log("rules.md matches SKILL.md");
+} else {
+  fs.writeFileSync(rulesPath, rendered);
+}

--- a/scripts/render_gemini_command.py
+++ b/scripts/render_gemini_command.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Render skills/i-have-adhd/agents/gemini.toml from the canonical SKILL.md ruleset.
+
+Gemini CLI custom commands have no import mechanism, so the ruleset has to be
+inlined into the command's prompt string. That inlining used to be a hand
+paraphrase, which drifted from SKILL.md (missing rules, missing overrides,
+missing the pre-send check). This script derives the prompt from SKILL.md
+instead, so the two can only go out of sync if this file isn't re-run.
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_PATH = ROOT / "skills" / "i-have-adhd" / "SKILL.md"
+GEMINI_TOML_PATH = ROOT / "skills" / "i-have-adhd" / "agents" / "gemini.toml"
+
+# Shown in Gemini CLI's command list; not part of the ruleset, so it is not
+# derived from SKILL.md's frontmatter description.
+GEMINI_DESCRIPTION = "ADHD-friendly output: action-first, numbered steps, no preamble or closers."
+
+HEADER = """# Gemini CLI custom command for i-have-adhd.
+# Install: copy to ~/.gemini/commands/i-have-adhd.toml, then type /i-have-adhd.
+# Self-contained so it works as a global command from any directory.
+#
+# Generated from skills/i-have-adhd/SKILL.md by scripts/render_gemini_command.py.
+# Do not hand-edit the prompt below: edit SKILL.md, then run
+#   python3 scripts/render_gemini_command.py
+"""
+
+
+def ruleset_body() -> str:
+    text = SKILL_PATH.read_text(encoding="utf8")
+    if not text.startswith("---\n"):
+        raise ValueError(f"{SKILL_PATH} is missing YAML frontmatter")
+
+    _, _, rest = text.partition("---\n")
+    frontmatter, separator, body = rest.partition("\n---\n")
+    if not separator:
+        raise ValueError(f"{SKILL_PATH} frontmatter is not closed with '---'")
+
+    body = body.strip("\n")
+    if '"""' in body:
+        raise ValueError(f'{SKILL_PATH} contains a TOML-breaking """ sequence')
+    return body
+
+
+def render() -> str:
+    prompt = f"{ruleset_body()}\n\n{{{{args}}}}"
+    rendered = "\n".join(
+        [
+            HEADER,
+            f'description = "{GEMINI_DESCRIPTION}"',
+            "",
+            'prompt = """',
+            prompt,
+            '"""',
+            "",
+        ]
+    )
+    tomllib.loads(rendered)  # fail loudly if the ruleset broke TOML syntax
+    return rendered
+
+
+def main() -> int:
+    rendered = render()
+
+    if "--check" in sys.argv[1:]:
+        current = (
+            GEMINI_TOML_PATH.read_text(encoding="utf8")
+            if GEMINI_TOML_PATH.exists()
+            else None
+        )
+        if current != rendered:
+            print(
+                f"{GEMINI_TOML_PATH} is out of sync with {SKILL_PATH}.\n"
+                "Run: python3 scripts/render_gemini_command.py",
+                file=sys.stderr,
+            )
+            return 1
+        print("gemini.toml matches SKILL.md")
+        return 0
+
+    GEMINI_TOML_PATH.write_text(rendered, encoding="utf8")
+    print(f"Wrote {GEMINI_TOML_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_gemini_command.py
+++ b/scripts/render_gemini_command.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Render skills/i-have-adhd/agents/gemini.toml from the canonical SKILL.md ruleset.
+"""Render skills/i-have-adhd/agents/gemini.toml from the canonical ruleset.
 
 Gemini CLI custom commands have no import mechanism, so the ruleset has to be
 inlined into the command's prompt string. That inlining used to be a hand
 paraphrase, which drifted from SKILL.md (missing rules, missing overrides,
-missing the pre-send check). This script derives the prompt from SKILL.md
-instead, so the two can only go out of sync if this file isn't re-run.
+missing the pre-send check). This script reads rules.md instead - the same
+parsed copy of the ruleset the other entry points read - so the two
+can only go out of sync if this file isn't re-run.
 """
 
 from __future__ import annotations
@@ -15,7 +16,7 @@ import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-SKILL_PATH = ROOT / "skills" / "i-have-adhd" / "SKILL.md"
+RULES_PATH = ROOT / "skills" / "i-have-adhd" / "rules.md"
 GEMINI_TOML_PATH = ROOT / "skills" / "i-have-adhd" / "agents" / "gemini.toml"
 
 # Shown in Gemini CLI's command list; not part of the ruleset, so it is not
@@ -26,25 +27,18 @@ HEADER = """# Gemini CLI custom command for i-have-adhd.
 # Install: copy to ~/.gemini/commands/i-have-adhd.toml, then type /i-have-adhd.
 # Self-contained so it works as a global command from any directory.
 #
-# Generated from skills/i-have-adhd/SKILL.md by scripts/render_gemini_command.py.
-# Do not hand-edit the prompt below: edit SKILL.md, then run
+# Generated from skills/i-have-adhd/rules.md by scripts/render_gemini_command.py.
+# Do not hand-edit the prompt below: edit SKILL.md, run
+#   node scripts/generate_rules.mjs
+# then
 #   python3 scripts/render_gemini_command.py
 """
 
 
 def ruleset_body() -> str:
-    text = SKILL_PATH.read_text(encoding="utf8")
-    if not text.startswith("---\n"):
-        raise ValueError(f"{SKILL_PATH} is missing YAML frontmatter")
-
-    _, _, rest = text.partition("---\n")
-    frontmatter, separator, body = rest.partition("\n---\n")
-    if not separator:
-        raise ValueError(f"{SKILL_PATH} frontmatter is not closed with '---'")
-
-    body = body.strip("\n")
-    if '"""' in body:
-        raise ValueError(f'{SKILL_PATH} contains a TOML-breaking """ sequence')
+    body = RULES_PATH.read_text(encoding="utf8").strip("\n")
+    if "'''" in body:
+        raise ValueError(f"{RULES_PATH} contains a TOML-breaking ''' sequence")
     return body
 
 
@@ -55,9 +49,13 @@ def render() -> str:
             HEADER,
             f'description = "{GEMINI_DESCRIPTION}"',
             "",
-            'prompt = """',
+            # A literal (single-quoted) multi-line string: TOML processes
+            # no escapes inside one, so a backslash in the ruleset survives
+            # verbatim. A basic ("""-quoted) string would read a \\t in
+            # SKILL.md as a tab character.
+            "prompt = '''",
             prompt,
-            '"""',
+            "'''",
             "",
         ]
     )
@@ -76,12 +74,12 @@ def main() -> int:
         )
         if current != rendered:
             print(
-                f"{GEMINI_TOML_PATH} is out of sync with {SKILL_PATH}.\n"
+                f"{GEMINI_TOML_PATH} is out of sync with {RULES_PATH}.\n"
                 "Run: python3 scripts/render_gemini_command.py",
                 file=sys.stderr,
             )
             return 1
-        print("gemini.toml matches SKILL.md")
+        print("gemini.toml matches rules.md")
         return 0
 
     GEMINI_TOML_PATH.write_text(rendered, encoding="utf8")

--- a/scripts/render_manifests.py
+++ b/scripts/render_manifests.py
@@ -68,7 +68,9 @@ TARGETS: list[tuple[str, list[tuple[str, str]]]] = [
             ("author", "author"),
             ("homepage", "homepage"),
             ("license", "license"),
+            ("repository", "homepage"),
             ("interface.developerName", "author.name"),
+            ("interface.websiteURL", "homepage"),
         ],
     ),
     (
@@ -110,7 +112,11 @@ def _set(data: Any, dotted_path: str, value: Any) -> None:
         key: Any = int(segment) if segment.isdigit() else segment
         node = node[key]
     last: Any = int(segments[-1]) if segments[-1].isdigit() else segments[-1]
-    if last not in node if isinstance(node, dict) else last >= len(node):
+    if isinstance(node, dict):
+        missing = last not in node
+    else:
+        missing = last >= len(node)
+    if missing:
         raise KeyError(
             f"{dotted_path!r} does not exist yet; add the field by hand once, "
             "then let this script keep it in sync"

--- a/scripts/render_manifests.py
+++ b/scripts/render_manifests.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Project package.json's shared fields into the other harness manifests.
+
+name, version, description, license, homepage, and author used to be
+hand-typed separately in up to nine files (package.json, kimi.plugin.json,
+plugin.json, .claude-plugin/plugin.json, .claude-plugin/marketplace.json,
+.codex-plugin/plugin.json, .agents/plugins/marketplace.json,
+gemini-extension.json, qwen-extension.json), so a version bump meant six
+edits and nothing caught the ones that got missed.
+
+package.json is now the canonical source. Every other manifest keeps its
+own harness-specific fields (interface blocks, capabilities, per-harness
+description text, ...) but has its copies of the shared fields rendered
+from package.json. Do not hand-edit the mapped fields below: edit
+package.json, then run
+    python3 scripts/render_manifests.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_PATH = ROOT / "package.json"
+
+# (file relative to ROOT, [(dotted path in that file, dotted path in source)])
+TARGETS: list[tuple[str, list[tuple[str, str]]]] = [
+    (
+        "kimi.plugin.json",
+        [
+            ("name", "name"),
+            ("version", "version"),
+            ("description", "description"),
+            ("license", "license"),
+            ("homepage", "homepage"),
+        ],
+    ),
+    (
+        "plugin.json",
+        [
+            ("name", "name"),
+        ],
+    ),
+    (
+        ".claude-plugin/plugin.json",
+        [
+            ("name", "name"),
+            ("version", "version"),
+            ("author", "author"),
+        ],
+    ),
+    (
+        ".claude-plugin/marketplace.json",
+        [
+            ("name", "name"),
+            ("owner.name", "author.name"),
+            ("plugins.0.name", "name"),
+        ],
+    ),
+    (
+        ".codex-plugin/plugin.json",
+        [
+            ("name", "name"),
+            ("version", "version"),
+            ("author", "author"),
+            ("homepage", "homepage"),
+            ("license", "license"),
+            ("interface.developerName", "author.name"),
+        ],
+    ),
+    (
+        ".agents/plugins/marketplace.json",
+        [
+            ("name", "name"),
+            ("plugins.0.name", "name"),
+        ],
+    ),
+    (
+        "gemini-extension.json",
+        [
+            ("name", "name"),
+            ("version", "version"),
+        ],
+    ),
+    (
+        "qwen-extension.json",
+        [
+            ("name", "name"),
+            ("version", "version"),
+        ],
+    ),
+]
+
+
+def _get(data: Any, dotted_path: str) -> Any:
+    node = data
+    for segment in dotted_path.split("."):
+        key: Any = int(segment) if segment.isdigit() else segment
+        node = node[key]
+    return node
+
+
+def _set(data: Any, dotted_path: str, value: Any) -> None:
+    segments = dotted_path.split(".")
+    node = data
+    for segment in segments[:-1]:
+        key: Any = int(segment) if segment.isdigit() else segment
+        node = node[key]
+    last: Any = int(segments[-1]) if segments[-1].isdigit() else segments[-1]
+    if last not in node if isinstance(node, dict) else last >= len(node):
+        raise KeyError(
+            f"{dotted_path!r} does not exist yet; add the field by hand once, "
+            "then let this script keep it in sync"
+        )
+    node[last] = value
+
+
+def render_target(source: dict[str, Any], relative_path: str, mapping: list[tuple[str, str]]) -> str:
+    target_path = ROOT / relative_path
+    data = json.loads(target_path.read_text(encoding="utf8"))
+    for target_field, source_field in mapping:
+        _set(data, target_field, _get(source, source_field))
+    return json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+
+
+def main() -> int:
+    source = json.loads(SOURCE_PATH.read_text(encoding="utf8"))
+    check = "--check" in sys.argv[1:]
+    out_of_sync: list[str] = []
+
+    for relative_path, mapping in TARGETS:
+        rendered = render_target(source, relative_path, mapping)
+        target_path = ROOT / relative_path
+
+        if check:
+            current = target_path.read_text(encoding="utf8")
+            if current != rendered:
+                out_of_sync.append(relative_path)
+            continue
+
+        target_path.write_text(rendered, encoding="utf8")
+        print(f"Wrote {relative_path}")
+
+    if check:
+        if out_of_sync:
+            print(
+                "Out of sync with package.json: " + ", ".join(out_of_sync) + "\n"
+                "Run: python3 scripts/render_manifests.py",
+                file=sys.stderr,
+            )
+            return 1
+        print("All manifests match package.json")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import abc
 import argparse
 import json
 import shlex
@@ -10,6 +11,7 @@ import subprocess
 import sys
 import time
 from collections import Counter, defaultdict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -206,7 +208,115 @@ def _parse_response(output: str, response_format: str) -> tuple[str, dict[str, A
     raise ValueError(f"Unsupported response format: {response_format}")
 
 
-def run_evaluations(args: argparse.Namespace) -> int:
+@dataclass
+class Response:
+    text: str
+    usage: dict[str, Any]
+    cost_usd: float | None
+
+
+class Runner(abc.ABC):
+    """Invokes one provider's CLI recipe in isolation from the operator's own configuration."""
+
+    @abc.abstractmethod
+    def invoke(self, prompt: str, *, remaining_budget: float) -> Response:
+        """Run one trial and return its response, raising if the trial ultimately fails."""
+
+
+class SubprocessRunner(Runner):
+    """Shells out to a runner's command, hiding budget-flag injection, retries, backoff, and format parsing."""
+
+    def __init__(self, config: dict[str, Any], *, retries: int, allow_unmetered: bool):
+        self._command = list(config["command"])
+        self._budget_flag = config.get("budget_flag")
+        self._response_format = config.get("response_format", "text")
+        self._retries = retries
+        self._allow_unmetered = allow_unmetered
+        if self._response_format != "claude-json" and not allow_unmetered:
+            raise RuntimeError(
+                f"The {self._response_format!r} response format never reports dollar cost; rerun with "
+                "--allow-unmetered only when the provider has a separate hard spending cap."
+            )
+
+    def invoke(self, prompt: str, *, remaining_budget: float) -> Response:
+        invocation = [*self._command]
+        if self._budget_flag:
+            invocation.extend([self._budget_flag, f"{remaining_budget:.4f}"])
+        invocation.append(prompt)
+
+        completed = None
+        for attempt in range(self._retries + 1):
+            completed = subprocess.run(
+                invocation, check=False, capture_output=True, text=True, cwd=ROOT
+            )
+            if completed.returncode == 0:
+                break
+            if attempt < self._retries:
+                time.sleep(min(2**attempt, 5))
+        assert completed is not None
+
+        if completed.returncode:
+            detail = completed.stderr.strip() or completed.stdout.strip()
+            if completed.stdout.strip():
+                try:
+                    parsed_text, _, _ = _parse_response(completed.stdout, self._response_format)
+                    detail = parsed_text or detail
+                except (ValueError, json.JSONDecodeError):
+                    pass
+            raise RuntimeError(
+                f"Runner failed after {self._retries + 1} attempts "
+                f"({shlex.join(invocation[:-1])}):\n{detail}"
+            )
+
+        text, usage, cost = _parse_response(completed.stdout, self._response_format)
+        if cost is None and not self._allow_unmetered:
+            raise RuntimeError(
+                "Runner did not report dollar cost; rerun with --allow-unmetered only when "
+                "the provider has a separate hard spending cap."
+            )
+        return Response(text=text, usage=usage, cost_usd=cost)
+
+
+class Ledger:
+    """Tracks which rows are already recorded and how much budget remains, and appends new rows durably."""
+
+    def __init__(self, path: Path, *, condition: str, runner: str, budget_usd: float):
+        if budget_usd <= 0 or budget_usd > 25:
+            raise ValueError("--budget-usd must be greater than 0 and no more than 25")
+        prior_rows = read_jsonl(path) if path.exists() else []
+        self._done = completed_keys(prior_rows)
+        self._budget = budget_usd
+        self._spent = sum(
+            float(row.get("cost_usd") or 0)
+            for row in prior_rows
+            if row.get("condition") == condition and row.get("runner") == runner
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._file = path.open("a", encoding="utf-8")
+
+    def __enter__(self) -> "Ledger":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self._file.close()
+
+    def done(self, key: tuple[str, int, str, str]) -> bool:
+        return key in self._done
+
+    def remaining(self) -> float:
+        return self._budget - self._spent
+
+    @property
+    def spent(self) -> float:
+        return self._spent
+
+    def record(self, row: dict[str, Any]) -> None:
+        self._spent += float(row.get("cost_usd") or 0)
+        self._file.write(json.dumps(row, ensure_ascii=False) + "\n")
+        self._file.flush()
+
+
+def run_evaluations(args: argparse.Namespace, runner: Runner | None = None) -> int:
     cases = load_cases(args.cases)
     errors = validate_cases(cases)
     if errors:
@@ -214,92 +324,43 @@ def run_evaluations(args: argparse.Namespace) -> int:
     unknown = sorted(set(args.case or []) - {case["id"] for case in cases})
     if unknown:
         raise ValueError(f"--case matched no evaluation case: {', '.join(unknown)}")
-    config = json.loads(args.runner_config.read_text(encoding="utf-8"))
-    runner = config[args.runner]
-    command = list(runner["command"])
-    response_format = runner.get("response_format", "text")
-    if response_format != "claude-json" and not args.allow_unmetered:
-        raise RuntimeError(
-            f"The {response_format!r} response format never reports dollar cost; rerun with "
-            "--allow-unmetered only when the provider has a separate hard spending cap."
+
+    if runner is None:
+        config = json.loads(args.runner_config.read_text(encoding="utf-8"))
+        runner = SubprocessRunner(
+            config[args.runner], retries=args.retries, allow_unmetered=args.allow_unmetered
         )
-    reported_cost = 0.0
-    prior_rows = read_jsonl(args.output) if args.output.exists() else []
-    done = completed_keys(prior_rows)
-    reported_cost = sum(
-        float(row.get("cost_usd") or 0)
-        for row in prior_rows
-        if row.get("condition") == args.condition and row.get("runner") == args.runner
-    )
 
-    if args.budget_usd <= 0 or args.budget_usd > 25:
-        raise ValueError("--budget-usd must be greater than 0 and no more than 25")
-
-    args.output.parent.mkdir(parents=True, exist_ok=True)
-    with args.output.open("a", encoding="utf-8") as destination:
+    with Ledger(
+        args.output, condition=args.condition, runner=args.runner, budget_usd=args.budget_usd
+    ) as ledger:
         for trial in range(1, args.trials + 1):
             for case in cases:
                 if args.case and case["id"] not in args.case:
                     continue
                 key = (case["id"], trial, args.condition, args.runner)
-                if key in done:
+                if ledger.done(key):
                     print(f"skip completed {args.condition} trial {trial}: {case['id']}")
                     continue
-                remaining = args.budget_usd - reported_cost
+                remaining = ledger.remaining()
                 if remaining <= 0:
                     print("Budget exhausted; stopping.", file=sys.stderr)
                     return 2
                 prompt = _condition_prompt(case["prompt"], args.condition, args.condition_skill)
-                invocation = [*command]
-                if runner.get("budget_flag"):
-                    invocation.extend([runner["budget_flag"], f"{remaining:.4f}"])
-                invocation.append(prompt)
-                completed = None
-                for attempt in range(args.retries + 1):
-                    completed = subprocess.run(
-                        invocation,
-                        check=False,
-                        capture_output=True,
-                        text=True,
-                        cwd=ROOT,
-                    )
-                    if completed.returncode == 0:
-                        break
-                    if attempt < args.retries:
-                        time.sleep(min(2**attempt, 5))
-                assert completed is not None
-                if completed.returncode:
-                    detail = completed.stderr.strip() or completed.stdout.strip()
-                    if completed.stdout.strip():
-                        try:
-                            parsed_text, _, _ = _parse_response(completed.stdout, response_format)
-                            detail = parsed_text or detail
-                        except (ValueError, json.JSONDecodeError):
-                            pass
-                    raise RuntimeError(
-                        f"Runner failed after {args.retries + 1} attempts "
-                        f"({shlex.join(invocation[:-1])}):\n{detail}"
-                    )
-                text, usage, cost = _parse_response(completed.stdout, response_format)
-                if cost is None and not args.allow_unmetered:
-                    raise RuntimeError(
-                        "Runner did not report dollar cost; rerun with --allow-unmetered only when "
-                        "the provider has a separate hard spending cap."
-                    )
-                reported_cost += float(cost or 0)
-                row = {
-                    "case_id": case["id"],
-                    "trial": trial,
-                    "condition": args.condition,
-                    "runner": args.runner,
-                    "response": text,
-                    "usage": usage,
-                    "cost_usd": cost,
-                }
-                destination.write(json.dumps(row, ensure_ascii=False) + "\n")
-                destination.flush()
+                response = runner.invoke(prompt, remaining_budget=remaining)
+                ledger.record(
+                    {
+                        "case_id": case["id"],
+                        "trial": trial,
+                        "condition": args.condition,
+                        "runner": args.runner,
+                        "response": response.text,
+                        "usage": response.usage,
+                        "cost_usd": response.cost_usd,
+                    }
+                )
                 print(f"{args.condition} trial {trial}: {case['id']}")
-    print(f"Reported cost: ${reported_cost:.4f}")
+        print(f"Reported cost: ${ledger.spent:.4f}")
     return 0
 
 

--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -215,6 +215,23 @@ class Response:
     cost_usd: float | None
 
 
+@dataclass(frozen=True)
+class RunConfig:
+    """Typed parameters for one evaluation-condition run, decoupled from argparse."""
+
+    cases: Path
+    runner_config: Path
+    runner: str
+    condition: str
+    condition_skill: Path | None
+    case: list[str] | None
+    trials: int
+    retries: int
+    budget_usd: float
+    allow_unmetered: bool
+    output: Path
+
+
 class Runner(abc.ABC):
     """Invokes one provider's CLI recipe in isolation from the operator's own configuration."""
 
@@ -316,50 +333,52 @@ class Ledger:
         self._file.flush()
 
 
-def run_evaluations(args: argparse.Namespace, runner: Runner | None = None) -> int:
-    cases = load_cases(args.cases)
+def run_evaluations(config: RunConfig, runner: Runner | None = None) -> int:
+    cases = load_cases(config.cases)
     errors = validate_cases(cases)
     if errors:
         raise ValueError("\n".join(errors))
-    unknown = sorted(set(args.case or []) - {case["id"] for case in cases})
+    unknown = sorted(set(config.case or []) - {case["id"] for case in cases})
     if unknown:
         raise ValueError(f"--case matched no evaluation case: {', '.join(unknown)}")
 
     if runner is None:
-        config = json.loads(args.runner_config.read_text(encoding="utf-8"))
+        runner_config = json.loads(config.runner_config.read_text(encoding="utf-8"))
         runner = SubprocessRunner(
-            config[args.runner], retries=args.retries, allow_unmetered=args.allow_unmetered
+            runner_config[config.runner],
+            retries=config.retries,
+            allow_unmetered=config.allow_unmetered,
         )
 
     with Ledger(
-        args.output, condition=args.condition, runner=args.runner, budget_usd=args.budget_usd
+        config.output, condition=config.condition, runner=config.runner, budget_usd=config.budget_usd
     ) as ledger:
-        for trial in range(1, args.trials + 1):
+        for trial in range(1, config.trials + 1):
             for case in cases:
-                if args.case and case["id"] not in args.case:
+                if config.case and case["id"] not in config.case:
                     continue
-                key = (case["id"], trial, args.condition, args.runner)
+                key = (case["id"], trial, config.condition, config.runner)
                 if ledger.done(key):
-                    print(f"skip completed {args.condition} trial {trial}: {case['id']}")
+                    print(f"skip completed {config.condition} trial {trial}: {case['id']}")
                     continue
                 remaining = ledger.remaining()
                 if remaining <= 0:
                     print("Budget exhausted; stopping.", file=sys.stderr)
                     return 2
-                prompt = _condition_prompt(case["prompt"], args.condition, args.condition_skill)
+                prompt = _condition_prompt(case["prompt"], config.condition, config.condition_skill)
                 response = runner.invoke(prompt, remaining_budget=remaining)
                 ledger.record(
                     {
                         "case_id": case["id"],
                         "trial": trial,
-                        "condition": args.condition,
-                        "runner": args.runner,
+                        "condition": config.condition,
+                        "runner": config.runner,
                         "response": response.text,
                         "usage": response.usage,
                         "cost_usd": response.cost_usd,
                     }
                 )
-                print(f"{args.condition} trial {trial}: {case['id']}")
+                print(f"{config.condition} trial {trial}: {case['id']}")
         print(f"Reported cost: ${ledger.spent:.4f}")
     return 0
 
@@ -391,15 +410,28 @@ def _build_parser() -> argparse.ArgumentParser:
     run.add_argument("--budget-usd", type=float, default=25.0)
     run.add_argument("--allow-unmetered", action="store_true")
     run.add_argument("--output", type=Path, required=True)
-    run.set_defaults(handler=run_evaluations)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
-    if hasattr(args, "handler"):
-        return args.handler(args)
+    if args.command == "run":
+        return run_evaluations(
+            RunConfig(
+                cases=args.cases,
+                runner_config=args.runner_config,
+                runner=args.runner,
+                condition=args.condition,
+                condition_skill=args.condition_skill,
+                case=args.case,
+                trials=args.trials,
+                retries=args.retries,
+                budget_usd=args.budget_usd,
+                allow_unmetered=args.allow_unmetered,
+                output=args.output,
+            )
+        )
     if args.command == "validate":
         errors = validate_cases(load_cases(args.cases))
         if errors:

--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -333,7 +333,23 @@ class Ledger:
         self._file.flush()
 
 
-def run_evaluations(config: RunConfig, runner: Runner | None = None) -> int:
+def build_runner(config: RunConfig) -> Runner:
+    """Build the provider runner the config describes.
+
+    Kept as its own function so the wiring - which JSON file, which runner
+    entry, which flags - is visible at the call site instead of hiding behind
+    a default parameter in run_evaluations.
+    """
+
+    runner_config = json.loads(config.runner_config.read_text(encoding="utf-8"))
+    return SubprocessRunner(
+        runner_config[config.runner],
+        retries=config.retries,
+        allow_unmetered=config.allow_unmetered,
+    )
+
+
+def run_evaluations(config: RunConfig, runner: Runner) -> int:
     cases = load_cases(config.cases)
     errors = validate_cases(cases)
     if errors:
@@ -341,14 +357,6 @@ def run_evaluations(config: RunConfig, runner: Runner | None = None) -> int:
     unknown = sorted(set(config.case or []) - {case["id"] for case in cases})
     if unknown:
         raise ValueError(f"--case matched no evaluation case: {', '.join(unknown)}")
-
-    if runner is None:
-        runner_config = json.loads(config.runner_config.read_text(encoding="utf-8"))
-        runner = SubprocessRunner(
-            runner_config[config.runner],
-            retries=config.retries,
-            allow_unmetered=config.allow_unmetered,
-        )
 
     with Ledger(
         config.output, condition=config.condition, runner=config.runner, budget_usd=config.budget_usd
@@ -417,21 +425,20 @@ def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
     if args.command == "run":
-        return run_evaluations(
-            RunConfig(
-                cases=args.cases,
-                runner_config=args.runner_config,
-                runner=args.runner,
-                condition=args.condition,
-                condition_skill=args.condition_skill,
-                case=args.case,
-                trials=args.trials,
-                retries=args.retries,
-                budget_usd=args.budget_usd,
-                allow_unmetered=args.allow_unmetered,
-                output=args.output,
-            )
+        config = RunConfig(
+            cases=args.cases,
+            runner_config=args.runner_config,
+            runner=args.runner,
+            condition=args.condition,
+            condition_skill=args.condition_skill,
+            case=args.case,
+            trials=args.trials,
+            retries=args.retries,
+            budget_usd=args.budget_usd,
+            allow_unmetered=args.allow_unmetered,
+            output=args.output,
         )
+        return run_evaluations(config, build_runner(config))
     if args.command == "validate":
         errors = validate_cases(load_cases(args.cases))
         if errors:

--- a/skills/i-have-adhd/agents/gemini.toml
+++ b/skills/i-have-adhd/agents/gemini.toml
@@ -1,24 +1,144 @@
 # Gemini CLI custom command for i-have-adhd.
 # Install: copy to ~/.gemini/commands/i-have-adhd.toml, then type /i-have-adhd.
 # Self-contained so it works as a global command from any directory.
+#
+# Generated from skills/i-have-adhd/SKILL.md by scripts/render_gemini_command.py.
+# Do not hand-edit the prompt below: edit SKILL.md, then run
+#   python3 scripts/render_gemini_command.py
 
 description = "ADHD-friendly output: action-first, numbered steps, no preamble or closers."
 
 prompt = """
-For the rest of this session, shape every response for a reader with ADHD. The output is not just brief; it is shaped so an ADHD brain can act on it.
+# i-have-adhd
 
-1. Lead with the next action. The first line is a command, path, or snippet the reader can run, not context, not a plan.
-2. Number multi-step work. One bounded action per step; no step with two "and then"s.
-3. End with one concrete next action the reader can do in under two minutes.
-4. Suppress tangents. Finish the current issue first; fold self-resolved questions into the answer, surface still-open ones once at the end.
-5. Restate state every turn ("Step 3 of 5 done: schema updated. Next: backfill the column.").
-6. Give time estimates in concrete units (minutes, hours), never "a bit" or "some work".
-7. Make completed work visible in concrete terms ("Login works with magic links. Try: npm run dev").
-8. State errors matter-of-factly: cause, then fix. No "uh oh" or "there seems to be a problem".
-9. Cap lists at 5 items; split into now/later or must/nice-to-have if longer.
-10. No preamble, no recap, no closing pleasantries. Start with the answer; end when it is done.
+The reader has ADHD. Output is not just brief. It is shaped so an ADHD brain can act on it.
 
-Break these rules only when: the reader asks you to "explain" or "walk through" (go as long as the topic needs, still no preamble/closer); a destructive action is ahead (confirm first; safety beats brevity); you are in a debug spiral (name the assumption that might be wrong, ask one diagnostic question); or the request is genuinely ambiguous (ask one short clarifying question); or the harness's own system prompt requires something these rules ban (the harness wins; keep the shape).
+## Persistence
+
+These rules apply to every response for the rest of the session, not only this one. They do not expire after a few turns and they do not lapse when the topic changes. If you are unsure whether they still apply, they do.
+
+Turn them off only when the reader says "stop adhd mode" or "normal mode". Confirm in one line, then return to your default style.
+
+## What ADHD changes about reading
+
+Five facts drive every rule below:
+
+1. Working memory is small. Anything not on screen is forgotten. Do not ask the reader to "keep in mind X."
+2. Knowing the answer is not doing the answer. The friction between "got it" and "done it" is where work dies.
+3. Starting is the hardest step. The first action must be obvious, small, and doable now.
+4. Time estimates feel uniform. "A bit of work" and "a few hours" register the same. Vague estimates fail.
+5. Dopamine is scarce. Visible progress matters. Buried wins do not register.
+
+## Rules
+
+### 1. Lead with the next action
+
+The first line is something the reader can do. Not context. Not a plan. The action.
+
+Bad: "Let's think about this. Your auth flow has a few moving pieces..."
+Good: "Run `npm install jsonwebtoken`, then edit `src/auth.ts:42`."
+
+If the answer is a command, path, or snippet, it goes first. Prose comes after, if at all.
+
+### 2. Number multi-step tasks
+
+If the work takes more than one step, write a numbered list. Each step is one bounded action. No step contains "and then" twice.
+
+Use the fewest steps that still work. Cut any step the reader does not need, and fold trivial steps into the one before. A short path finished beats a complete path abandoned.
+
+Bad: "First open the file, find the function, swap it out, then run the tests."
+
+Good:
+```
+1. Open `src/auth.ts`
+2. Replace `verifyToken` (lines 42 to 58) with the snippet below
+3. Run `npm test -- auth.spec.ts`
+```
+
+### 3. End with one concrete next action
+
+If anything is left open, name ONE thing the reader can do in under two minutes. Even "open the file" counts.
+
+Bad: "Hope that helps. Let me know if you want to dig deeper."
+Good: "Next: run `npm test` and paste the first failing line."
+
+### 4. Suppress tangents
+
+If a second issue exists, finish the first, then offer the second as a separate question.
+
+Bad: "Here's the fix. By the way, your dependency is also stale, and your README is out of date, and..."
+Good: "Here's the fix. Separately: there is also a stale dependency. Want me to handle that next?"
+
+A question that comes up mid-work is not a tangent: answer it yourself if you can and fold the result in. If it still needs the reader, surface it once, at the end.
+
+### 5. Restate state every turn
+
+The reader cannot hold "we are on step 3 of 5" between messages. Restate it.
+
+Bad: "Done. Ready for the next part?"
+Good: "Step 3 of 5 done: schema updated. Next: backfill the new column. Run the script?"
+
+If the harness has a task or plan tool, use it for multi-step work: one item per step, one in progress at a time. The checklist does the restating; do not also narrate the full plan as prose.
+
+### 6. Give specific time estimates
+
+Vague estimates fail. Ballpark in concrete units.
+
+Bad: "This will take some work."
+Good: "About 15 minutes if tests already cover this. An afternoon if not."
+
+### 7. Make completed work visible
+
+Show what now works, in concrete terms. Do not bury wins in a recap.
+
+Bad: "I've made some changes to the auth flow. Among other things..."
+Good: "Login now works with magic links. Try: `npm run dev`, open `/login`."
+
+### 8. Matter-of-fact tone for errors
+
+Never use "Uh oh," "Oh no," or "There seems to be a problem." State cause and fix.
+
+Bad: "Uh oh, the test is failing. There seems to be an issue..."
+Good: "Test fails at `auth.spec.ts:42`: expected 200, got 401. Cause: missing auth header. Fix: add `Authorization: Bearer ${token}` to the request."
+
+### 9. Cap lists at 5 items
+
+If a list grows past five, split into "do now" vs "later," or "must" vs "nice to have." Five items ranked beats ten unranked.
+
+### 10. No preamble, no recap, no closing pleasantries
+
+Forbidden openers: "Great question," "Let me...", "I'll...", "Sure!", "Looking at your...", "To answer your question..."
+
+Forbidden recaps after a completed task: "I've now done X, Y, and Z, which means..."
+
+Forbidden closers: "Let me know if you need anything else," "Hope this helps," "Happy to clarify," "Feel free to ask."
+
+Start with the answer. End when the answer is done.
+
+## When to break the rules
+
+Override the defaults when:
+
+1. User asks to "explain" or "walk me through." Explain fully. Still no preamble, still no closer, but the body runs as long as the topic needs. Add headers so the reader can skim back.
+2. Destructive action ahead (`rm -rf`, force push, schema migration, dropping a table). Confirm before acting. Safety wins over brevity.
+3. Debug spiral. If the last three turns have been "still broken," stop iterating on code. Name the assumption that might be wrong. Ask one diagnostic question.
+4. Real ambiguity in the request. One short clarifying question beats guessing and rewriting.
+5. A rule fights the task. When a rule would delete the answer itself, the task wins; the shape stays. Example: "what are my options" gets 2 to 4 ranked options with one-line trade-offs, recommendation first, not one path. The options are the answer.
+6. A rule fights the harness. Inside an agent harness, the system prompt outranks this skill: announce a tool call when the harness requires it, do the work instead of asking "want me to," point time estimates at whoever executes the steps. Same principle as 5: the constraint wins, the shape stays.
+
+## Pre-send check
+
+Before sending, delete:
+
+1. The first sentence if it announces what you are about to do.
+2. The last sentence if it asks "anything else?" or recaps what just happened.
+3. Any "by the way" sidebar.
+4. Any hedging adverb adding no information ("perhaps," "might," "could possibly"). Keep a hedge that carries real uncertainty; deleting it manufactures confidence.
+5. Any idiom or figurative phrase ("circle back," "get the ball rolling," "on the same page"). Replace with the literal action.
+
+Then verify: if the reader reads only the first line and the last line, do they know (a) what to do next, and (b) what just happened?
+
+If yes, send.
 
 {{args}}
 """

--- a/skills/i-have-adhd/agents/gemini.toml
+++ b/skills/i-have-adhd/agents/gemini.toml
@@ -2,13 +2,15 @@
 # Install: copy to ~/.gemini/commands/i-have-adhd.toml, then type /i-have-adhd.
 # Self-contained so it works as a global command from any directory.
 #
-# Generated from skills/i-have-adhd/SKILL.md by scripts/render_gemini_command.py.
-# Do not hand-edit the prompt below: edit SKILL.md, then run
+# Generated from skills/i-have-adhd/rules.md by scripts/render_gemini_command.py.
+# Do not hand-edit the prompt below: edit SKILL.md, run
+#   node scripts/generate_rules.mjs
+# then
 #   python3 scripts/render_gemini_command.py
 
 description = "ADHD-friendly output: action-first, numbered steps, no preamble or closers."
 
-prompt = """
+prompt = '''
 # i-have-adhd
 
 The reader has ADHD. Output is not just brief. It is shaped so an ADHD brain can act on it.
@@ -141,4 +143,4 @@ Then verify: if the reader reads only the first line and the last line, do they 
 If yes, send.
 
 {{args}}
-"""
+'''

--- a/skills/i-have-adhd/rules.md
+++ b/skills/i-have-adhd/rules.md
@@ -1,0 +1,131 @@
+
+# i-have-adhd
+
+The reader has ADHD. Output is not just brief. It is shaped so an ADHD brain can act on it.
+
+## Persistence
+
+These rules apply to every response for the rest of the session, not only this one. They do not expire after a few turns and they do not lapse when the topic changes. If you are unsure whether they still apply, they do.
+
+Turn them off only when the reader says "stop adhd mode" or "normal mode". Confirm in one line, then return to your default style.
+
+## What ADHD changes about reading
+
+Five facts drive every rule below:
+
+1. Working memory is small. Anything not on screen is forgotten. Do not ask the reader to "keep in mind X."
+2. Knowing the answer is not doing the answer. The friction between "got it" and "done it" is where work dies.
+3. Starting is the hardest step. The first action must be obvious, small, and doable now.
+4. Time estimates feel uniform. "A bit of work" and "a few hours" register the same. Vague estimates fail.
+5. Dopamine is scarce. Visible progress matters. Buried wins do not register.
+
+## Rules
+
+### 1. Lead with the next action
+
+The first line is something the reader can do. Not context. Not a plan. The action.
+
+Bad: "Let's think about this. Your auth flow has a few moving pieces..."
+Good: "Run `npm install jsonwebtoken`, then edit `src/auth.ts:42`."
+
+If the answer is a command, path, or snippet, it goes first. Prose comes after, if at all.
+
+### 2. Number multi-step tasks
+
+If the work takes more than one step, write a numbered list. Each step is one bounded action. No step contains "and then" twice.
+
+Use the fewest steps that still work. Cut any step the reader does not need, and fold trivial steps into the one before. A short path finished beats a complete path abandoned.
+
+Bad: "First open the file, find the function, swap it out, then run the tests."
+
+Good:
+```
+1. Open `src/auth.ts`
+2. Replace `verifyToken` (lines 42 to 58) with the snippet below
+3. Run `npm test -- auth.spec.ts`
+```
+
+### 3. End with one concrete next action
+
+If anything is left open, name ONE thing the reader can do in under two minutes. Even "open the file" counts.
+
+Bad: "Hope that helps. Let me know if you want to dig deeper."
+Good: "Next: run `npm test` and paste the first failing line."
+
+### 4. Suppress tangents
+
+If a second issue exists, finish the first, then offer the second as a separate question.
+
+Bad: "Here's the fix. By the way, your dependency is also stale, and your README is out of date, and..."
+Good: "Here's the fix. Separately: there is also a stale dependency. Want me to handle that next?"
+
+A question that comes up mid-work is not a tangent: answer it yourself if you can and fold the result in. If it still needs the reader, surface it once, at the end.
+
+### 5. Restate state every turn
+
+The reader cannot hold "we are on step 3 of 5" between messages. Restate it.
+
+Bad: "Done. Ready for the next part?"
+Good: "Step 3 of 5 done: schema updated. Next: backfill the new column. Run the script?"
+
+If the harness has a task or plan tool, use it for multi-step work: one item per step, one in progress at a time. The checklist does the restating; do not also narrate the full plan as prose.
+
+### 6. Give specific time estimates
+
+Vague estimates fail. Ballpark in concrete units.
+
+Bad: "This will take some work."
+Good: "About 15 minutes if tests already cover this. An afternoon if not."
+
+### 7. Make completed work visible
+
+Show what now works, in concrete terms. Do not bury wins in a recap.
+
+Bad: "I've made some changes to the auth flow. Among other things..."
+Good: "Login now works with magic links. Try: `npm run dev`, open `/login`."
+
+### 8. Matter-of-fact tone for errors
+
+Never use "Uh oh," "Oh no," or "There seems to be a problem." State cause and fix.
+
+Bad: "Uh oh, the test is failing. There seems to be an issue..."
+Good: "Test fails at `auth.spec.ts:42`: expected 200, got 401. Cause: missing auth header. Fix: add `Authorization: Bearer ${token}` to the request."
+
+### 9. Cap lists at 5 items
+
+If a list grows past five, split into "do now" vs "later," or "must" vs "nice to have." Five items ranked beats ten unranked.
+
+### 10. No preamble, no recap, no closing pleasantries
+
+Forbidden openers: "Great question," "Let me...", "I'll...", "Sure!", "Looking at your...", "To answer your question..."
+
+Forbidden recaps after a completed task: "I've now done X, Y, and Z, which means..."
+
+Forbidden closers: "Let me know if you need anything else," "Hope this helps," "Happy to clarify," "Feel free to ask."
+
+Start with the answer. End when the answer is done.
+
+## When to break the rules
+
+Override the defaults when:
+
+1. User asks to "explain" or "walk me through." Explain fully. Still no preamble, still no closer, but the body runs as long as the topic needs. Add headers so the reader can skim back.
+2. Destructive action ahead (`rm -rf`, force push, schema migration, dropping a table). Confirm before acting. Safety wins over brevity.
+3. Debug spiral. If the last three turns have been "still broken," stop iterating on code. Name the assumption that might be wrong. Ask one diagnostic question.
+4. Real ambiguity in the request. One short clarifying question beats guessing and rewriting.
+5. A rule fights the task. When a rule would delete the answer itself, the task wins; the shape stays. Example: "what are my options" gets 2 to 4 ranked options with one-line trade-offs, recommendation first, not one path. The options are the answer.
+6. A rule fights the harness. Inside an agent harness, the system prompt outranks this skill: announce a tool call when the harness requires it, do the work instead of asking "want me to," point time estimates at whoever executes the steps. Same principle as 5: the constraint wins, the shape stays.
+
+## Pre-send check
+
+Before sending, delete:
+
+1. The first sentence if it announces what you are about to do.
+2. The last sentence if it asks "anything else?" or recaps what just happened.
+3. Any "by the way" sidebar.
+4. Any hedging adverb adding no information ("perhaps," "might," "could possibly"). Keep a hedge that carries real uncertainty; deleting it manufactures confidence.
+5. Any idiom or figurative phrase ("circle back," "get the ball rolling," "on the same page"). Replace with the literal action.
+
+Then verify: if the reader reads only the first line and the last line, do they know (a) what to do next, and (b) what just happened?
+
+If yes, send.

--- a/tests/state-machine.test.ts
+++ b/tests/state-machine.test.ts
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  AdhdMode,
+  DISABLED_MESSAGE_TYPE,
+  RULES_MESSAGE_TYPE,
+  STATE_ENTRY_TYPE,
+  isStopPhrase,
+  latestEnabledState,
+  rulesActiveInContext,
+  type Entry,
+  type Effect,
+} from "../extensions/state-machine.ts";
+
+const rulesEntry = (): Entry => ({
+  type: "custom_message",
+  customType: RULES_MESSAGE_TYPE,
+});
+const disabledEntry = (): Entry => ({
+  type: "custom_message",
+  customType: DISABLED_MESSAGE_TYPE,
+});
+const stateEntry = (enabled: boolean): Entry => ({
+  type: "custom",
+  customType: STATE_ENTRY_TYPE,
+  data: { enabled },
+});
+const kinds = (effects: Effect[]): string[] => effects.map((effect) => effect.kind);
+
+test("latestEnabledState: no state entries means no saved mode", () => {
+  assert.equal(latestEnabledState([]), undefined);
+  assert.equal(
+    latestEnabledState([
+      { type: "user", text: "hi" },
+      rulesEntry(),
+    ]),
+    undefined,
+  );
+});
+
+test("latestEnabledState: newest persisted mode wins", () => {
+  const entries = [stateEntry(true), stateEntry(false), stateEntry(true)];
+  assert.equal(latestEnabledState(entries), true);
+});
+
+test("latestEnabledState: non-boolean payloads are ignored", () => {
+  const entries = [
+    { type: "custom", customType: STATE_ENTRY_TYPE, data: { enabled: "yes" } },
+    { type: "custom", customType: STATE_ENTRY_TYPE, data: {} },
+    stateEntry(true),
+  ];
+  assert.equal(latestEnabledState(entries), true);
+});
+
+test("rulesActiveInContext: no markers means the ruleset is not live", () => {
+  assert.equal(rulesActiveInContext([]), false);
+  assert.equal(
+    rulesActiveInContext([
+      { type: "user", text: "hello" },
+      { type: "custom_message", customType: "someone-elses-message" },
+    ]),
+    false,
+  );
+});
+
+test("rulesActiveInContext: the newest marker wins", () => {
+  const entries = [
+    rulesEntry(),
+    disabledEntry(),
+    rulesEntry(),
+    disabledEntry(),
+    rulesEntry(),
+  ];
+  assert.equal(rulesActiveInContext(entries), true);
+
+  assert.equal(rulesActiveInContext([rulesEntry(), disabledEntry()]), false);
+});
+
+test("isStopPhrase: only the exact phrases count", () => {
+  assert.equal(isStopPhrase("stop adhd mode"), true);
+  assert.equal(isStopPhrase("normal mode"), true);
+  assert.equal(isStopPhrase("stop adhd"), false);
+  assert.equal(isStopPhrase("normal"), false);
+  assert.equal(isStopPhrase(""), false);
+});
+
+test("AdhdMode.restore: saved mode overrides the default", () => {
+  const mode = new AdhdMode();
+  const effects = mode.restore(false, true, true);
+
+  assert.equal(mode.enabled, false);
+  assert.deepEqual(effects, [
+    { kind: "set-status", enabled: false },
+    { kind: "inject-disabled" },
+  ]);
+});
+
+test("AdhdMode.restore: restoring disabled with no live rules injects nothing", () => {
+  const mode = new AdhdMode();
+  const effects = mode.restore(false, true, false);
+
+  assert.equal(mode.enabled, false);
+  assert.deepEqual(kinds(effects), ["set-status"]);
+});
+
+test("AdhdMode.restore: no saved mode falls back to the default", () => {
+  const mode = new AdhdMode();
+  const effects = mode.restore(undefined, true, false);
+
+  assert.equal(mode.enabled, true);
+  assert.deepEqual(effects, [
+    { kind: "set-status", enabled: true },
+    { kind: "inject-rules" },
+  ]);
+});
+
+test("AdhdMode.restore: never re-injects rules that are already live", () => {
+  const mode = new AdhdMode();
+  const effects = mode.restore(undefined, true, true);
+
+  assert.equal(mode.enabled, true);
+  assert.deepEqual(kinds(effects), ["set-status"]);
+});
+
+test("AdhdMode.sync: enabled without live rules injects them", () => {
+  const mode = new AdhdMode();
+  mode.enabled = true;
+
+  assert.deepEqual(kinds(mode.sync(false)), ["set-status", "inject-rules"]);
+});
+
+test("AdhdMode.sync: enabled with live rules changes nothing", () => {
+  const mode = new AdhdMode();
+  mode.enabled = true;
+
+  assert.deepEqual(kinds(mode.sync(true)), ["set-status"]);
+});
+
+test("AdhdMode.sync: disabled with stale live rules sends the cancel notice", () => {
+  const mode = new AdhdMode();
+  mode.enabled = false;
+
+  assert.deepEqual(kinds(mode.sync(true)), ["set-status", "inject-disabled"]);
+});
+
+test("AdhdMode.setEnabled: turning on persists, notifies, and injects", () => {
+  const mode = new AdhdMode();
+  mode.enabled = false;
+
+  const effects = mode.setEnabled(true, false);
+
+  assert.equal(mode.enabled, true);
+  assert.deepEqual(effects, [
+    { kind: "persist-state", enabled: true },
+    { kind: "set-status", enabled: true },
+    { kind: "inject-rules" },
+    { kind: "notify", message: "ADHD mode enabled" },
+  ]);
+});
+
+test("AdhdMode.setEnabled: turning off cancels live rules", () => {
+  const mode = new AdhdMode();
+  mode.enabled = true;
+
+  const effects = mode.setEnabled(false, true);
+
+  assert.equal(mode.enabled, false);
+  assert.deepEqual(effects, [
+    { kind: "persist-state", enabled: false },
+    { kind: "set-status", enabled: false },
+    { kind: "inject-disabled" },
+    { kind: "notify", message: "ADHD mode disabled" },
+  ]);
+});
+
+test("in-process walkthrough mirrors the RPC smoke test's session", () => {
+  // The same scenario scripts/check_pi_extension.py drives over RPC, asserted
+  // here in milliseconds: --adhd restore, toggle off, toggle on, alias, stop
+  // phrase. This is the fast seam the RPC test cannot provide.
+  const context: Entry[] = [];
+  const mode = new AdhdMode();
+
+  // Faithful mini-adapter: turn effects into the entries the real pi
+  // harness would append, the way extensions/i-have-adhd.ts does.
+  const apply = (effects: Effect[]): void => {
+    for (const effect of effects) {
+      if (effect.kind === "inject-rules") context.push(rulesEntry());
+      else if (effect.kind === "inject-disabled") context.push(disabledEntry());
+      else if (effect.kind === "persist-state") context.push(stateEntry(effect.enabled));
+    }
+  };
+
+  const restore = (defaultEnabled: boolean) => {
+    apply(mode.restore(latestEnabledState(context), defaultEnabled, rulesActiveInContext(context)));
+  };
+  const toggle = (next: boolean) => {
+    apply(mode.setEnabled(next, rulesActiveInContext(context)));
+  };
+
+  restore(true);
+  assert.equal(mode.enabled, true);
+  assert.equal(rulesActiveInContext(context), true);
+
+  toggle(false);
+  assert.equal(mode.enabled, false);
+  assert.equal(rulesActiveInContext(context), false);
+
+  toggle(true);
+  assert.equal(rulesActiveInContext(context), true);
+
+  toggle(false); // stop phrase path
+  assert.equal(mode.enabled, false);
+  assert.equal(rulesActiveInContext(context), false);
+});

--- a/tests/test_always_on_hooks.py
+++ b/tests/test_always_on_hooks.py
@@ -91,6 +91,31 @@ class AlwaysOnHookTest(unittest.TestCase):
 
         self.assertEqual(1, len(set(outputs.values())))
 
+    def test_banner_comes_from_banner_file_verbatim(self):
+        # The banner is single-sourced in hooks/banner.txt with a
+        # {{FLAG_PATH}} placeholder. Each runtime must splice its own flag
+        # path into that file's text verbatim rather than embedding its own
+        # copy, so the test reads the real banner file and asserts the
+        # output equals it (with the token replaced).
+        (self.config_dir / ".i-have-adhd-always").touch()
+        banner_template = (
+            (ROOT / "hooks" / "banner.txt").read_text().rstrip("\r\n")
+        )
+        expected_flag = (self.config_dir / ".i-have-adhd-always").as_posix()
+        expected_banner = banner_template.replace("{{FLAG_PATH}}", expected_flag)
+
+        for name, command in self.runtimes():
+            with self.subTest(runtime=name):
+                result = self.run_hook(command)
+                self.assertEqual(0, result.returncode)
+                self.assertEqual("", result.stderr)
+                self.assertTrue(
+                    self.normalize(result.stdout).startswith(
+                        expected_banner + "\n\n"
+                    ),
+                    f"{name} did not emit the banner.txt text verbatim",
+                )
+
     def test_hook_is_silent_when_rules_file_is_missing(self):
         (self.plugin_root / "skills" / "i-have-adhd" / "rules.md").unlink()
         (self.config_dir / ".i-have-adhd-always").touch()

--- a/tests/test_always_on_hooks.py
+++ b/tests/test_always_on_hooks.py
@@ -70,9 +70,13 @@ class AlwaysOnHookTest(unittest.TestCase):
                 self.assertEqual("", result.stdout)
                 self.assertEqual("", result.stderr)
 
-    def test_runtimes_strip_frontmatter_with_trailing_whitespace(self):
-        skill_path = self.plugin_root / "skills" / "i-have-adhd" / "SKILL.md"
-        skill_path.write_text("---   \nname: fixture\n--- \t\nFixture body.\n")
+    def test_runtimes_emit_rules_file_verbatim(self):
+        # Frontmatter parsing happens once, at build time, in
+        # scripts/generate_rules.mjs (see tests/test_generate_rules.py). The
+        # hooks themselves just read rules.md and print it, so this only
+        # checks that all three runtimes do that identically.
+        rules_path = self.plugin_root / "skills" / "i-have-adhd" / "rules.md"
+        rules_path.write_text("Fixture body.\n\nSecond paragraph.\n")
         (self.config_dir / ".i-have-adhd-always").touch()
         outputs = {}
 
@@ -82,31 +86,21 @@ class AlwaysOnHookTest(unittest.TestCase):
                 self.assertEqual(0, result.returncode)
                 self.assertEqual("", result.stderr)
                 normalized = self.normalize(result.stdout)
-                self.assertNotIn("name: fixture", normalized)
-                self.assertIn("\n\nFixture body.\n", normalized)
+                self.assertIn("\n\nFixture body.\n\nSecond paragraph.\n", normalized)
                 outputs[name] = normalized
 
         self.assertEqual(1, len(set(outputs.values())))
 
-    def test_runtimes_keep_content_when_frontmatter_is_unclosed(self):
-        # An opening --- with no closing delimiter is not frontmatter. Keeping
-        # the whole file beats injecting a banner that promises "the ruleset
-        # below" followed by nothing.
-        skill_path = self.plugin_root / "skills" / "i-have-adhd" / "SKILL.md"
-        skill_path.write_text("---\nname: fixture\nFixture body, fence never closed.\n")
+    def test_hook_is_silent_when_rules_file_is_missing(self):
+        (self.plugin_root / "skills" / "i-have-adhd" / "rules.md").unlink()
         (self.config_dir / ".i-have-adhd-always").touch()
-        outputs = {}
 
         for name, command in self.runtimes():
             with self.subTest(runtime=name):
                 result = self.run_hook(command)
                 self.assertEqual(0, result.returncode)
+                self.assertEqual("", result.stdout)
                 self.assertEqual("", result.stderr)
-                normalized = self.normalize(result.stdout)
-                self.assertIn("Fixture body, fence never closed.", normalized)
-                outputs[name] = normalized
-
-        self.assertEqual(1, len(set(outputs.values())))
 
     def test_hook_uses_shell_free_node_exec_form(self):
         config = json.loads((ROOT / "hooks" / "hooks.json").read_text())

--- a/tests/test_generate_rules.py
+++ b/tests/test_generate_rules.py
@@ -1,0 +1,73 @@
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GENERATOR = ROOT / "scripts" / "generate_rules.mjs"
+
+
+class GenerateRulesTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+
+        self.script_dir = Path(self.temp_dir.name) / "scripts"
+        self.script_dir.mkdir()
+        shutil.copy(GENERATOR, self.script_dir / "generate_rules.mjs")
+
+        self.skill_dir = Path(self.temp_dir.name) / "skills" / "i-have-adhd"
+        self.skill_dir.mkdir(parents=True)
+
+    def run_generator(self, skill_content):
+        (self.skill_dir / "SKILL.md").write_text(skill_content)
+        result = subprocess.run(
+            ["node", str(self.script_dir / "generate_rules.mjs")],
+            cwd=self.temp_dir.name,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        return (self.skill_dir / "rules.md").read_text()
+
+    def test_strips_frontmatter_with_trailing_whitespace(self):
+        rules = self.run_generator("---   \nname: fixture\n--- \t\nFixture body.\n")
+
+        self.assertNotIn("name: fixture", rules)
+        self.assertEqual("Fixture body.\n", rules)
+
+    def test_keeps_content_when_frontmatter_is_unclosed(self):
+        # An opening --- with no closing delimiter is not frontmatter. Keeping
+        # the whole file beats generating a rules.md that promises "the
+        # ruleset below" (via the hook banner) followed by nothing.
+        rules = self.run_generator(
+            "---\nname: fixture\nFixture body, fence never closed.\n"
+        )
+
+        self.assertIn("Fixture body, fence never closed.", rules)
+
+    def test_fails_when_stripping_leaves_nothing(self):
+        result = subprocess.run(
+            ["node", str(self.script_dir / "generate_rules.mjs")],
+            cwd=self.temp_dir.name,
+            capture_output=True,
+            text=True,
+        )
+        # No SKILL.md at all: readFileSync throws before the emptiness check.
+        self.assertNotEqual(0, result.returncode)
+
+        (self.skill_dir / "SKILL.md").write_text("---\nname: fixture\n---\n")
+        result = subprocess.run(
+            ["node", str(self.script_dir / "generate_rules.mjs")],
+            cwd=self.temp_dir.name,
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("Stripping frontmatter left no content", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -1,0 +1,28 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import render_manifests  # noqa: E402
+
+
+class ManifestSyncTest(unittest.TestCase):
+    def test_manifests_match_package_json(self):
+        source = json.loads(render_manifests.SOURCE_PATH.read_text(encoding="utf8"))
+
+        for relative_path, mapping in render_manifests.TARGETS:
+            rendered = render_manifests.render_target(source, relative_path, mapping)
+            current = (ROOT / relative_path).read_text(encoding="utf8")
+            self.assertEqual(
+                current,
+                rendered,
+                f"{relative_path} is out of sync with package.json; "
+                "run python3 scripts/render_manifests.py",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -23,6 +23,22 @@ class ManifestSyncTest(unittest.TestCase):
                 "run python3 scripts/render_manifests.py",
             )
 
+    def test_package_json_declares_the_pi_package(self):
+        """Pi discovers the extension and skills through package.json's `pi` block.
+
+        Asserted here rather than in scripts/check_pi_extension.py so it runs
+        without the pi CLI installed, leaving that script a pure smoke test.
+        """
+        package = json.loads(render_manifests.SOURCE_PATH.read_text(encoding="utf8"))
+
+        self.assertEqual(
+            {
+                "extensions": ["./extensions/i-have-adhd.ts"],
+                "skills": ["./skills"],
+            },
+            package.get("pi"),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -160,6 +160,66 @@ class EvaluationHarnessTest(unittest.TestCase):
             self.assertEqual(0, run_evals.run_evaluations(args))
             self.assertTrue(marker.exists())
 
+    def test_run_evaluations_skips_completed_and_records_new_via_recorded_runner(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            output = tmp_path / "out.jsonl"
+            output.write_text(
+                json.dumps(
+                    {
+                        "case_id": "direct-answer",
+                        "trial": 1,
+                        "condition": "baseline",
+                        "runner": "recorded",
+                        "response": "prior",
+                        "usage": {},
+                        "cost_usd": 0.5,
+                    }
+                )
+                + "\n"
+            )
+            args = argparse.Namespace(
+                cases=ROOT / "evals" / "cases.jsonl",
+                runner_config=None,
+                runner="recorded",
+                condition="baseline",
+                condition_skill=None,
+                case=["direct-answer", "casual-message"],
+                trials=1,
+                retries=0,
+                budget_usd=1.0,
+                allow_unmetered=True,
+                output=output,
+            )
+            runner = self._RecordedRunner(
+                [run_evals.Response(text="hi", usage={}, cost_usd=0.1)]
+            )
+
+            result = run_evals.run_evaluations(args, runner=runner)
+
+            self.assertEqual(0, result)
+            self.assertEqual(1, len(runner.calls))
+            prompt, remaining_budget = runner.calls[0]
+            self.assertEqual("Thanks, that solved it.", prompt)
+            self.assertAlmostEqual(0.5, remaining_budget)
+
+            rows = run_evals.read_jsonl(output)
+            self.assertEqual(2, len(rows))
+            self.assertEqual("prior", rows[0]["response"])
+            self.assertEqual("casual-message", rows[1]["case_id"])
+            self.assertEqual("hi", rows[1]["response"])
+
+    class _RecordedRunner(run_evals.Runner):
+        """A canned Runner for tests: no subprocess, just plays back responses in order."""
+
+        def __init__(self, responses):
+            self._responses = list(responses)
+            self.calls = []
+
+        def invoke(self, prompt, *, remaining_budget):
+            self.calls.append((prompt, remaining_budget))
+            return self._responses.pop(0)
+
     def test_completed_keys_support_resuming_partial_runs(self):
         rows = [
             {

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -152,13 +152,14 @@ class EvaluationHarnessTest(unittest.TestCase):
             )
 
             with self.assertRaisesRegex(RuntimeError, "never reports dollar cost"):
-                run_evals.run_evaluations(config)
+                run_evals.build_runner(config)
 
             self.assertFalse(marker.exists(), "runner was invoked before the rejection")
             self.assertFalse((tmp_path / "out.jsonl").exists())
 
             config = dataclasses.replace(config, allow_unmetered=True)
-            self.assertEqual(0, run_evals.run_evaluations(config))
+            runner = run_evals.build_runner(config)
+            self.assertEqual(0, run_evals.run_evaluations(config, runner))
             self.assertTrue(marker.exists())
 
     def test_run_evaluations_skips_completed_and_records_new_via_recorded_runner(self):

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -1,9 +1,10 @@
-import argparse
+import dataclasses
 import json
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -136,7 +137,7 @@ class EvaluationHarnessTest(unittest.TestCase):
                     }
                 )
             )
-            args = argparse.Namespace(
+            config = run_evals.RunConfig(
                 cases=ROOT / "evals" / "cases.jsonl",
                 runner_config=runner_config,
                 runner="stub",
@@ -151,13 +152,13 @@ class EvaluationHarnessTest(unittest.TestCase):
             )
 
             with self.assertRaisesRegex(RuntimeError, "never reports dollar cost"):
-                run_evals.run_evaluations(args)
+                run_evals.run_evaluations(config)
 
             self.assertFalse(marker.exists(), "runner was invoked before the rejection")
             self.assertFalse((tmp_path / "out.jsonl").exists())
 
-            args.allow_unmetered = True
-            self.assertEqual(0, run_evals.run_evaluations(args))
+            config = dataclasses.replace(config, allow_unmetered=True)
+            self.assertEqual(0, run_evals.run_evaluations(config))
             self.assertTrue(marker.exists())
 
     def test_run_evaluations_skips_completed_and_records_new_via_recorded_runner(self):
@@ -178,7 +179,7 @@ class EvaluationHarnessTest(unittest.TestCase):
                 )
                 + "\n"
             )
-            args = argparse.Namespace(
+            config = run_evals.RunConfig(
                 cases=ROOT / "evals" / "cases.jsonl",
                 runner_config=None,
                 runner="recorded",
@@ -195,7 +196,7 @@ class EvaluationHarnessTest(unittest.TestCase):
                 [run_evals.Response(text="hi", usage={}, cost_usd=0.1)]
             )
 
-            result = run_evals.run_evaluations(args, runner=runner)
+            result = run_evals.run_evaluations(config, runner=runner)
 
             self.assertEqual(0, result)
             self.assertEqual(1, len(runner.calls))
@@ -234,6 +235,107 @@ class EvaluationHarnessTest(unittest.TestCase):
             {("direct-answer", 1, "baseline", "claude")},
             run_evals.completed_keys(rows),
         )
+
+
+class ParseResponseTest(unittest.TestCase):
+    def test_extracts_claude_json_fields(self):
+        output = json.dumps({"result": "  hi  ", "usage": {"foo": 1}, "total_cost_usd": 0.02})
+
+        text, usage, cost = run_evals._parse_response(output, "claude-json")
+
+        self.assertEqual("hi", text)
+        self.assertEqual({"foo": 1}, usage)
+        self.assertEqual(0.02, cost)
+
+    def test_extracts_codex_jsonl_fields(self):
+        events = [
+            {"type": "item.completed", "item": {"type": "agent_message", "text": "  hello  "}},
+            {"type": "turn.completed", "usage": {"tokens": 42}},
+        ]
+        output = "\n".join(json.dumps(event) for event in events)
+
+        text, usage, cost = run_evals._parse_response(output, "codex-jsonl")
+
+        self.assertEqual("hello", text)
+        self.assertEqual({"tokens": 42}, usage)
+        self.assertIsNone(cost)
+
+    def test_codex_jsonl_ignores_incomplete_events(self):
+        events = [
+            {"type": "item.completed", "item": {"type": "reasoning", "text": "skip me"}},
+            {"type": "item.completed", "item": {"type": "agent_message", "text": "final"}},
+        ]
+        output = "\n".join(json.dumps(event) for event in events)
+
+        text, usage, cost = run_evals._parse_response(output, "codex-jsonl")
+
+        self.assertEqual("final", text)
+        self.assertEqual({}, usage)
+
+
+class SubprocessRunnerTest(unittest.TestCase):
+    """Exercises the runner directly instead of only through run_evaluations,
+    so retry/backoff and response parsing are covered without a live provider CLI."""
+
+    def test_retries_until_success_and_sleeps_with_backoff(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            counter = Path(tmp) / "attempts"
+            script = (
+                f'n=$(cat {counter} 2>/dev/null || echo 0); n=$((n + 1)); echo "$n" > {counter}; '
+                f'if [ "$n" -lt 3 ]; then exit 1; fi; '
+                'echo \'{"result": "ok", "total_cost_usd": 0.01}\''
+            )
+            runner = run_evals.SubprocessRunner(
+                {"command": ["sh", "-c", script], "response_format": "claude-json"},
+                retries=2,
+                allow_unmetered=False,
+            )
+
+            with mock.patch("run_evals.time.sleep") as sleep:
+                response = runner.invoke("prompt", remaining_budget=1.0)
+
+            self.assertEqual("ok", response.text)
+            self.assertEqual(0.01, response.cost_usd)
+            self.assertEqual(3, int(counter.read_text().strip()))
+            self.assertEqual([mock.call(1), mock.call(2)], sleep.call_args_list)
+
+    def test_raises_after_exhausting_retries(self):
+        runner = run_evals.SubprocessRunner(
+            {"command": ["sh", "-c", "echo boom 1>&2; exit 1"], "response_format": "text"},
+            retries=1,
+            allow_unmetered=True,
+        )
+
+        with mock.patch("run_evals.time.sleep") as sleep:
+            with self.assertRaisesRegex(RuntimeError, "failed after 2 attempts"):
+                runner.invoke("prompt", remaining_budget=1.0)
+
+        self.assertEqual(1, sleep.call_count)
+
+    def test_failure_detail_prefers_parsed_response_over_raw_stdout(self):
+        output = json.dumps({"result": "explained failure"})
+        runner = run_evals.SubprocessRunner(
+            {
+                "command": ["sh", "-c", f"echo '{output}'; exit 1"],
+                "response_format": "claude-json",
+            },
+            retries=0,
+            allow_unmetered=True,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "explained failure"):
+            runner.invoke("prompt", remaining_budget=1.0)
+
+    def test_raises_when_claude_json_omits_cost_and_unmetered_not_allowed(self):
+        output = json.dumps({"result": "ok"})
+        runner = run_evals.SubprocessRunner(
+            {"command": ["sh", "-c", f"echo '{output}'"], "response_format": "claude-json"},
+            retries=0,
+            allow_unmetered=False,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "did not report dollar cost"):
+            runner.invoke("prompt", remaining_budget=1.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 ## What

   Makes the multi-harness distribution of the ruleset reliable by removing
   hand-maintained duplicates and verifying every generated artifact in CI.

   ## Why

   The ruleset ships to five harnesses (Pi, Claude, Cursor, Gemini CLI, and
   always-on hooks) that each need the rules in a different shape. Those shapes
   used to be hand-written or hand-paraphrased, so they drifted from SKILL.md
   (missing rules, missing overrides, stale install docs).

   ## Changes

   - **Single source of truth**
     - `scripts/generate_rules.mjs`: the only place that parses SKILL.md
       frontmatter; regenerates `skills/i-have-adhd/rules.md` once instead of
       each adapter parsing it itself
     - `scripts/render_gemini_command.py`: renders `gemini.toml` from SKILL.md
       instead of a hand paraphrase that drifted
     - `scripts/render_manifests.py`: renders the plugin/marketplace manifests
       from `package.json` (shared fields no longer duplicated per harness)

   - **Sync + parity checks in CI** (new workflows)
     - `gemini-command-sync.yml`, `rules-sync-check.yml`, `manifest-sync.yml`:
       regenerate artifacts and fail if the committed copy is stale
     - `i18n-parity-check.yml`: INSTALL/README translations stay in sync with
       the canonical English docs
     - `unit-tests.yml`: the orphaned unit tests are now wired into CI

   - **Eval runner refactor**
     - `scripts/run_evals.py`: split `run_evaluations` into a `Runner` (runs
       evals) and a `Ledger` (records results), with unit tests covering both

   - **Docs**: INSTALL translations re-synced from the canonical source

   ## Testing

   - `node --test tests/state-machine.test.ts`
   - `pytest tests/` (run_evals, manifests, always-on hooks, rules generation)
   - CI now runs all of the above plus the generated-artifact parity checks