### PR TITLE
fix(tests): convert plugin paths to file URLs

### DIFF
--- a/tests/opencode_plugin_driver.mjs
+++ b/tests/opencode_plugin_driver.mjs
@@ -2,8 +2,10 @@
 // `experimental.chat.system.transform` hook against an empty system prompt, and
 // prints the resulting system text so tests can assert on the injected banner.
 // Nothing is printed when the hook injects nothing (always-on flag absent).
+import { pathToFileURL } from 'node:url';
+
 const pluginPath = process.argv[2];
-const { default: init } = await import(pluginPath);
+const { default: init } = await import(pathToFileURL(pluginPath).href);
 const hooks = await init();
 const output = { system: [] };
 await hooks['experimental.chat.system.transform']({}, output);

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -45,6 +45,15 @@ class OpenCodePluginTest(unittest.TestCase):
     def write_skill(self, text):
         (self.plugin_root / "skills" / "i-have-adhd" / "SKILL.md").write_text(text)
 
+    def test_imports_plugin_from_path_with_url_characters(self):
+        renamed_root = self.plugin_root.with_name("plugin #1")
+        self.plugin_root.rename(renamed_root)
+        self.plugin_root = renamed_root
+        self.opt_in()
+        result = self.run_plugin()
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertTrue(result.stdout)
+
     def test_silent_without_opt_in_flag(self):
         result = self.run_plugin()
         self.assertEqual(0, result.returncode, result.stderr)


### PR DESCRIPTION
## Summary
Convert the plugin filesystem path to a file URL before dynamic import in the OpenCode test driver. This handles Windows drive-letter paths and prevents URL characters such as `#` from truncating a plugin path. Add a regression using a directory named `plugin #1`.

Fixes #132.

## Authorship and provenance — select exactly one
- [ ] **Human-authored**
- [x] **Autonomous agent-authored**
- [ ] **Hybrid**

**Agent/tool and model/version:** Codex; exact model/version identifier is not available in this task.

**Agent contribution:** Investigated the issue, implemented the test-driver fix and regression test, reviewed the diff, ran checks, and prepared this draft.

**Human verification:** Pending. The submitting user requested publication for code review; no full human diff review or human-run checks are claimed. Please keep this PR in draft until human review is complete.

**Known limitations or uncertain results:** Checks ran on macOS, not Windows. The URL-character regression exercises file-URL conversion, but an actual Windows run remains outstanding.

## Labels
**Target label:** Target:Integrations

**Author label:** Author:AI

**Workflow labels:** bug

## Safety and side effects
- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [x] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [x] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects, permissions, network access, and cost:** The new test renames its temporary plugin fixture. No new network calls, dependencies, permissions, or provider costs.

## Compatibility
- [x] This is not a breaking change.
- [ ] This is a breaking change.

Canonical skill files, platform manifests, and installation documentation are unchanged; this is limited to the test driver.

**Migration or rollback notes:** No migration required.

## Verification
- `python3 -m unittest discover -s tests -v` — 42 tests passed.
- `python3 scripts/run_evals.py validate` — evaluation cases valid.
- `git diff --check` — passed.

The new URL-character regression failed before the fix.

**Behavior evals:** Not applicable; no material skill behavior or plugin runtime change.

## Final accountability
- [ ] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content. (Human review pending.)
- [x] All failed, skipped, or unrun checks are disclosed above.
