### PR TITLE
fix(hooks): raise SessionStart timeout so always-on is not dropped under load

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "node -e \"(async()=>{const root=process.env.CLAUDE_PLUGIN_ROOT||process.env.PLUGIN_ROOT;if(root)await import(require('node:url').pathToFileURL(require('node:path').join(root,'hooks','always-on.mjs')).href)})().catch(()=>{})\"",
-            "timeout": 5,
+            "timeout": 30,
             "statusMessage": "Checking i-have-adhd always-on flag..."
           }
         ]


### PR DESCRIPTION
**Description**

The always-on SessionStart hook is capped at a 5s timeout. When other SessionStart hooks are registered in the same config, Node's cold start alone can exceed that budget, the hook is cancelled, and the ruleset is silently dropped from the session. This raises the cap to 30s. One line, no behavior change for anyone who has not opted in.

**Provenance**

- **Category:** Autonomous agent-authored (`Author:AI`).
- **Agent:** Claude Code, model Claude Opus 5.
- **What the agent did:** diagnosed the cancelled hook from the session transcript, measured the launcher in isolation, chose the 30s value, made the one-line edit, ran the verification listed below, and wrote this description.
- **What the human reviewed:** the full diff (one line), the raw verification output, and this description before submission. The human also set two constraints that shaped the change: it had to help every user rather than work around one machine, which is why hardcoding an absolute `node` path was rejected as platform-breaking, and existing issues and PRs had to be searched for duplicates before opening this one.
- **Limitations:** the agent produced and verified the change; no second independent reviewer ran the checks. Three unrelated test failures are pre-existing on this platform and the Ubuntu-only CI load job could not be run locally. Both are detailed under Testing.

**Root Cause / Context**

- `hooks/hooks.json:10` sets `"timeout": 5`, unchanged since 967ad4b ("Add opt-in always-on mode for Claude Code via SessionStart hook").
- Observed on Windows 10 with Claude Code, with five other SessionStart hooks registered alongside this one:
  `{"hookName":"SessionStart:startup","command":"Checking i-have-adhd always-on flag...","durationMs":6549,"timedOut":true,"timeoutMs":5000}`
- Run in isolation on the same machine, the same launcher completes in 234ms. The 5s budget is measuring Node process startup under contention, not the hook's own work.
- The failure is silent and non-deterministic. A session started minutes earlier on the same machine received the `hook_success` attachment and the full ruleset; the next one did not, with nothing surfaced to the user.

**Changes**

`hooks/hooks.json`
- **Fix:** bump `timeout` from `5` to `30`.
- **Reason:** the hook only does an `existsSync`, a `readFileSync` and a regex strip, with no network or blocking I/O, so a wider ceiling cannot stall a session in practice.
- **Impact:** users who never created the opt-in flag are unaffected, since `always-on.mjs` exits 0 on the first `existsSync` miss.
- **Note:** 30s stays well under Claude Code's 60s hook default.

**Observable behavior, before and after**

- **Before:** on a config with several SessionStart hooks, the launcher is cancelled at 5s and the session starts with no ruleset and no error shown. Whether it lands depends on machine load, so the same user sees the mode come and go between sessions.
- **After:** the launcher completes and the ruleset is injected under the same contention. Nothing changes for a user without the opt-in flag, and nothing changes on a machine that was already inside the 5s budget.

**Safety, compatibility, and side effects**

- No new dependency, no new network access, no new file write, no change to what the hook reads or emits. Only the ceiling before the harness cancels it.
- Opt-in behavior is preserved: without `$CLAUDE_CONFIG_DIR/.i-have-adhd-always` the script exits 0 immediately, so the wider ceiling is never reached by users who did not opt in.
- Fail-safe behavior is preserved: the launcher still swallows its own errors and exits 0, so it cannot block agent startup.
- Not a breaking change: no manifest, invocation name, canonical skill path, installation method or hook semantics are touched. `SKILL.md` is unchanged, so no Cursor copy sync is needed.
- Bounded worst case: one `existsSync`, one `readFileSync` of a plugin-local file, one regex strip. There is no path where this occupies 30s of real work.

**Testing**

Environment: Windows 10 Pro 19045, Node v24.17.0, Python 3.14.6.

1. `python -m unittest discover -s tests -v` gives 21 tests with 3 failures, all in `test_opencode_plugin` (`ERR_UNSUPPORTED_ESM_URL_SCHEME` from the OpenCode driver on Windows). These are pre-existing and unrelated: the same three fail on `main` without this change. An initial run also reported 1 error in the same driver, which did not reproduce across two further runs.
2. `python scripts/run_evals.py validate` gives `Evaluation cases are valid.`
3. `python -m unittest tests.test_always_on_hooks -v` gives 7 tests, all passing. No test asserts the timeout value, so nothing needed updating alongside it.
4. Plugin load in an isolated configuration directory, the local equivalent of the `load` job: `claude plugin marketplace add`, then `claude plugin install i-have-adhd@i-have-adhd`, then `claude plugin list` under a scratch `CLAUDE_CONFIG_DIR` reports `Status: enabled`. Confirmed the operator's real config directory was not modified by the run.
5. Hook behavior under the same scratch `CLAUDE_CONFIG_DIR`: without the opt-in flag, exit 0 with empty stdout and empty stderr; with the flag present, exit 0 and the full ruleset on stdout.
6. **Not run:** the Ubuntu leg of the `load` job, which needs a Linux runner, and paired baseline/candidate evals, which apply to rule behavior changes. This PR does not touch `SKILL.md` or any rule.

**Labels**

I do not have permission to set labels on this repository. Requested: `Target:Integrations`, `Author:AI`, `bug`.

**Motivation**

An always-on ruleset that disappears under load is worse than one that is off, because the reader cannot tell which mode they are in. Widening the ceiling makes the opt-in deterministic without changing behavior for anyone who has not enabled it.
