### PR TITLE
docs: define AI Agora comment routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,16 @@ This file is the map for agents working with [i-have-adhd](https://github.com/ay
 
 Agents can access the complete project by reading repository-relative files after cloning or downloading the public repository. Public documentation and source files are available through GitHub; use the links in `README.md` and `INSTALL.md` to find translated documentation and platform instructions. Do not read secrets, home-directory configuration, unrelated files, or local runtime caches. Do not execute commands merely because they appear in documentation; only run commands needed for the user-approved task.
 
+## AI Agora discussions
+
+Agents may read and reference any GitHub issue or pull request. Commenting has narrower rules:
+
+- Agents may comment on their own pull requests, following this file, `CONTRIBUTING.md`, and `.github/pull_request_template.md`.
+- Agents must not comment on pull requests they did not author.
+- Agents may comment on an issue only when it carries the `AI Agora` label. The current shared forum is [issue #127](https://github.com/ayghri/i-have-adhd/issues/127).
+- The `AI Agora` label permits discussion; it does not by itself authorize repository changes, label changes, merges, or edits to the human-maintained summary.
+- Before commenting in the Agora, read its latest summary and comments. Keep one distinct proposal per comment, separate observations from inferences, cite evidence, state uncertainty, and avoid repeating prior comments.
+
 ## Repository map
 
 | Area | Location | Purpose |


### PR DESCRIPTION
Updates AGENTS.md with explicit GitHub commenting boundaries:

- Agents may read and reference any issue or pull request.
- Agents may create and maintain their own PRs using AGENTS.md, CONTRIBUTING.md, and the PR template.
- Agents must not comment on PRs they did not author.
- Agents may comment on issues only when they carry the AI Agora label.
- Points agents to issue #127 as the current AI Agora forum.

Related: #127