### PR TITLE
Support omp (@oh-my-pi/pi-coding-agent) session-context API

### DIFF
--- a/extensions/i-have-adhd.ts
+++ b/extensions/i-have-adhd.ts
@@ -86,12 +86,29 @@ function getSavedState(ctx: ExtensionContext): boolean | undefined {
 function rulesAreInContext(ctx: ExtensionContext): boolean {
   let active = false;
 
-  for (const entry of ctx.sessionManager.buildContextEntries()) {
-    if (entry.type !== "custom_message") continue;
+  // Upstream pi exposes buildContextEntries(); omp (@oh-my-pi/pi-coding-agent)
+  // names the compaction-aware equivalent buildSessionContext() and returns
+  // messages (role "custom") instead of entries (type "custom_message").
+  const sessionManager = ctx.sessionManager as {
+    buildContextEntries?: () => Array<{ type: string; customType?: string }>;
+    buildSessionContext?: () => {
+      messages: Array<{ role: string; customType?: string }>;
+    };
+  };
 
-    if (entry.customType === RULES_MESSAGE_TYPE) {
+  const markers =
+    typeof sessionManager.buildContextEntries === "function"
+      ? sessionManager
+          .buildContextEntries()
+          .filter((entry) => entry.type === "custom_message")
+      : sessionManager
+          .buildSessionContext!()
+          .messages.filter((message) => message.role === "custom");
+
+  for (const marker of markers) {
+    if (marker.customType === RULES_MESSAGE_TYPE) {
       active = true;
-    } else if (entry.customType === DISABLED_MESSAGE_TYPE) {
+    } else if (marker.customType === DISABLED_MESSAGE_TYPE) {
       active = false;
     }
   }


### PR DESCRIPTION
## Problem

Installing the plugin in [omp (Oh My Pi)](https://github.com/nicobailon/oh-my-pi) fails at extension load:

```
Extension ".../extensions/i-have-adhd.ts" error: ctx.sessionManager.buildContextEntries is not a function.
```

omp aliases `@earendil-works/pi-coding-agent` imports to its own compat shim, so everything else in the extension already works — but its fork renamed `sessionManager.buildContextEntries()` to `buildSessionContext()`, which returns `{ messages }` where custom messages have `role: "custom"` + `customType`, instead of entries with `type: "custom_message"`.

## Fix

Feature-detect the API in `rulesAreInContext()`:

- `buildContextEntries` present (upstream pi) → unchanged behavior
- otherwise (omp) → scan `buildSessionContext().messages` for `role: "custom"` markers

Both APIs are compaction-aware, so the "re-inject rules after compaction drops them" semantics are identical on both harnesses.

## Verification

- `python3 scripts/check_pi_extension.py` against a fresh `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`: **passed** (same as the `pi-load-check` workflow)
- omp v17.3.5: extension loads with no error; `--adhd` flag injects the ruleset and the status/toggle flow works