### PR TITLE
fix(pi): support oh-my-pi fork session manager API

### DIFF
--- a/extensions/i-have-adhd.ts
+++ b/extensions/i-have-adhd.ts
@@ -77,6 +77,52 @@ function getSavedState(ctx: ExtensionContext): boolean | undefined {
 }
 
 /**
+ * Entries or messages the model actually receives, carrying the custom-message
+ * markers the ruleset uses.
+ *
+ * Upstream Pi exposes `sessionManager.buildContextEntries()` — the session
+ * tree after the compaction transform, where custom messages appear as
+ * `{ type: "custom_message", customType, ... }`. The oh-my-pi fork
+ * (can1357/oh-my-pi) dropped that method; its session manager exposes
+ * `buildSessionContext()` instead, whose `.messages` carry custom messages as
+ * `{ role: "custom", customType, ... }`. Feature-detect so the extension runs
+ * on both.
+ */
+type CustomMessageLike = {
+  type?: string;
+  role?: string;
+  customType?: string;
+};
+
+function getContextEntries(ctx: ExtensionContext): readonly CustomMessageLike[] {
+  const sessionManager = ctx.sessionManager as unknown as {
+    buildContextEntries?: () => unknown;
+    buildSessionContext?: () => { messages?: readonly CustomMessageLike[] };
+  };
+
+  if (typeof sessionManager.buildContextEntries === "function") {
+    try {
+      const entries = sessionManager.buildContextEntries();
+      if (
+        entries != null &&
+        typeof (entries as { [Symbol.iterator]: unknown })[Symbol.iterator] ===
+          "function"
+      ) {
+        return entries as readonly CustomMessageLike[];
+      }
+    } catch {
+      // Fall through to buildSessionContext (a stub that throws, for example).
+    }
+  }
+
+  if (typeof sessionManager.buildSessionContext === "function") {
+    return sessionManager.buildSessionContext().messages ?? [];
+  }
+
+  return [];
+}
+
+/**
  * Whether the rules are still live in the context the model actually receives.
  *
  * Only the newest marker counts: a later "disabled" notice cancels an earlier
@@ -86,8 +132,8 @@ function getSavedState(ctx: ExtensionContext): boolean | undefined {
 function rulesAreInContext(ctx: ExtensionContext): boolean {
   let active = false;
 
-  for (const entry of ctx.sessionManager.buildContextEntries()) {
-    if (entry.type !== "custom_message") continue;
+  for (const entry of getContextEntries(ctx)) {
+    if (entry.type !== "custom_message" && entry.role !== "custom") continue;
 
     if (entry.customType === RULES_MESSAGE_TYPE) {
       active = true;


### PR DESCRIPTION
## Problem

On the [oh-my-pi](https://github.com/can1357/oh-my-pi) fork of Pi, loading this extension crashes at session start:

```
Extension ".../i-have-adhd/extensions/i-have-adhd.ts" error:
ctx.sessionManager.buildContextEntries is not a function.
```

The extension calls `ctx.sessionManager.buildContextEntries()` in `rulesAreInContext()` to check whether the ruleset is still live in the model context. Upstream Pi's session manager has that method, but the oh-my-pi fork reworked the session manager and **dropped it** — its equivalent is `buildSessionContext()`, which returns `{ messages, ... }` where custom messages appear as `{ role: "custom", customType, ... }` instead of tree entries `{ type: "custom_message", customType, ... }`.

## Fix

Feature-detect instead of assuming one API shape:

- `getContextEntries()` prefers `buildContextEntries()` when present (upstream Pi, unchanged behaviour), falls back to `buildSessionContext().messages` (oh-my-pi), and tolerates a broken/stub `buildContextEntries` by falling through.
- `rulesAreInContext()` now accepts both entry shapes (`type === "custom_message"` or `role === "custom"`), keying on `customType` as before.

Backward compatible: on upstream Pi nothing changes — the same method is called with the same result.

## Verification

- Typecheck: `tsc --noEmit` clean.
- Behaviour harness driving the real extension against both session-manager shapes (fork: no `buildContextEntries`; upstream: present): 32/32 checks pass — session start no longer throws, rules inject exactly once, resume doesn't duplicate, compaction re-injects, `stop adhd mode` appends the disabled notice after the rules, `--adhd` flag default works.
- Existing repo tests (`python3 -m unittest discover -s tests`): 13/13 pass (hooks unaffected).

Fixes #117
