### PR TITLE
docs(install): fix Hermes activation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -298,7 +298,7 @@ Exceptions: explain fully when asked to explain. Confirm before destructive acti
 hermes skills install ayghri/i-have-adhd/skills/i-have-adhd
 ```
 
-Type `/i-have-adhd`. The skill installs into `~/.hermes/skills/` and is exposed as a slash command at the next session start.
+The skill installs into `~/.hermes/skills/` and is auto-discovered at the next session start. Hermes has no `/i-have-adhd` slash command (unlike Claude Code or Pi) — activate it by asking the agent directly (e.g. "use i-have-adhd mode"), or it may load itself when the conversation matches its description. Turn it off with "stop adhd mode".
 
 Prefer to browse first? Add this repo as a skill source (a "tap"), then search and install:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -298,7 +298,7 @@ Exceptions: explain fully when asked to explain. Confirm before destructive acti
 hermes skills install ayghri/i-have-adhd/skills/i-have-adhd
 ```
 
-The skill installs into `~/.hermes/skills/` and is auto-discovered at the next session start. Hermes has no `/i-have-adhd` slash command (unlike Claude Code or Pi) — activate it by asking the agent directly (e.g. "use i-have-adhd mode"), or it may load itself when the conversation matches its description. Turn it off with "stop adhd mode".
+Type `/i-have-adhd`. Hermes registers every installed skill as a slash command, so the skill name is the command; the skill installs into `~/.hermes/skills/` and is available from the next session start (`/reload-skills` picks it up in the current session without a restart). You can also activate it in natural language ("use i-have-adhd mode"). It stays on until you say "stop adhd mode".
 
 Prefer to browse first? Add this repo as a skill source (a "tap"), then search and install:
 


### PR DESCRIPTION
**Problem**

The Hermes section of INSTALL.md tells users to "Type `/i-have-adhd`" and says the skill is "exposed as a slash command at the next session start". An earlier revision of this PR claimed that instruction was wrong — that Hermes has no per-skill slash-command registry. That claim was **incorrect**: Hermes does register every installed skill as a slash command (see the review discussion on #119).

**Fix**

Keep the slash-command instruction and make the activation path precise: the skill is registered as a slash command at the next session start, `/reload-skills` picks it up in an already-running session, and natural language ("use i-have-adhd mode") works as a secondary path. `stop adhd mode` turns it off.

**Verification**

- `website/docs/user-guide/cli.md` § "Skill Slash Commands" and `website/docs/guides/work-with-skills.md`: every installed skill in `~/.hermes/skills/` is registered as a slash command automatically
- `get_skill_commands()` (`agent/skill_commands.py`) returns 159 skill commands on a real install including `/i-have-adhd`; `hermes chat -q "/i-have-adhd <task>"` expands the skill and runs it
- Clean-`HERMES_HOME` repro of the exact command in this file: `hermes skills install ayghri/i-have-adhd/skills/i-have-adhd` registers exactly one skill command, `/i-have-adhd`
- No older-version caveat applies: dynamic skill slash commands landed 2026-02-28 (commit `8e0c48e6d2`) and are present in the earliest tagged release (`v0.2.0` / `v2026.3.12`)
- `disable-model-invocation: true` in the skill's frontmatter means explicit invocation is the sanctioned path, which is what the file now says

Supersedes the premise in #118.
