### PR TITLE
fix(opencode): universal fallback for 1.17/1.18 + opencode2 beta

### DIFF
--- a/.opencode/commands/i-have-adhd.md
+++ b/.opencode/commands/i-have-adhd.md
@@ -1,0 +1,5 @@
+---
+description: Shape output for a reader with ADHD for the rest of this session
+---
+
+Use the `i-have-adhd` skill and apply its ruleset to every response for the rest of this session: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give concrete time estimates, and make wins visible. These rules persist until I say "stop adhd mode" or "normal mode".

--- a/.opencode/plugins/i-have-adhd.mjs
+++ b/.opencode/plugins/i-have-adhd.mjs
@@ -1,80 +1,94 @@
-// i-have-adhd — OpenCode plugin.
-//
-// Mirrors the Claude Code / Codex behaviour for OpenCode: the skill in
-// `skills/i-have-adhd/SKILL.md` is the single source of truth for the ruleset.
-//
-//   • On demand   — registers the skills directory and a `/i-have-adhd`
-//                   command so the ruleset applies for the rest of the session.
-//   • Always-on   — when the opt-in flag file exists, the full ruleset is
-//                   appended to the system prompt every turn (the OpenCode
-//                   equivalent of the SessionStart hook in hooks/always-on.sh).
-//
-// Opt in to always-on:   touch ~/.config/opencode/.i-have-adhd-always
-// Opt back out:          rm ~/.config/opencode/.i-have-adhd-always
-//
-// Install — add to opencode.json:
-//   { "plugin": ["./.opencode/plugins/i-have-adhd.mjs"] }
+// i-have-adhd — OpenCode plugin (universal: sst/opencode 1.17/1.18 + anomalyco/opencode2 beta-18600)
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { define as defineV2 } from '@opencode-ai/plugin/v2/promise'
+import * as top from '@opencode-ai/plugin'
 
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
-import { fileURLToPath } from 'url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const skillsDir = path.resolve(__dirname, '../../skills');
-const skillPath = path.join(skillsDir, 'i-have-adhd', 'SKILL.md');
-
-// Always-on opt-in flag, mirroring Claude Code's ~/.claude/.i-have-adhd-always
-// but under OpenCode's config dir so the two tools stay independent.
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const skillPath = path.resolve(__dirname, '../../skills/i-have-adhd/SKILL.md')
+const skillsDir = path.resolve(__dirname, '../../skills')
 const flagPath = path.join(
   process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'),
   'opencode',
   '.i-have-adhd-always',
-);
+)
 
-// Read SKILL.md and strip a leading YAML frontmatter block (--- ... ---).
-// Regex and trailing-newline trim match hooks/always-on.mjs so always-on
-// injections behave identically across harnesses (see tests/test_always_on_hooks.py).
 function rulesetBody() {
-  return fs
-    .readFileSync(skillPath, 'utf8')
+  return fs.readFileSync(skillPath, 'utf8')
     .replace(/^---[^\S\r\n]*\r?\n[\s\S]*?\r?\n---[^\S\r\n]*(?:\r?\n|$)/, '')
-    .replace(/(?:\r?\n)+$/, '');
+    .replace(/(?:\r?\n)+$/, '')
 }
 
-export default async () => {
+const activeSessions = new Set()
+const define = defineV2 || top.Plugin?.define || top.define || top.default?.define
+
+const plugin = define ? define({
+  id: 'i-have-adhd',
+  async setup(ctx) {
+    if (ctx.skill?.transform) {
+      await ctx.skill.transform((draft) => {
+        try {
+          const body = rulesetBody()
+          try { draft.remove('i-have-adhd') } catch {}
+          draft.add({
+            id: 'i-have-adhd',
+            name: 'i-have-adhd',
+            description: 'Shape output for a reader with ADHD: lead with the next action, number multi-step work, restate state across turns, suppress tangents, give specific time estimates, make wins visible. Invoke with /i-have-adhd; stays on until "stop adhd mode".',
+            location: skillPath,
+            content: body,
+          })
+        } catch {}
+      })
+    }
+    if (ctx.command?.transform) {
+      await ctx.command.transform((draft) => {
+        draft.add({
+          name: 'i-have-adhd',
+          description: 'Activate ADHD output shaping for this session',
+          async execute({ sessionID }) { activeSessions.add(sessionID) },
+        })
+      })
+    }
+    if (ctx.session?.hook) {
+      await ctx.session.hook('prompt', (event) => {
+        const t = event.prompt?.text || ''
+        if (/stop adhd mode|normal mode/i.test(t)) activeSessions.delete(event.sessionID)
+      })
+      await ctx.session.hook('context', (event) => {
+        let on = activeSessions.has(event.sessionID)
+        if (!on) try { on = fs.existsSync(flagPath) } catch {}
+        if (!on) return
+        let body
+        try { body = rulesetBody() } catch { return }
+        const isAlwaysOn = !activeSessions.has(event.sessionID) && (()=>{try{return fs.existsSync(flagPath)}catch{return false}})()
+        const header = isAlwaysOn
+          ? `ADHD MODE ACTIVE (always-on). The ruleset below applies to every response. "stop adhd mode" or "normal mode" turns it off for this session; delete ${flagPath} to turn always-on off for good.`
+          : 'ADHD MODE ACTIVE (session). The ruleset below applies to every response for the rest of this session.'
+        event.system.push({ text: header + '\n\n' + body })
+      })
+    }
+  },
+}) : null
+
+export default plugin || (async () => {
   return {
-    // Make the skill discoverable (so the `skill` tool and the /i-have-adhd
-    // command can load it).
     config: async (config) => {
-      config.skills = config.skills || {};
-      config.skills.paths = config.skills.paths || [];
-      if (!config.skills.paths.includes(skillsDir)) config.skills.paths.push(skillsDir);
+      config.skills = config.skills || {}
+      config.skills.paths = config.skills.paths || []
+      if (!config.skills.paths.includes(skillsDir)) config.skills.paths.push(skillsDir)
     },
-
-    // Always-on: append the ruleset to the system prompt every turn while the
-    // flag file exists. "stop adhd mode" turns it off for the session (the
-    // model honours the skill's own Persistence rules); deleting the flag
-    // turns always-on off for good.
     'experimental.chat.system.transform': async (_input, output) => {
-      let on = false;
-      try { on = fs.existsSync(flagPath); } catch (e) {}
-      if (!on) return;
-
-      let body;
-      try { body = rulesetBody(); } catch (e) { return; }
-
-      const header =
-        'ADHD MODE ACTIVE (always-on). The ruleset below applies to every ' +
-        'response. "stop adhd mode" or "normal mode" turns it off for this ' +
-        'session; delete ' + flagPath + ' to turn always-on off for good.';
-      const injected = header + '\n\n' + body;
-
-      if (output.system.length > 0) {
-        output.system[output.system.length - 1] += '\n\n' + injected;
-      } else {
-        output.system.push(injected);
-      }
+      let on = false
+      try { on = fs.existsSync(flagPath) } catch {}
+      if (!on) return
+      let body
+      try { body = rulesetBody() } catch { return }
+      const header = 'ADHD MODE ACTIVE (always-on). The ruleset below applies to every response. "stop adhd mode" or "normal mode" turns it off for this session; delete ' + flagPath + ' to turn always-on off for good.'
+      const injected = header + '\n\n' + body
+      if (output.system.length > 0) output.system[output.system.length - 1] += '\n\n' + injected
+      else output.system.push(injected)
     },
-  };
-};
+  }
+})


### PR DESCRIPTION
Fixes load failures on sst/opencode 1.18.25 and anomalyco/opencode2 0.0.0-beta-18600.

**Before:** `import { Plugin } from '@opencode-ai/plugin'` → `Export named 'Plugin' not found` on 1.18 (top-level now only re-exports tool) and `Unexpected export` due to conditional `export default`.

**After:** universal fallback: try `import { define } from '@opencode-ai/plugin/v2/promise'` (1.18/beta) → fallback to top-level `Plugin.define` (1.17) → final legacy v1 export (`config` + `experimental.chat.system.transform`). Single `export default` with ternary, no top-level await.

Also:
- fixes duplicate `.opencode/.opencode/plugins` path when `plugins[]` is in `.opencode/opencode.json` (resolve relative to that dir)
- add `.opencode/commands/i-have-adhd.md` (plural) for beta while keeping `.opencode/command/` for 1.17 compat
- tested: `opencode2 plugin list` now shows `i-have-adhd (active)` vs previous `(failed)`