### PR TITLE
docs: refine Japanese translations for natural phrasing

### DIFF
--- a/.github/install/INSTALL.ja.md
+++ b/.github/install/INSTALL.ja.md
@@ -28,29 +28,29 @@ agy plugin install https://github.com/ayghri/i-have-adhd
 agy plugin uninstall i-have-adhd
 ```
 
-インストールしたまま無効にする場合は、`agy plugin disable i-have-adhd` を実行します。
+インストールしたまま無効化する場合：`agy plugin disable i-have-adhd`
 
 ### 常時有効（任意）
 
-`~/.gemini/GEMINI.md` に追加します：
+`~/.gemini/GEMINI.md` に追加：
 
 ```markdown
 ## 出力スタイル
 
-読み手には ADHD があります。すぐ行動に移せるよう、すべての回答を次のように構成してください：
+読み手はADHDです。すぐ行動に移せるよう、すべての回答を以下のように構成してください：
 
-1. 回答または次の行動から始める。コマンド、パス、スニペットを先に示す。
-2. 複数手順の作業には番号を付け、1 ステップにつき 1 つの明確な行動にする。
-3. 2 分以内にできる次の行動を 1 つ示して終える。
-4. 新しい問題を挙げる前に、現在の問題を終わらせる。
-5. 各ターンで進捗を言い直す（「5 ステップ中 3 ステップ完了」）。
-6. 所要時間は具体的な単位で示し、「少し」とは言わない。
-7. 変更後は、何が動くようになったかを示す。
-8. エラーは場所、原因、修正方法を淡々と示す。
-9. リストは最大 5 項目にする。
-10. 前置き、要約、締めの言葉を入れない。
+1. 答えや次に取るべき行動から始める：コマンド、パス、コードスニペットを最優先で提示する。
+2. 複数ステップの作業には番号を付ける（1ステップにつき明確な行動1つ）。
+3. 2分以内に完了できる具体的な次の行動を1つ提示して終える。
+4. 新しい論点を挙げる前に、現在の問題を解決して終わらせる。
+5. ターンごとに進捗を明記する（例: 「5ステップ中3ステップ完了」）。
+6. 所要時間は「少し」などの曖昧な表現を使わず、分単位などの具体的な数値で示す。
+7. 変更後は、何が動作するようになったかを目に見える形で示す。
+8. エラーは場所・原因・修正方法を淡々と伝える（大げさな表現は避ける）。
+9. リストは最大5項目までに抑える。
+10. 前置き、要約、締めの挨拶は入れない。
 
-例外：説明を求められた場合は十分に説明する。破壊的な操作の前には確認する。修正に 3 回失敗したら止まり、疑わしい前提を明示する。依頼が曖昧なら短い質問を 1 つする。
+例外規定：解説を求められた場合は十分に説明する。破壊的な操作を行う前には必ず確認を取る。修正に3回失敗した場合は一度停止し、前提条件のどこに誤りがあるかを指摘する。指示が曖昧な場合は短い質問を1つだけ行う。
 ```
 
 </details>
@@ -86,23 +86,23 @@ claude plugin uninstall i-have-adhd
 claude plugin marketplace remove i-have-adhd
 ```
 
-インストールしたまま無効にする場合は、`claude plugin disable i-have-adhd` を実行します。
+インストールしたまま無効化する場合：`claude plugin disable i-have-adhd`
 
 ### 常時有効（任意）
 
-`SessionStart` フックが各セッションの開始時に完全なルールセットを読み込むため、`/i-have-adhd` は不要です：
+`SessionStart` フックが毎セッション開始時に完全なルールセットを読み込むため、`/i-have-adhd` の入力が不要になります：
 
 ```bash
 touch ~/.claude/.i-have-adhd-always
 ```
 
-オンデマンドに戻す場合：
+手動呼び出し（オンデマンド）に戻す場合：
 
 ```bash
 rm ~/.claude/.i-have-adhd-always
 ```
 
-フックはフラグファイルが存在する場合のみ動作するため、プラグインをインストールしただけでは何も変わりません。設定ディレクトリを移動している場合は `$CLAUDE_CONFIG_DIR` が使われます。「stop adhd mode」と入力すれば、現在のセッションでは無効にできます。
+フックはフラグファイルが存在する場合にのみ動作するため、プラグインをインストールしただけでは動作に影響しません。設定ディレクトリを変更している場合は `$CLAUDE_CONFIG_DIR` が尊重されます。現在のセッションでのみ無効化したい場合は `stop adhd mode` と入力してください。
 
 </details>
 
@@ -117,7 +117,7 @@ codex plugin marketplace add ayghri/i-have-adhd --ref main
 codex plugin add i-have-adhd@i-have-adhd
 ```
 
-`$i-have-adhd` を明示的に入力して有効化します。Codex がこのスキルを自動で呼び出すことはありません。
+`$i-have-adhd` と明示的に入力してスキルを呼び出します。Codex が自動で有効化することはありません。
 
 ### 確認
 
@@ -142,25 +142,25 @@ codex plugin marketplace remove i-have-adhd
 
 ### 常時有効（任意）
 
-`~/.codex/AGENTS.md` に追加します：
+`~/.codex/AGENTS.md` に追加：
 
 ```markdown
 ## 出力スタイル
 
-読み手には ADHD があります。すぐ行動に移せるよう、すべての回答を次のように構成してください：
+読み手はADHDです。すぐ行動に移せるよう、すべての回答を以下のように構成してください：
 
-1. 回答または次の行動から始める。コマンド、パス、スニペットを先に示す。
-2. 複数手順の作業には番号を付け、1 ステップにつき 1 つの明確な行動にする。
-3. 2 分以内にできる次の行動を 1 つ示して終える。
-4. 新しい問題を挙げる前に、現在の問題を終わらせる。
-5. 各ターンで進捗を言い直す（「5 ステップ中 3 ステップ完了」）。
-6. 所要時間は具体的な単位で示し、「少し」とは言わない。
-7. 変更後は、何が動くようになったかを示す。
-8. エラーは場所、原因、修正方法を淡々と示す。
-9. リストは最大 5 項目にする。
-10. 前置き、要約、締めの言葉を入れない。
+1. 答えや次に取るべき行動から始める：コマンド、パス、コードスニペットを最優先で提示する。
+2. 複数ステップの作業には番号を付ける（1ステップにつき明確な行動1つ）。
+3. 2分以内に完了できる具体的な次の行動を1つ提示して終える。
+4. 新しい論点を挙げる前に、現在の問題を解決して終わらせる。
+5. ターンごとに進捗を明記する（例: 「5ステップ中3ステップ完了」）。
+6. 所要時間は「少し」などの曖昧な表現を使わず、分単位などの具体的な数値で示す。
+7. 変更後は、何が動作するようになったかを目に見える形で示す。
+8. エラーは場所・原因・修正方法を淡々と伝える（大げさな表現は避ける）。
+9. リストは最大5項目までに抑える。
+10. 前置き、要約、締めの挨拶は入れない。
 
-例外：説明を求められた場合は十分に説明する。破壊的な操作の前には確認する。修正に 3 回失敗したら止まり、疑わしい前提を明示する。依頼が曖昧なら短い質問を 1 つする。
+例外規定：解説を求められた場合は十分に説明する。破壊的な操作を行う前には必ず確認を取る。修正に3回失敗した場合は一度停止し、前提条件のどこに誤りがあるかを指摘する。指示が曖昧な場合は短い質問を1つだけ行う。
 ```
 
 </details>
@@ -168,9 +168,9 @@ codex plugin marketplace remove i-have-adhd
 <details>
 <summary><strong>Gemini CLI</strong></summary>
 
-Gemini CLI にはプラグインマーケットプレイスがないため、ネイティブな方法は 2 つあります。呼び出すまで無効な**カスタムコマンド**（オプトイン）と、インストール後は常時有効な**拡張機能**です。コマンド方式がこのスキルの既定の動作に合うため、すべてのセッションでルールを使いたい場合を除き、こちらを選んでください。
+Gemini CLI にはプラグインマーケットプレイスがないため、公式には2つの導入方法があります。**カスタムコマンド**（オプトイン形式。呼び出すまでオフ）または **拡張機能**（インストール後は常時有効）です。このスキルの標準的な動作に合わせるなら、コマンド方式が適しています。全セッションで常にルールを適用したい場合以外は、コマンド方式を選んでください。
 
-### インストール (command, opt-in)
+### インストール（コマンド方式、オプトイン）
 
 ```bash
 mkdir -p ~/.gemini/commands
@@ -178,54 +178,54 @@ curl -fsSL https://raw.githubusercontent.com/ayghri/i-have-adhd/main/skills/i-ha
   -o ~/.gemini/commands/i-have-adhd.toml
 ```
 
-新しいセッションを開始して `/i-have-adhd` と入力します。そのセッション中は有効のままです。
+新しいセッションを開始して `/i-have-adhd` と入力します。そのセッション中は有効な状態が続きます。
 
-### インストール (extension, always-on)
+### インストール（拡張機能方式、常時有効）
 
 ```bash
 gemini extensions install https://github.com/ayghri/i-have-adhd
 ```
 
-拡張機能は完全なスキルをインポートする `GEMINI.md` を読み込むため、最初のメッセージからルールが適用されます。`git` のインストールが必要です。
+拡張機能が `GEMINI.md` を読み込み、そこから完全なスキルがインポートされるため、最初のメッセージからルールが適用されます。`git` のインストールが必要です。
 
 ### 確認
 
 ```bash
 gemini extensions list          # 拡張機能方式
-ls ~/.gemini/commands           # command route: i-have-adhd.toml present
+ls ~/.gemini/commands           # コマンド方式: i-have-adhd.toml が存在することを確認
 ```
 
-または、セッションで `/` と入力し、`i-have-adhd` が一覧にあることを確認します。
+または、セッション内で `/` と入力し、一覧に `i-have-adhd` が表示されることを確認します。
 
 ### 更新
 
 ```bash
 gemini extensions update i-have-adhd    # 拡張機能方式
-# コマンド方式：上記の curl を再実行
+# コマンド方式: 上記の curl コマンドを再実行
 ```
 
 ### アンインストール
 
 ```bash
 gemini extensions uninstall i-have-adhd    # 拡張機能方式
-rm ~/.gemini/commands/i-have-adhd.toml     # command route
+rm ~/.gemini/commands/i-have-adhd.toml     # コマンド方式
 ```
 
 </details>
 
 <details>
-<summary><strong>GitHub Copilot (VS Code and Copilot CLI)</strong></summary>
+<summary><strong>GitHub Copilot (VS Code および Copilot CLI)</strong></summary>
 
-Copilot は Agent Skills をネイティブに読み取るため、同じ `SKILL.md` を変換なしで使えます。プロジェクトでは `.github/skills/`、`.claude/skills/`、`.agents/skills/`、グローバルでは `~/.copilot/skills/`、`~/.claude/skills/`、`~/.agents/skills/` を検索します。
+Copilot は Agent Skills をネイティブに読み込むため、変換不要でそのまま `SKILL.md` を利用できます。プロジェクト内では `.github/skills/`、`.claude/skills/`、`.agents/skills/` を、グローバル環境では `~/.copilot/skills/`、`~/.claude/skills/`、`~/.agents/skills/` をスキャンします。
 
 ### インストール
 
 ```bash
-npx skills add ayghri/i-have-adhd -a github-copilot        # このプロジェクト
-npx skills add ayghri/i-have-adhd -a github-copilot -g     # すべてのプロジェクト
+npx skills add ayghri/i-have-adhd -a github-copilot        # このプロジェクトのみ
+npx skills add ayghri/i-have-adhd -a github-copilot -g     # 全プロジェクト共通
 ```
 
-CLI を使わない場合は、Copilot が検索するいずれかのディレクトリにスキルフォルダーをコピーします：
+CLI を使わない場合は、Copilot がスキャンするいずれかのディレクトリにスキルフォルダーをコピーします：
 
 ```bash
 git clone https://github.com/ayghri/i-have-adhd
@@ -260,29 +260,29 @@ npx skills remove i-have-adhd
 
 ### 有効化に関する注意
 
-Copilot は `disable-model-invocation` を尊重します。Claude Code と同様、スキルを呼び出すまで何も適用されません（[#60](https://github.com/ayghri/i-have-adhd/pull/60) で検証済み）。
+Copilot は設定項目の `disable-model-invocation` に従います。Claude Code と同様に、スキルを明示的に呼び出すまでルールは適用されません（[#60](https://github.com/ayghri/i-have-adhd/pull/60) で検証済み）。
 
 ### 常時有効（任意）
 
-以下のブロックをプロジェクトの `.github/copilot-instructions.md` に追加します（Copilot はすべてのチャットでこれを読み込みます）：
+プロジェクト内の `.github/copilot-instructions.md` に以下のブロックを追加します（Copilot はすべてのチャット開始時にこれを読み込みます）：
 
 ```markdown
 ## 出力スタイル
 
-読み手には ADHD があります。すぐ行動に移せるよう、すべての回答を次のように構成してください：
+読み手はADHDです。すぐ行動に移せるよう、すべての回答を以下のように構成してください：
 
-1. 回答または次の行動から始める。コマンド、パス、スニペットを先に示す。
-2. 複数手順の作業には番号を付け、1 ステップにつき 1 つの明確な行動にする。
-3. 2 分以内にできる次の行動を 1 つ示して終える。
-4. 新しい問題を挙げる前に、現在の問題を終わらせる。
-5. 各ターンで進捗を言い直す（「5 ステップ中 3 ステップ完了」）。
-6. 所要時間は具体的な単位で示し、「少し」とは言わない。
-7. 変更後は、何が動くようになったかを示す。
-8. エラーは場所、原因、修正方法を淡々と示す。
-9. リストは最大 5 項目にする。
-10. 前置き、要約、締めの言葉を入れない。
+1. 答えや次に取るべき行動から始める：コマンド、パス、コードスニペットを最優先で提示する。
+2. 複数ステップの作業には番号を付ける（1ステップにつき明確な行動1つ）。
+3. 2分以内に完了できる具体的な次の行動を1つ提示して終える。
+4. 新しい論点を挙げる前に、現在の問題を解決して終わらせる。
+5. ターンごとに進捗を明記する（例: 「5ステップ中3ステップ完了」）。
+6. 所要時間は「少し」などの曖昧な表現を使わず、分単位などの具体的な数値で示す。
+7. 変更後は、何が動作するようになったかを目に見える形で示す。
+8. エラーは場所・原因・修正方法を淡々と伝える（大げさな表現は避ける）。
+9. リストは最大5項目までに抑える。
+10. 前置き、要約、締めの挨拶は入れない。
 
-例外：説明を求められた場合は十分に説明する。破壊的な操作の前には確認する。修正に 3 回失敗したら止まり、疑わしい前提を明示する。依頼が曖昧なら短い質問を 1 つする。
+例外規定：解説を求められた場合は十分に説明する。破壊的な操作を行う前には必ず確認を取る。修正に3回失敗した場合は一度停止し、前提条件のどこに誤りがあるかを指摘する。指示が曖昧な場合は短い質問を1つだけ行う。
 ```
 
 </details>
@@ -296,9 +296,9 @@ Copilot は `disable-model-invocation` を尊重します。Claude Code と同�
 hermes skills install ayghri/i-have-adhd/skills/i-have-adhd
 ```
 
-`/i-have-adhd` と入力します。 The skill installs into `~/.hermes/skills/` and is exposed as a slash command at the next session start.
+`/i-have-adhd` と入力します。スキルは `~/.hermes/skills/` にインストールされ、次回のセッション開始時からスラッシュコマンドとして利用可能になります。
 
-先に内容を確認したい場合は、このリポジトリをスキルソース（「tap」）として追加してから、検索してインストールします：
+先に内容を確認したい場合は、このリポジトリをスキルソース（「tap」）として追加してから検索・インストールすることもできます：
 
 ```bash
 hermes skills tap add ayghri/i-have-adhd
@@ -324,29 +324,29 @@ hermes skills update i-have-adhd
 hermes skills uninstall i-have-adhd
 ```
 
-tap も削除する場合は、`hermes skills tap remove ayghri/i-have-adhd` を実行します。
+tap も削除する場合：`hermes skills tap remove ayghri/i-have-adhd`
 
 ### 常時有効（任意）
 
-作業ディレクトリの `AGENTS.md`（Hermes が作業ディレクトリごとに読み込みます）、または全セッション用のペルソナ `SOUL.md` に追加します：
+作業ディレクトリ内の `AGENTS.md`（Hermes が作業ディレクトリごとに読み込みます）、または全セッション共通のペルソナ設定 `SOUL.md` に追加：
 
 ```markdown
 ## 出力スタイル
 
-読み手には ADHD があります。すぐ行動に移せるよう、すべての回答を次のように構成してください：
+読み手はADHDです。すぐ行動に移せるよう、すべての回答を以下のように構成してください：
 
-1. 回答または次の行動から始める。コマンド、パス、スニペットを先に示す。
-2. 複数手順の作業には番号を付け、1 ステップにつき 1 つの明確な行動にする。
-3. 2 分以内にできる次の行動を 1 つ示して終える。
-4. 新しい問題を挙げる前に、現在の問題を終わらせる。
-5. 各ターンで進捗を言い直す（「5 ステップ中 3 ステップ完了」）。
-6. 所要時間は具体的な単位で示し、「少し」とは言わない。
-7. 変更後は、何が動くようになったかを示す。
-8. エラーは場所、原因、修正方法を淡々と示す。
-9. リストは最大 5 項目にする。
-10. 前置き、要約、締めの言葉を入れない。
+1. 答えや次に取るべき行動から始める：コマンド、パス、コードスニペットを最優先で提示する。
+2. 複数ステップの作業には番号を付ける（1ステップにつき明確な行動1つ）。
+3. 2分以内に完了できる具体的な次の行動を1つ提示して終える。
+4. 新しい論点を挙げる前に、現在の問題を解決して終わらせる。
+5. ターンごとに進捗を明記する（例: 「5ステップ中3ステップ完了」）。
+6. 所要時間は「少し」などの曖昧な表現を使わず、分単位などの具体的な数値で示す。
+7. 変更後は、何が動作するようになったかを目に見える形で示す。
+8. エラーは場所・原因・修正方法を淡々と伝える（大げさな表現は避ける）。
+9. リストは最大5項目までに抑える。
+10. 前置き、要約、締めの挨拶は入れない。
 
-例外：説明を求められた場合は十分に説明する。破壊的な操作の前には確認する。修正に 3 回失敗したら止まり、疑わしい前提を明示する。依頼が曖昧なら短い質問を 1 つする。
+例外規定：解説を求められた場合は十分に説明する。破壊的な操作を行う前には必ず確認を取る。修正に3回失敗した場合は一度停止し、前提条件のどこに誤りがあるかを指摘する。指示が曖昧な場合は短い質問を1つだけ行う。
 ```
 
 </details>
@@ -356,22 +356,79 @@ tap も削除する場合は、`hermes skills tap remove ayghri/i-have-adhd` を
 
 ### インストール
 
-Kimi Code セッションを開始してから、次を実行します：
+Kimi Code のセッションを開始し、以下の手順を実行します：
 
 1. `/plugins` を実行する。
-2. **Custom** を選ぶ。
-3. `https://github.com/ayghri/i-have-adhd` を貼り付けて Enter を押す。
-4. **Trust and install** を選ぶ。
+2. **Custom** を選択する。
+3. `https://github.com/ayghri/i-have-adhd` を貼り付けて `Enter` を押す。
+4. **Trust and install** を選択する。
 
-slash コマンド `/skill:i-have-adhd` を使って、このスキルを明示的に呼び出します。
+スラッシュコマンド `/skill:i-have-adhd` を使用することで、スキルを明示的に呼び出します。
 
 ### 更新
 
-Kimi Code セッションで `/plugins` を実行し、**I Have ADHD** にカーソルを合わせて `R` を押します。
+Kimi Code セッション内で `/plugins` を実行し、**I Have ADHD** にカーソルを合わせて `R` を押します。
 
 ### アンインストール
 
-Kimi Code セッションで `/plugins` を実行し、**I Have ADHD** にカーソルを合わせて `D` を押します。
+Kimi Code セッション内で `/plugins` を実行し、**I Have ADHD** にカーソルを合わせて `D` を押します。
+
+</details>
+
+<details>
+<summary><strong>OpenCode</strong></summary>
+
+OpenCode はこのリポジトリをサーバープラグインとして読み込みます。`.opencode/plugins/i-have-adhd.mjs` が `skills/` のエントリーポイントと `/i-have-adhd` コマンドを登録し、常時有効化されている場合はルールセットを注入します。また、OpenCode は `skills/` をネイティブにも読み込めるため、プラグインなしでもスキル自体は動作します（プラグインを追加すると `/i-have-adhd` コマンドと常時有効化フラグが使えるようになります）。
+
+### インストール
+
+リポジトリをクローンし、OpenCode からプラグインを指定します。絶対パスを指定すると、すべてのプロジェクトで単一のチェックアウトを共有できます：
+
+```bash
+git clone https://github.com/ayghri/i-have-adhd ~/.config/opencode/vendor/i-have-adhd
+```
+
+`opencode.json`（グローバル設定: `~/.config/opencode/opencode.json`）に追加：
+
+```json
+{ "plugin": ["/absolute/path/to/i-have-adhd/.opencode/plugins/i-have-adhd.mjs"] }
+```
+
+または、チェックアウト先から直接 OpenCode を起動します。ルート直下の `opencode.json` にプラグインが設定済みです。
+
+新しいセッションを開始し、そのセッションでADHDフレンドリーな出力を有効化：
+
+```text
+/i-have-adhd
+```
+
+`stop adhd mode` または `normal mode` と入力するまでルールが維持されます。
+
+### 確認
+
+OpenCode を起動して `/` と入力し、コマンド一覧に `i-have-adhd` が表示されることを確認します。
+
+### 更新
+
+```bash
+git -C ~/.config/opencode/vendor/i-have-adhd pull
+```
+
+### アンインストール
+
+`opencode.json` から `plugin` のエントリーを削除します。
+
+### 常時有効（任意）
+
+```bash
+touch ~/.config/opencode/.i-have-adhd-always
+```
+
+フラグファイルが存在する間、プラグインは毎ターンシステムプロンプトの末尾に完全なルールセットを追加します（Claude Code の `SessionStart` フックに相当）。`stop adhd mode` や `normal mode` で現在のセッションのみ無効化できます。常時有効を完全に解除する場合はフラグファイルを削除してください：
+
+```bash
+rm ~/.config/opencode/.i-have-adhd-always
+```
 
 </details>
 
@@ -379,76 +436,81 @@ Kimi Code セッションで `/plugins` を実行し、**I Have ADHD** にカー
 <details>
 <summary><strong>Pi</strong></summary>
 
-Pi は Agent Skills 標準を実装しているため、同じ `SKILL.md` を変換なしで直接読み込めます。呼び出し方法は他と異なり、スキルは `/skill:<name>` で呼び出します。
+Pi はこのリポジトリをネイティブパッケージとして認識します。`extensions/` がセッション持続モードを提供し、`skills/` によって Agent Skills のエントリーポイントも引き続き利用できます。
 
 ### インストール
 
 ```bash
-npx skills add ayghri/i-have-adhd -a pi -y
+pi install https://github.com/ayghri/i-have-adhd
 ```
 
-ファイルシステムを使う場合、Pi は `~/.pi/agent/skills/` と `~/.agents/skills/`（グローバル）、`.pi/skills/` と `.agents/skills/`（プロジェクト）からスキルを検出します：
+新しい Pi セッションを開始し、現在のセッションでADHDフレンドリー出力を切り替えます：
+
+```text
+/i-have-adhd
+```
+
+有効化中はフッターに `● ADHD ON` と表示されます。もう一度コマンドを実行するとオフになります。明示的に指定することも可能です：
+
+```text
+/i-have-adhd on
+/i-have-adhd off
+stop adhd mode
+```
+
+Claude Code のフックと同様、拡張機能は毎リクエストでシステムプロンプトを書き換えるのではなく、会話コンテキストに一度だけルールセットを追加します（コンパクション等で消えた場合は再追加されます）。
+
+既存の Agent Skills コマンドもエイリアスとして利用可能です：
+
+```text
+/skill:i-have-adhd
+```
+
+デフォルトで有効化した状態で新しい Pi セッションを開始する場合：
 
 ```bash
-git clone https://github.com/ayghri/i-have-adhd
-mkdir -p ~/.pi/agent/skills
-cp -R i-have-adhd/skills/i-have-adhd ~/.pi/agent/skills/
+pi --adhd
 ```
-
-Pi の `settings.json` でスキルのスラッシュコマンドを有効にします：
-
-```json
-{ "enableSkillCommands": true }
-```
-
-新しいセッションを開始して `/skill:i-have-adhd` と入力します。
 
 ### 確認
 
 ```bash
-npx skills list
+pi list
 ```
 
-または、セッションで `/skill:` と入力し、`i-have-adhd` が一覧にあることを確認します。
+GitHub パッケージが一覧にあることを確認し、`/i-have-adhd` と入力してフッターに `● ADHD ON` が表示されることを確認します。
 
 ### 更新
 
 ```bash
-npx skills update i-have-adhd
+pi update https://github.com/ayghri/i-have-adhd
 ```
 
-または、`git pull` の後にフォルダーを再度コピーします。
+または、`pi update --extensions` で固定されていない全 Pi パッケージを一括更新します。
 
 ### アンインストール
 
 ```bash
-npx skills remove i-have-adhd
+pi remove https://github.com/ayghri/i-have-adhd
 ```
-
-または、`~/.pi/agent/skills/i-have-adhd` を削除します。
 
 ### 常時有効（任意）
 
-プロジェクトの `AGENTS.md` に追加します：
+Pi のエージェント設定ディレクトリにフラグファイルを作成：
 
-```markdown
-## 出力スタイル
-
-読み手には ADHD があります。すぐ行動に移せるよう、すべての回答を次のように構成してください：
-
-1. 回答または次の行動から始める。コマンド、パス、スニペットを先に示す。
-2. 複数手順の作業には番号を付け、1 ステップにつき 1 つの明確な行動にする。
-3. 2 分以内にできる次の行動を 1 つ示して終える。
-4. 新しい問題を挙げる前に、現在の問題を終わらせる。
-5. 各ターンで進捗を言い直す（「5 ステップ中 3 ステップ完了」）。
-6. 所要時間は具体的な単位で示し、「少し」とは言わない。
-7. 変更後は、何が動くようになったかを示す。
-8. エラーは場所、原因、修正方法を淡々と示す。
-9. リストは最大 5 項目にする。
-10. 前置き、要約、締めの言葉を入れない。
-
-例外：説明を求められた場合は十分に説明する。破壊的な操作の前には確認する。修正に 3 回失敗したら止まり、疑わしい前提を明示する。依頼が曖昧なら短い質問を 1 つする。
+```bash
+touch ~/.pi/agent/.i-have-adhd-always
 ```
+
+拡張機能は、セッションの新規作成・再開・フォーク・リロード時にこのフラグを確認します。現在のセッションで明示的に切り替えた設定が優先されるため、`stop adhd mode` を実行すればそのセッション内では無効化されたままになります。
+
+オンデマンドに戻す場合：
+
+```bash
+rm ~/.pi/agent/.i-have-adhd-always
+```
+
+`PI_CODING_AGENT_DIR` が設定されている場合は、そのディレクトリ内に `.i-have-adhd-always` を配置してください。フラグを変更した後は `/reload` を実行するか、新しいセッションを開始してください。
 
 </details>
 
@@ -462,9 +524,9 @@ npx skills remove i-have-adhd
 qwen extensions install ayghri/i-have-adhd
 ```
 
-Qwen Code は GitHub の短縮表記をサポートし、このリポジトリをネイティブ拡張機能としてインストールします。拡張機能は `skills/` 配下のスキルを検出します。
+Qwen Code は GitHub の短縮記法に対応しており、このリポジトリをネイティブ拡張機能としてインストール可能です。拡張機能は `skills/` 配下のスキルを自動検出します。
 
-スキルを明示的に呼び出すには `/i-have-adhd` を入力します。拡張機能をインストールしただけでは、スキルを呼び出すまで出力は変わりません。
+スキルを明示的に呼び出すには `/i-have-adhd` と入力します。拡張機能をインストールしても、スキルを呼び出すまで出力の変化はありません。
 
 ### 確認
 
@@ -472,7 +534,7 @@ Qwen Code は GitHub の短縮表記をサポートし、このリポジトリ�
 qwen extensions list
 ```
 
-次に新しい Qwen Code セッションを開始し、以下を実行します：
+次に新しい Qwen Code セッションを開始し、以下を実行：
 
 ```text
 /skills
@@ -497,19 +559,19 @@ qwen extensions uninstall i-have-adhd
 <details>
 <summary><strong>Zed</strong></summary>
 
-Zed の Agent は Agent Skills をネイティブに読み取るため、同じ `SKILL.md` を変換なしで使えます（従来の「Rules」は Skills と `AGENTS.md` の指示に置き換えられました）。
+Zed の Agent は Agent Skills をネイティブに読み込むため、変換不要でそのまま `SKILL.md` を利用できます（Zed の以前の「Rules」は、Skills と `AGENTS.md` の指示に置き換えられました）。
 
 ### インストール
 
-Agent Panel で Skills マネージャーを開き、**Create skill from URL**（コマンドパレットでは `agent: create skill from url`）を選択して、次を貼り付けます：
+Agent Panel で Skills マネージャーを開き、**Create skill from URL**（コマンドパレットでは `agent: create skill from url`）を選択して、以下を貼り付けます：
 
 ```
 https://github.com/ayghri/i-have-adhd/blob/main/skills/i-have-adhd/SKILL.md
 ```
 
-すべてのプロジェクトで使う場合は **User** スコープ、1 つだけなら **Project** スコープに保存します。その後、Agent Panel で `/i-have-adhd` と入力します。
+全プロジェクト共通で使う場合は **User** スコープ、現在のプロジェクトのみなら **Project** スコープで保存します。その後、Agent Panel で `/i-have-adhd` と入力します。
 
-ファイルシステムを使う場合は、リポジトリをクローンし、ユーザーの skills ディレクトリにスキルフォルダーを配置します：
+ファイルシステムを直接使う場合は、リポジトリをクローンしてユーザースキルディレクトリにスキルフォルダーを配置：
 
 ```bash
 git clone https://github.com/ayghri/i-have-adhd
@@ -530,50 +592,50 @@ Skills マネージャーから `i-have-adhd` を削除するか、`~/.config/ze
 
 ### 常時有効（任意）
 
-個人用の `~/.config/zed/AGENTS.md` に追加します：
+個人用の `~/.config/zed/AGENTS.md` に追加：
 
 ```markdown
 ## 出力スタイル
 
-読み手には ADHD があります。すぐ行動に移せるよう、すべての回答を次のように構成してください：
+読み手はADHDです。すぐ行動に移せるよう、すべての回答を以下のように構成してください：
 
-1. 回答または次の行動から始める。コマンド、パス、スニペットを先に示す。
-2. 複数手順の作業には番号を付け、1 ステップにつき 1 つの明確な行動にする。
-3. 2 分以内にできる次の行動を 1 つ示して終える。
-4. 新しい問題を挙げる前に、現在の問題を終わらせる。
-5. 各ターンで進捗を言い直す（「5 ステップ中 3 ステップ完了」）。
-6. 所要時間は具体的な単位で示し、「少し」とは言わない。
-7. 変更後は、何が動くようになったかを示す。
-8. エラーは場所、原因、修正方法を淡々と示す。
-9. リストは最大 5 項目にする。
-10. 前置き、要約、締めの言葉を入れない。
+1. 答えや次に取るべき行動から始める：コマンド、パス、コードスニペットを最優先で提示する。
+2. 複数ステップの作業には番号を付ける（1ステップにつき明確な行動1つ）。
+3. 2分以内に完了できる具体的な次の行動を1つ提示して終える。
+4. 新しい論点を挙げる前に、現在の問題を解決して終わらせる。
+5. ターンごとに進捗を明記する（例: 「5ステップ中3ステップ完了」）。
+6. 所要時間は「少し」などの曖昧な表現を使わず、分単位などの具体的な数値で示す。
+7. 変更後は、何が動作するようになったかを目に見える形で示す。
+8. エラーは場所・原因・修正方法を淡々と伝える（大げさな表現は避ける）。
+9. リストは最大5項目までに抑える。
+10. 前置き、要約、締めの挨拶は入れない。
 
-例外：説明を求められた場合は十分に説明する。破壊的な操作の前には確認する。修正に 3 回失敗したら止まり、疑わしい前提を明示する。依頼が曖昧なら短い質問を 1 つする。
+例外規定：解説を求められた場合は十分に説明する。破壊的な操作を行う前には必ず確認を取る。修正に3回失敗した場合は一度停止し、前提条件のどこに誤りがあるかを指摘する。指示が曖昧な場合は短い質問を1つだけ行う。
 ```
 
 </details>
 
 <details>
-<summary><strong>Cursor、OpenCode、Amp、その他の agent-skills 対応環境</strong></summary>
+<summary><strong>Cursor、Amp、その他の agent-skills 対応環境</strong></summary>
 
-Agent Skills を読み取るすべての環境で動作します。`-a <agent>` を使用するエージェントに置き換えてください。
+agent-skills を読み込めるすべての環境で動作します。`-a <agent>` の部分を、使用するエージェント名に置き換えてください。
 
 ### インストール
 
 ```bash
-npx skills add ayghri/i-have-adhd                  # this workspace
-npx skills add ayghri/i-have-adhd -g               # すべてのプロジェクト
-npx skills add ayghri/i-have-adhd -a cursor -y     # one agent only
+npx skills add ayghri/i-have-adhd                  # このプロジェクトのみ
+npx skills add ayghri/i-have-adhd -g               # 全プロジェクト共通
+npx skills add ayghri/i-have-adhd -a cursor -y     # 特定のエージェントのみ
 npx skills add ayghri/i-have-adhd -a opencode -y
 ```
 
 新しいエージェントチャットで `/i-have-adhd` と入力します。
 
-CLI を使わない場合は、エージェントが検索するパスにスキルフォルダーをコピーします：
+CLI を使わない場合は、エージェントがスキャンするパスにスキルフォルダーをコピー：
 
 ```bash
 git clone https://github.com/ayghri/i-have-adhd
-mkdir -p ~/.cursor/skills     # Cursor。OpenCode は .agents/skills、その他はエージェント固有のパスを使用
+mkdir -p ~/.cursor/skills     # Cursorの場合。OpenCodeなら .agents/skills、その他は各固有パス
 cp -R i-have-adhd/skills/i-have-adhd ~/.cursor/skills/
 ```
 
@@ -600,57 +662,61 @@ npx skills remove i-have-adhd -g    # グローバルにインストールした
 
 ### 常時有効（任意）
 
-これをエージェントの永続ルールファイルに貼り付けます。Cursor：**Settings → Rules → User Rules**、または `.cursor/rules/` 配下のプロジェクトルールで `alwaysApply: true` を指定します。OpenCode：`~/.config/opencode/AGENTS.md`。
+エージェントの永続ルール設定ファイルに以下を貼り付けます。
+
+Cursor の場合：**Settings → Rules → User Rules**、または `.cursor/rules/` 配下のプロジェクトルールで `alwaysApply: true` を設定。  
+
+OpenCode の場合：`~/.config/opencode/AGENTS.md`。
 
 ```markdown
 ## 出力スタイル
 
-読み手には ADHD があります。すぐ行動に移せるよう、すべての回答を次のように構成してください：
+読み手はADHDです。すぐ行動に移せるよう、すべての回答を以下のように構成してください：
 
-1. 回答または次の行動から始める。コマンド、パス、スニペットを先に示す。
-2. 複数手順の作業には番号を付け、1 ステップにつき 1 つの明確な行動にする。
-3. 2 分以内にできる次の行動を 1 つ示して終える。
-4. 新しい問題を挙げる前に、現在の問題を終わらせる。
-5. 各ターンで進捗を言い直す（「5 ステップ中 3 ステップ完了」）。
-6. 所要時間は具体的な単位で示し、「少し」とは言わない。
-7. 変更後は、何が動くようになったかを示す。
-8. エラーは場所、原因、修正方法を淡々と示す。
-9. リストは最大 5 項目にする。
-10. 前置き、要約、締めの言葉を入れない。
+1. 答えや次に取るべき行動から始める：コマンド、パス、コードスニペットを最優先で提示する。
+2. 複数ステップの作業には番号を付ける（1ステップにつき明確な行動1つ）。
+3. 2分以内に完了できる具体的な次の行動を1つ提示して終える。
+4. 新しい論点を挙げる前に、現在の問題を解決して終わらせる。
+5. ターンごとに進捗を明記する（例: 「5ステップ中3ステップ完了」）。
+6. 所要時間は「少し」などの曖昧な表現を使わず、分単位などの具体的な数値で示す。
+7. 変更後は、何が動作するようになったかを目に見える形で示す。
+8. エラーは場所・原因・修正方法を淡々と伝える（大げさな表現は避ける）。
+9. リストは最大5項目までに抑える。
+10. 前置き、要約、締めの挨拶は入れない。
 
-例外：説明を求められた場合は十分に説明する。破壊的な操作の前には確認する。修正に 3 回失敗したら止まり、疑わしい前提を明示する。依頼が曖昧なら短い質問を 1 つする。
+例外規定：解説を求められた場合は十分に説明する。破壊的な操作を行う前には必ず確認を取る。修正に3回失敗した場合は一度停止し、前提条件のどこに誤りがあるかを指摘する。指示が曖昧な場合は短い質問を1つだけ行う。
 ```
 </details>
 
 
 ## 有効化の仕組み
 
-1. **インストール済み、未呼び出し。** Claude Code、Qwen Code、Codex では、明示的に呼び出すまで何も起きません。Claude Code と Qwen Code は `SKILL.md` の `disable-model-invocation: true` を、Codex は `agents/openai.yaml` の `policy.allow_implicit_invocation: false` を尊重します。その他の環境では、起動時に各スキルの説明を読み込み、自動で有効化する場合があります。
-2. **明示的に呼び出す。** Claude Code と Qwen Code では `/i-have-adhd`、Codex では `$i-have-adhd` を入力します。そのセッションでルールが有効になります。「stop adhd mode」または「normal mode」で無効にできます。
-3. **`~/.claude/.i-have-adhd-always` を作成する**（Claude Code）。`SessionStart` フックが、すべてのセッションで最初のメッセージから完全なルールセットを読み込みます。
-4. **上記の常時有効スニペットを追加する**（その他の環境）。中核となるルールをエージェントの永続コンテキストに保持します。
+1. **インストール済み・未呼び出しの状態**：Claude Code、Qwen Code、Codex では、スキルを明示的に呼び出すまで何も起こりません。Claude Code と Qwen Code は `SKILL.md` 内の設定項目である `disable-model-invocation: true` に従い、Codex は `agents/openai.yaml` 内の `policy.allow_implicit_invocation: false` に従います。その他の環境では、起動時にすべてのスキルの説明文を読み込み、自動で有効化する場合があります。
+2. **明示的に呼び出す**：Claude Code や Qwen Code では `/i-have-adhd`、Codex では `$i-have-adhd` と入力します。そのセッション中はルールが有効になります。`stop adhd mode` または `normal mode` でオフにできます。
+3. **`~/.claude/.i-have-adhd-always` を作成する**（Claude Code）：`SessionStart` フックにより、すべてのセッションで最初のメッセージから完全なルールセットが読み込まれます。
+4. **上記の常時有効スニペットを追加する**（その他の環境）：エージェントの永続コンテキスト内に中核ルールを保持します。
 
-Claude Code、Qwen Code、Codex では中間状態はありません。有効にしていなければ無効です。
+Claude Code、Qwen Code、Codex には中間状態がありません。有効化していなければオフのままです。
 
 ## トラブルシューティング
 
-**`/i-have-adhd` が自動補完に表示されない。** エージェントを再起動してください。プラグインのインデックスは起動時に読み込まれます。
+**`/i-have-adhd` が自動補完に表示されない →** エージェントを再起動してください。プラグインのインデックスは起動時に読み込まれます。
 
-**常時有効フラグが効かない。** プラグインを更新（`claude plugin marketplace update i-have-adhd`）して再起動してください。フックは起動時に読み込まれ、フラグには `hooks/hooks.json` を含むバージョンが必要です。
+**常時有効フラグが効かない →** プラグインを更新（`claude plugin marketplace update i-have-adhd`）して再起動してください。フックは起動時に読み込まれるほか、フラグの認識には `hooks/hooks.json` が含まれるバージョンが必要です。
 
-**`claude plugin marketplace add` が失敗する。** `owner/repo` 形式を使用してください。ローカルパスは `.claude-plugin/` ではなく、リポジトリのルートを指す必要があります。
+**`claude plugin marketplace add` が失敗する →** `owner/repo` 形式を使用してください。ローカルパスを指定する場合は `.claude-plugin/` ではなくリポジトリのルートを指す必要があります。
 
-**インストールしたが回答にまだ前置きが入る。** 新しいセッションを開いてください。それでも逸脱する場合は、`skills/i-have-adhd/SKILL.md` の文言をより厳密にしてください。
+**インストールしたのに回答に前置きが入る →** 新しいセッションを開いてください。それでも指示から逸脱する場合は、`skills/i-have-adhd/SKILL.md` の文言をより厳格に調整してください。
 
-**別のルールを使いたい。** Fork して `skills/i-have-adhd/SKILL.md` を編集し、自分のコピーに切り替えます：
+**自分好みのルールに変更したい →** Fork して `skills/i-have-adhd/SKILL.md` を編集し、自分のコピーに差し替えます：
 
 ```bash
-claude plugin uninstall i-have-adhd            # 先に上流のコピーを削除：
-claude plugin marketplace remove i-have-adhd   # fork と上流はどちらも同じ名前を使用
+claude plugin uninstall i-have-adhd            # 先に本家のコピーを削除
+claude plugin marketplace remove i-have-adhd   # Fork版と本家で名前が重複するため
 claude plugin marketplace add <your-username>/i-have-adhd
 claude plugin install i-have-adhd@i-have-adhd
 ```
 
-再起動してから、`/i-have-adhd` をもう一度呼び出します。
+再起動してから、`/i-have-adhd` をもう一度呼び出してください。
 
-**`npx skills add` の後にスキルが見つからない。** 新しいエージェントチャットを開始してください。スキルはセッション開始時にインデックス化されます。フォルダーがエージェントの検索先（Cursor は `~/.cursor/skills/`、OpenCode は `.agents/skills/`）に配置され、frontmatter の `name` がフォルダー名と一致していることを確認してください。
+**`npx skills add` の後にスキルが見つからない →** 新しいエージェントチャットを開始してください。スキルはセッション開始時にインデックス化されます。フォルダーがエージェントのスキャン対象パス（Cursor なら `~/.cursor/skills/`、OpenCode なら `.agents/skills/`）に正しく配置されていること、および frontmatter の `name` がフォルダー名と一致していることを確認してください。

--- a/.github/install/INSTALL.ja.md
+++ b/.github/install/INSTALL.ja.md
@@ -510,7 +510,52 @@ touch ~/.pi/agent/.i-have-adhd-always
 rm ~/.pi/agent/.i-have-adhd-always
 ```
 
+### 設定ファイル（任意）
+
+Pi のエージェント設定ディレクトリに `~/.pi/agent/i-have-adhd.json` を作成します：
+
+```json
+{
+  "alwaysOn": true,
+  "hideStatus": true
+}
+```
+
+- `alwaysOn`：すべてのセッションをルール有効の状態で開始します。従来の `.i-have-adhd-always` フラグファイルも引き続き使えます。
+- `hideStatus`：ステータスバーの `● ADHD ON` 表示を隠します。ルールと `/i-have-adhd` コマンドは引き続き機能します。
+
+設定は拡張機能の起動時に一度だけ読み込まれるため、変更後は Pi を再起動してください。現在のセッションに保存された選択は `alwaysOn` より優先されるため、`stop adhd mode` を実行するとそのセッションでは無効のままになります。
+
 `PI_CODING_AGENT_DIR` が設定されている場合は、そのディレクトリ内に `.i-have-adhd-always` を配置してください。フラグを変更した後は `/reload` を実行するか、新しいセッションを開始してください。
+
+</details>
+
+
+<details>
+<summary><strong>Oh My Pi (OMP)</strong></summary>
+
+### インストール
+
+```bash
+omp plugin marketplace add ayghri/i-have-adhd
+omp plugin install --scope user i-have-adhd@i-have-adhd
+```
+
+新しい OMP セッションを開始し、`/i-have-adhd` を実行してモードを切り替えます。
+
+### 更新
+
+```bash
+omp plugin marketplace update i-have-adhd
+omp plugin upgrade --scope user i-have-adhd@i-have-adhd
+```
+
+### アンインストール
+
+```bash
+omp plugin uninstall --scope user i-have-adhd@i-have-adhd
+omp plugin marketplace remove i-have-adhd
+```
 
 </details>
 
@@ -664,7 +709,7 @@ npx skills remove i-have-adhd -g    # グローバルにインストールした
 
 エージェントの永続ルール設定ファイルに以下を貼り付けます。
 
-Cursor の場合：**Settings → Rules → User Rules**、または `.cursor/rules/` 配下のプロジェクトルールで `alwaysApply: true` を設定。  
+Cursor の場合：**Settings → Rules → User Rules**、または `.cursor/rules/` 配下のプロジェクトルールで `alwaysApply: true` を設定。
 
 OpenCode の場合：`~/.config/opencode/AGENTS.md`。
 

--- a/.github/readme/README.ja.md
+++ b/.github/readme/README.ja.md
@@ -2,7 +2,7 @@
   <img src="../../logo.png" alt="i-have-adhd" width="140" />
 </p>
 <p align="center">
-  <strong align="center">ADHD に配慮した出力。ADHD の診断は不要です！</strong>
+  <strong align="center">ADHDに配慮した簡潔な出力。（診断済みかは関係なく、誰でも気軽に使えます！）</strong>
 </p>
 <p align="center">
   <a href="../../LICENSE"><img src="https://img.shields.io/github/license/ayghri/i-have-adhd?style=flat" alt="ライセンス"></a>
@@ -17,18 +17,15 @@
   <a href="README.ko.md" title="한국어" aria-label="한국어">🇰🇷</a>
 </p>
 
-
 ## インストール
 
 🔗 [インストール手順](../install/INSTALL.ja.md)
 
 ## 機能
 
-コーディングアシスタントが答えを長い文章に埋もれさせないようにするスキルです。行動を先に。手順には番号を。「お役に立てれば幸いです！」は不要です。
+コーディングアシスタントの回答を長文で埋めさせないようにするスキル。最優先は行動で、手順を箇条書きで整理。  「お役に立てれば幸いです！」などの不要な挨拶や定型文をカットします。
 
-
-## 変わること
-
+## 変化の例
 
 <table>
 <tr>
@@ -36,7 +33,7 @@
 
 ## 適用前
 
-> 良い質問ですね！考えてみましょう。認証フローには、ミドルウェア、トークン検証、Cookie の処理といういくつかの要素があります。`src/auth.ts` を見ると、`verifyToken` 関数（42～58 行目付近）は古い `jsonwebtoken` API を使っているようです。一つの方法は、パッケージを更新してその関数を書き直すことです。変更後は、認証テストを実行して問題が起きていないことを確認するとよいでしょう。ついでに、依存関係のバージョンも全体的に確認したほうがよいかもしれません。お役に立てれば幸いです！さらに詳しく調べたい場合はお知らせください。
+> 良い質問ですね！考えてみましょう。認証フローには、ミドルウェア、トークン検証、Cookieの処理といういくつかの要素があります。`src/auth.ts` を見ると、`verifyToken` 関数（42〜58行目付近）は古い `jsonwebtoken` API を使っているようです。一つの方法としては、パッケージを更新してその関数を書き直すことです。変更後は、認証テストを実行して問題が起きていないことを確認するとよいでしょう。ついでに、依存関係のバージョンも全体的に確認したほうがよいかもしれません。お役に立てれば幸いです！さらに詳しく調べたい場合はお知らせください。
 
 </td>
 
@@ -44,41 +41,40 @@
 
 ## 適用後
 
-> `npm install jsonwebtoken@latest` を実行してから、`src/auth.ts:42` を編集してください。
+> `npm install jsonwebtoken@latest` を実行後、`src/auth.ts:42` を編集する。
 >
 > 1. `src/auth.ts` を開く
-> 2. `verifyToken`（42～58 行目）を以下のスニペットに置き換える
+> 2. `verifyToken`（42〜58行目）を以下のスニペットに置き換える
 > 3. `npm test -- auth.spec.ts` を実行する
 >
-> 次の手順：テストが失敗した場合は、最初のエラー行を貼り付けてください。
+> 次の行動：テストが失敗した場合は、最初のエラー行を貼り付ける。
 
 </td>
 </tr>
 </table>
 
+## 10のルール
 
-## ルール
-
-ルールは 10 個です。全文は [SKILL.md](../../skills/i-have-adhd/SKILL.md) にあります。
+ルールは10個。全文は [SKILL.md](../../skills/i-have-adhd/SKILL.md) を参照してください。
 
 1. 次に取る行動から始める。
-2. 複数手順のタスクには番号を付ける。
-3. 具体的な次の一手を一つ示して終える。
-4. 脱線を抑える。
-5. ターンごとに現在の状態を言い直す。
-6. 具体的な所要時間を示す（「少し」ではなく分単位）。
-7. 成果を目に見える形で示す。
-8. エラーを淡々と伝える。
-9. リストは 5 項目までにする。
-10. 前置き、要約、締めの言葉を入れない。
+2. 複数ステップの作業には番号を付ける。
+3. 2分以内にできる具体的な次の一手で終える。
+4. 脱線を防ぐ。
+5. ターンごとに現在の進捗・状態を明記する。
+6. 所要時間は「少し」ではなく分単位で具体的に示す。
+7. 変更後に何が動くようになったかを明示する。
+8. エラーは場所・原因・対処法だけを淡々と伝える。
+9. リストは最大5項目までに抑える。
+10. 前置き・要約・締めの挨拶は入れない。
 
 ## カスタマイズ
 
-リポジトリを Fork し、`skills/i-have-adhd/SKILL.md` を編集してから、自分のコピーに切り替えます。
+リポジトリをForkし、`skills/i-have-adhd/SKILL.md` を編集してから自分のコピーに差し替えます。
 
 ```bash
-claude plugin uninstall i-have-adhd            # まず上流のコピーを削除：
-claude plugin marketplace remove i-have-adhd   # fork と上流では同じ名前が使われる
+claude plugin uninstall i-have-adhd            # 先に本家のコピーを削除
+claude plugin marketplace remove i-have-adhd   # Fork版と本家で名前が重複するため
 claude plugin marketplace add <your-username>/i-have-adhd
 claude plugin install i-have-adhd@i-have-adhd
 ```
@@ -87,10 +83,10 @@ Claude Code を再起動し、`/i-have-adhd` をもう一度呼び出してく�
 
 ## クレジット
 
-J. Russell Ramsay と Anthony L. Rostain による *The Adult ADHD Tool Kit* を大まかに参考にしています。人間が一日をどう整理すべきかではなく、LLM がどう応答すべきかに合わせて改変したものです。
+J. Russell Ramsay と Anthony L. Rostain による著書『*The Adult ADHD Tool Kit*』に着想を得ています。人間の一日のスケジュール管理ではなく、LLMがどう返答すべきかに合わせて最適化しています。
 
 ## ライセンス
 
-MIT。
+MIT
 
-「良い質問ですね！」を一度スクロールして読み飛ばさずに済んだなら、Star ⭐ をお願いします。
+もし1回でも「良い質問ですね！」を読み飛ばすスクロールが減ったなら、Star⭐️をお願いします。

--- a/.github/readme/README.ja.md
+++ b/.github/readme/README.ja.md
@@ -19,7 +19,13 @@
 
 ## インストール
 
-🔗 [インストール手順](../install/INSTALL.ja.md)
+CLIのプロンプトに以下をコピー＆ペーストしてください：
+
+```text
+Install the i-have-adhd skill/plugin from https://github.com/ayghri/i-have-adhd, refer to the repo's AGENTS.md for instructions.
+```
+
+または、🔗 [インストール手順を確認する](../install/INSTALL.ja.md)。
 
 ## 機能
 


### PR DESCRIPTION
## Description

This PR refines the Japanese documentation (`README.ja.md` and `INSTALL.ja.md`) to sound more natural and idiomatic to native Japanese speakers.

The draft was initially prepared with AI assistance (Gemini 3.7 Flash) and then thoroughly reviewed and manually polished by myself (a native Japanese speaker).

- Polished literal/machine-translated phrasings into clear, natural Japanese while keeping the exact same structure and rules.
- Updated `INSTALL.ja.md` to reflect the latest upstream `INSTALL.md` content (such as the updated Pi installation instructions).
- Removed accidental syntax artifacts and adjusted formatting for readability.