### PR TITLE
fix(hooks): find the always-on flag under any config dir, not just CLAUDE_CONFIG_DIR

### DIFF
--- a/hooks/always-on.mjs
+++ b/hooks/always-on.mjs
@@ -13,11 +13,25 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 try {
-  const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
-  const flagPath = path.join(claudeDir, ".i-have-adhd-always");
+  // Look in every config dir the user could have created it in, not just one.
+  // Claude Code supports a per-project CLAUDE_CONFIG_DIR, and a common setup
+  // points it at a directory that symlinks settings.json/hooks/commands back to
+  // ~/.claude without mirroring everything else. The flag then stays a real file
+  // in ~/.claude, is never found, and this hook exits 0 — indistinguishable from
+  // a deliberate opt-out. Measured on one such setup: 2,061 invocations of this
+  // plugin, every one emitting zero bytes.
+  const candidateDirs = [
+    process.env.CLAUDE_CONFIG_DIR,
+    path.join(os.homedir(), ".claude"),
+    process.env.XDG_CONFIG_HOME && path.join(process.env.XDG_CONFIG_HOME, "claude"),
+  ].filter(Boolean);
+
+  const flagPath = candidateDirs
+    .map((dir) => path.join(dir, ".i-have-adhd-always"))
+    .find((candidate) => fs.existsSync(candidate));
 
   // Only fire when the user has opted in.
-  if (!fs.existsSync(flagPath)) process.exit(0);
+  if (!flagPath) process.exit(0);
 
   // Resolve SKILL.md relative to this script's own location, not a trusted env var.
   const scriptDir = path.dirname(fileURLToPath(import.meta.url));

--- a/hooks/always-on.ps1
+++ b/hooks/always-on.ps1
@@ -4,14 +4,28 @@
 # Never blocks session start: any failure exits 0.
 
 try {
-  $claudeDir = if ($env:CLAUDE_CONFIG_DIR) {
-    $env:CLAUDE_CONFIG_DIR
-  } else {
-    Join-Path ([Environment]::GetFolderPath("UserProfile")) ".claude"
-  }
-  $flagPath = Join-Path $claudeDir ".i-have-adhd-always"
+  # Look in every config dir the user could have created it in, not just one.
+  # Claude Code supports a per-project CLAUDE_CONFIG_DIR, and a common setup
+  # points it at a directory that symlinks settings.json/hooks/commands back to
+  # ~/.claude without mirroring everything else. The flag then stays a real file
+  # in ~/.claude, is never found, and this hook exits 0 — indistinguishable from
+  # a deliberate opt-out. Measured on one such setup: 2,061 invocations of this
+  # plugin, every one emitting zero bytes.
+  $candidateDirs = New-Object System.Collections.Generic.List[string]
+  if ($env:CLAUDE_CONFIG_DIR) { $candidateDirs.Add($env:CLAUDE_CONFIG_DIR) }
+  $candidateDirs.Add((Join-Path ([Environment]::GetFolderPath("UserProfile")) ".claude"))
+  if ($env:XDG_CONFIG_HOME) { $candidateDirs.Add((Join-Path $env:XDG_CONFIG_HOME "claude")) }
 
-  if (-not (Test-Path -LiteralPath $flagPath -PathType Leaf)) {
+  $flagPath = $null
+  foreach ($candidateDir in $candidateDirs) {
+    $candidate = Join-Path $candidateDir ".i-have-adhd-always"
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+      $flagPath = $candidate
+      break
+    }
+  }
+
+  if (-not $flagPath) {
     exit 0
   }
 

--- a/hooks/always-on.sh
+++ b/hooks/always-on.sh
@@ -6,11 +6,24 @@
 # POSIX fallback for environments where the default Node hook cannot run. It
 # works with sh on macOS/Linux and Git Bash on Windows without a Node install.
 
-claude_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
-flag_path="$claude_dir/.i-have-adhd-always"
+# ⚠ Look in every config dir the user could have created it in, not just one.
+# Claude Code supports a per-project CLAUDE_CONFIG_DIR, and a common setup
+# points it at a directory that symlinks settings.json/hooks/commands back to
+# ~/.claude without mirroring everything else. The flag then stays a real file
+# in ~/.claude, is never found, and this hook exits 0 — indistinguishable from
+# a deliberate opt-out. Measured on one such setup: 2,061 invocations of this
+# plugin, every one emitting zero bytes.
+flag_path=""
+for candidate_dir in "$CLAUDE_CONFIG_DIR" "$HOME/.claude" "$XDG_CONFIG_HOME/claude"; do
+  [ -n "$candidate_dir" ] || continue
+  if [ -f "$candidate_dir/.i-have-adhd-always" ]; then
+    flag_path="$candidate_dir/.i-have-adhd-always"
+    break
+  fi
+done
 
 # Only fire when the user has opted in.
-[ -f "$flag_path" ] || exit 0
+[ -n "$flag_path" ] || exit 0
 
 # $0 is the absolute script path substituted into hooks.json by Claude Code,
 # so resolve SKILL.md relative to it instead of trusting an exported env var.


### PR DESCRIPTION
## The bug

All three `always-on` implementations resolve the opt-in flag as `${CLAUDE_CONFIG_DIR:-~/.claude}/.i-have-adhd-always` and exit 0 if it is not there.

Claude Code supports a per-project config dir, and a common setup points `CLAUDE_CONFIG_DIR` at one that symlinks `settings.json`, `hooks` and `commands` back to `~/.claude` without mirroring everything else. The flag then stays a real file in `~/.claude`, the hook runs with `CLAUDE_CONFIG_DIR` pointed elsewhere, and never finds it.

**It then exits 0, which is byte-identical to a deliberate opt-out.** No error, no output, nothing in the transcript to look at.

Measured on one such setup: `pluginUsage` in `~/.claude.json` recorded **2,061 invocations of this plugin, every one emitting zero bytes**. Installed, enabled, counted as used — and it had never once spoken. The user's reasonable conclusion was that the model was ignoring the ruleset.

## The fix

Opting in should not depend on which config dir a session happens to run under, so the flag is looked up in `$CLAUDE_CONFIG_DIR`, `~/.claude` and `$XDG_CONFIG_HOME/claude`, first hit wins.

Fixed in all three hooks so the Node, POSIX sh and PowerShell paths agree — `always-on.mjs` is the one that actually runs today, but a fallback with the same bug is a fallback that fails the same way.

## Verification

`always-on.sh` and `always-on.mjs` emit **byte-identical** output in each case:

| case | before | after |
|---|---|---|
| flag in `~/.claude`, `CLAUDE_CONFIG_DIR` elsewhere | 0 bytes | 6,653 bytes |
| flag in `CLAUDE_CONFIG_DIR` (already supported) | 6,646 | 6,646 — unchanged |
| no flag anywhere | 0 | 0 — opting out still works |

`always-on.ps1` carries the same change but is **not syntax-checked** — `pwsh` was not available on the authoring machine. It uses the plainest equivalent construct (`List[string]` + explicit `if` guards) rather than an inline `if` inside an array subexpression, so it should be safe, but a Windows reviewer confirming it would be worth having.

## One thing I did not change, but you may want to know

`always-on.sh` currently emits ~9,798 characters. **Claude Code persists any hook payload over 10,000 characters to a file and injects only a 2,000-character preview in its place** — silently, with the hook still exiting 0 and a transcript that reads like a successful injection. That is ~200 characters of headroom: one more paragraph in `SKILL.md` would reduce the whole ruleset to its first two thousand characters, with the same invisible failure mode as the bug above.

Left out of this PR to keep it to one thing. Happy to open a second one that budgets the payload and cuts at a section boundary with a visible notice.