### PR TITLE
rules: extend rule 8 to feedback on the reader's own work

### DIFF
--- a/.cursor/skills/i-have-adhd/SKILL.md
+++ b/.cursor/skills/i-have-adhd/SKILL.md
@@ -100,6 +100,11 @@ Never use "Uh oh," "Oh no," or "There seems to be a problem." State cause and fi
 Bad: "Uh oh, the test is failing. There seems to be an issue..."
 Good: "Test fails at `auth.spec.ts:42`: expected 200, got 401. Cause: missing auth header. Fix: add `Authorization: Bearer ${token}` to the request."
 
+The same tone covers feedback on the reader's own work. Criticism aimed at the person ("you forgot," "this is wrong") lands harder for many ADHD readers and can stall the work entirely. Anchor the gap to the work, not the person, and pair every gap with its fix. When something in the work is solid, say which part, concretely; skip generic praise.
+
+Bad: "This function is wrong. You forgot to handle the empty list."
+Good: "`avg` breaks on an empty list: `len(xs)` is 0, so it divides by zero. Fix: `if not xs: return 0.0` at the top. The core computation is correct."
+
 ### 9. Cap lists at 5 items
 
 If a list grows past five, split into "do now" vs "later," or "must" vs "nice to have." Five items ranked beats ten unranked.

--- a/skills/i-have-adhd/SKILL.md
+++ b/skills/i-have-adhd/SKILL.md
@@ -100,6 +100,11 @@ Never use "Uh oh," "Oh no," or "There seems to be a problem." State cause and fi
 Bad: "Uh oh, the test is failing. There seems to be an issue..."
 Good: "Test fails at `auth.spec.ts:42`: expected 200, got 401. Cause: missing auth header. Fix: add `Authorization: Bearer ${token}` to the request."
 
+The same tone covers feedback on the reader's own work. Criticism aimed at the person ("you forgot," "this is wrong") lands harder for many ADHD readers and can stall the work entirely. Anchor the gap to the work, not the person, and pair every gap with its fix. When something in the work is solid, say which part, concretely; skip generic praise.
+
+Bad: "This function is wrong. You forgot to handle the empty list."
+Good: "`avg` breaks on an empty list: `len(xs)` is 0, so it divides by zero. Fix: `if not xs: return 0.0` at the top. The core computation is correct."
+
 ### 9. Cap lists at 5 items
 
 If a list grows past five, split into "do now" vs "later," or "must" vs "nice to have." Five items ranked beats ten unranked.


### PR DESCRIPTION
## Summary

Extends rule 8 (matter-of-fact tone) to cover feedback on the reader's own work, not only error reports. Before: the skill governs how the assistant reports failures, but says nothing about how it critiques code or writing the reader made themselves, so "you forgot to handle the empty list" passes every rule. After: rule 8 tells the assistant to anchor the gap to the work rather than the person, pair every gap with its fix, and name what already works concretely instead of generic praise.

Why this matters for this skill's audience: rejection-sensitive responses to criticism are widely reported alongside ADHD, and person-aimed feedback ("you forgot," "this is wrong") is exactly the shape that stalls work instead of advancing it. I run a personal fleet of agent systems tuned for an AUDHD operator; the work-not-person feedback rule is the one that survived a year of daily use, so I am contributing it upstream where it fits. No new rule number: this stays inside rule 8, so the README's rule list, the translations, and all manifests are untouched.

Kept additive and modest on purpose: no medical claims, no diagnosis language, one paragraph and one Bad/Good pair in the canonical skill plus the synchronized Cursor mirror.

## Authorship and provenance — select exactly one

- [ ] **Human-authored** — substantive implementation and text were produced by a human.
- [x] **Autonomous agent-authored** — an agent planned and produced most of the substantive change.
- [ ] **Hybrid** — a human and one or more agents both made substantive contributions.

**Agent/tool and model/version:** Claude Code, Claude Fable 5 (claude-fable-5).

**Agent contribution:** Analysis of the existing ruleset, the rule-8 text, the Cursor mirror sync, running the verification commands, and this PR description.

**Human verification:** The repository owner (Assaf Kipnis) directed the contribution (extend rule 8 with work-not-person feedback, keep it additive) and reviews the diff on this PR. The final-accountability boxes below stay unchecked until that review is done; a follow-up comment will confirm it.

**Known limitations or uncertain results:** Paired baseline/candidate behavior evals were not run for this change (provider cost; no runner config in this environment). The change is additive prose inside one rule; the free checks below were run.

## Labels

**Target label:** Target:Rules

**Author label:** Author:AI

**Workflow labels:** enhancement

## Safety and side effects

- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [x] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [x] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects, permissions, network access, and cost:** None. Two markdown files change (canonical skill + Cursor mirror); no scripts, hooks, manifests, or workflows touched.

## Compatibility

- [x] This is not a breaking change.
- [ ] This is a breaking change; it was discussed, and migration/deprecation documentation is included below.
- [x] Canonical and mirrored skill files are synchronized when applicable.
- [x] Relevant platform manifests and installation documentation were reviewed.

**Migration or rollback notes:** None needed; additive text inside an existing rule.

## Verification

- `python3 -m unittest discover -s tests -v` — OK (all tests pass)
- `python3 scripts/run_evals.py validate` — "Evaluation cases are valid."
- `cmp skills/i-have-adhd/SKILL.md .cursor/skills/i-have-adhd/SKILL.md` — identical (mirror synchronized)

**Behavior evals:** Not run; disclosed above under known limitations. If maintainers want a paired eval before merging, an eval case for person-aimed feedback would pair naturally with this change and I am glad to add one to `evals/cases.jsonl`.

## Final accountability

- [ ] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content.
- [x] All failed, skipped, or unrun checks are disclosed above.
