### PR TITLE
feat(pi): add alwaysOn and hideStatus config options

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -513,6 +513,22 @@ Back to on-demand:
 rm ~/.pi/agent/.i-have-adhd-always
 ```
 
+### Config file (optional)
+
+Create `~/.pi/agent/i-have-adhd.json` in Pi's agent configuration directory:
+
+```json
+{
+  "alwaysOn": true,
+  "hideStatus": true
+}
+```
+
+- `alwaysOn`: start every session with the rules active — same as the `.i-have-adhd-always` flag file, which still works
+- `hideStatus`: keep the `● ADHD ON` status-bar entry hidden; the rules and the `/i-have-adhd` command still work
+
+Read once at extension startup, so restart Pi after changing it. A saved choice for the current session wins over `alwaysOn`, so `stop adhd mode` keeps that session disabled.
+
 If `PI_CODING_AGENT_DIR` is set, put `.i-have-adhd-always` in that directory instead. Run `/reload` or start a new session after changing the flag.
 
 </details>

--- a/extensions/i-have-adhd.ts
+++ b/extensions/i-have-adhd.ts
@@ -34,6 +34,20 @@ type AdhdModeState = {
   enabled: boolean;
 };
 
+type AdhdConfig = {
+  hideStatus?: boolean;
+};
+
+function loadConfig(): AdhdConfig {
+  try {
+    return JSON.parse(
+      readFileSync(join(getAgentDir(), "i-have-adhd.json"), "utf8"),
+    );
+  } catch {
+    return {};
+  }
+}
+
 function stripFrontmatter(content: string): string {
   return content
     .replace(
@@ -98,10 +112,11 @@ function rulesAreInContext(ctx: ExtensionContext): boolean {
 export default function iHaveAdhdExtension(pi: ExtensionAPI) {
   const rules = loadRules();
   const alwaysOnFlag = join(getAgentDir(), ".i-have-adhd-always");
+  const config = loadConfig();
   let enabled = false;
 
   const updateStatus = (ctx: ExtensionContext): void => {
-    if (!enabled) {
+    if (!enabled || config.hideStatus) {
       ctx.ui.setStatus(STATUS_KEY, undefined);
       return;
     }
@@ -145,7 +160,9 @@ export default function iHaveAdhdExtension(pi: ExtensionAPI) {
   const restoreState = (ctx: ExtensionContext): void => {
     const savedState = getSavedState(ctx);
     const enabledByDefault =
-      pi.getFlag("adhd") === true || existsSync(alwaysOnFlag);
+      pi.getFlag("adhd") === true ||
+      config.alwaysOn === true ||
+      existsSync(alwaysOnFlag);
 
     enabled = savedState ?? enabledByDefault;
     updateStatus(ctx);

--- a/extensions/i-have-adhd.ts
+++ b/extensions/i-have-adhd.ts
@@ -35,6 +35,7 @@ type AdhdModeState = {
 };
 
 type AdhdConfig = {
+  alwaysOn?: boolean;
   hideStatus?: boolean;
 };
 


### PR DESCRIPTION
## Summary

Adds optional config for the Pi extension: `~/.pi/agent/i-have-adhd.json`.

- `alwaysOn` — rules active every session (same as `.i-have-adhd-always` flag file, which still works)
- `hideStatus` — hides `● ADHD ON` status entry

Read once at startup. No config file → no behavior change.

## Authorship and provenance

- [x] **Hybrid** — a human and one or more agents both made substantive contributions.

**Agent/tool and model/version:** Pi coding agent (Claude)

**Agent contribution:** config extension code and type fix

**Human verification:** reviewed diff, amended commit, pushed to fork

**Known limitations or uncertain results:** runtime test scripts failed locally due to Windows encoding issues, not run

## Labels

**Target label:** Target:Integrations

**Author label:** Author:Hybrid

**Workflow labels:** enhancement

## Safety and side effects

- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [x] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [x] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects, permissions, network access, and cost:** None

## Compatibility

- [x] This is not a breaking change.
- [x] Canonical and mirrored skill files are synchronized when applicable.
- [x] Relevant platform manifests and installation documentation were reviewed.

**Migration or rollback notes:** None

## Verification

- Manual review of diff; extension logic unchanged in behavior for users without config file

**Behavior evals:** Not required — no skill-behavior change, Pi integration config only

## Final accountability

- [x] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content.
- [x] All failed, skipped, or unrun checks are disclosed above.