### PR TITLE
fix(opencode): register /i-have-adhd via config.command

### DIFF
--- a/.opencode/plugins/i-have-adhd.mjs
+++ b/.opencode/plugins/i-have-adhd.mjs
@@ -23,6 +23,7 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const skillsDir = path.resolve(__dirname, '../../skills');
 const skillPath = path.join(skillsDir, 'i-have-adhd', 'SKILL.md');
+const commandPath = path.join(__dirname, '..', 'command', 'i-have-adhd.md');
 
 // Always-on opt-in flag, mirroring Claude Code's ~/.claude/.i-have-adhd-always
 // but under OpenCode's config dir so the two tools stay independent.
@@ -42,6 +43,36 @@ function rulesetBody() {
     .replace(/(?:\r?\n)+$/, '');
 }
 
+// OpenCode only auto-discovers `.opencode/command/*.md` in project scope.
+// A global plugin install never sees that file, and skills registered via
+// `skills.paths` are omitted from the TUI `/` menu (source === "skill").
+// Registering through `config.command` makes the loader treat it as
+// source "command", which the menu shows. Keep the markdown file as the
+// source of truth so checkout-local and plugin-registered copies match.
+function slashCommand() {
+  const text = fs.readFileSync(commandPath, 'utf8');
+  const fence = '---';
+  if (!text.startsWith(fence)) {
+    return { description: '', template: text.trim() };
+  }
+  const rest = text.slice(fence.length).replace(/^[\r\n]+/, '');
+  const marker = '\n' + fence;
+  const idx = rest.indexOf(marker);
+  if (idx < 0) {
+    return { description: '', template: text.trim() };
+  }
+  const fm = rest.slice(0, idx);
+  const body = rest.slice(idx + marker.length);
+  let description = '';
+  for (const line of fm.split(/\r?\n/)) {
+    if (line.startsWith('description:')) {
+      description = line.slice('description:'.length).trim();
+      break;
+    }
+  }
+  return { description, template: body.trim() };
+}
+
 export default async () => {
   return {
     // Make the skill discoverable (so the `skill` tool and the /i-have-adhd
@@ -50,6 +81,17 @@ export default async () => {
       config.skills = config.skills || {};
       config.skills.paths = config.skills.paths || [];
       if (!config.skills.paths.includes(skillsDir)) config.skills.paths.push(skillsDir);
+
+      let command;
+      try {
+        command = slashCommand();
+      } catch (e) {
+        command = null;
+      }
+      if (command) {
+        config.command = config.command || {};
+        config.command['i-have-adhd'] = command;
+      }
     },
 
     // Always-on: append the ruleset to the system prompt every turn while the

--- a/.opencode/plugins/i-have-adhd.mjs
+++ b/.opencode/plugins/i-have-adhd.mjs
@@ -86,6 +86,7 @@ export default async () => {
       try {
         command = slashCommand();
       } catch (e) {
+        // Missing or unreadable command markdown must not fail plugin load.
         command = null;
       }
       if (command) {

--- a/tests/opencode_plugin_config_driver.mjs
+++ b/tests/opencode_plugin_config_driver.mjs
@@ -1,0 +1,14 @@
+// Test driver for the OpenCode plugin config hook.
+// Converts argv[2] with pathToFileURL so Windows absolute paths import.
+// Calls `config` and prints the resulting object as JSON.
+import { pathToFileURL } from 'node:url';
+
+const pluginPath = process.argv[2];
+const href = pluginPath.startsWith('file:')
+  ? pluginPath
+  : pathToFileURL(pluginPath).href;
+const { default: init } = await import(href);
+const hooks = await init();
+const config = JSON.parse(process.argv[3] || '{}');
+await hooks.config(config);
+process.stdout.write(JSON.stringify(config));

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import subprocess
@@ -39,6 +40,38 @@ class OpenCodePluginTest(unittest.TestCase):
             env=env,
         )
 
+    def run_config_hook(self, config=None):
+        env = os.environ.copy()
+        env["XDG_CONFIG_HOME"] = str(self.config_dir)
+        return subprocess.run(
+            [
+                "node",
+                str(ROOT / "tests" / "opencode_plugin_config_driver.mjs"),
+                str(self.plugin_root / ".opencode" / "plugins" / "i-have-adhd.mjs"),
+                json.dumps(config if config is not None else {}),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def command_markdown(self):
+        text = (
+            self.plugin_root / ".opencode" / "command" / "i-have-adhd.md"
+        ).read_text(encoding="utf-8")
+        fence = "---"
+        if not text.startswith(fence):
+            return "", text.strip()
+        rest = text[len(fence) :].lstrip("\r\n")
+        fm, _, body = rest.partition("\n" + fence)
+        description = ""
+        for line in fm.splitlines():
+            if line.startswith("description:"):
+                description = line.split(":", 1)[1].strip()
+                break
+        return description, body.strip()
+
     def opt_in(self):
         (self.config_dir / "opencode" / ".i-have-adhd-always").touch()
 
@@ -64,6 +97,26 @@ class OpenCodePluginTest(unittest.TestCase):
         result = self.run_plugin()
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertIn("Fixture body, fence never closed.", result.stdout)
+
+    def test_config_hook_registers_slash_command(self):
+        result = self.run_config_hook({})
+        self.assertEqual(0, result.returncode, result.stderr)
+        config = json.loads(result.stdout)
+        description, template = self.command_markdown()
+        command = config.get("command", {}).get("i-have-adhd")
+        self.assertIsNotNone(command)
+        self.assertEqual(description, command["description"])
+        # Node fs.readFileSync keeps CRLF; Path.read_text uses universal newlines.
+        self.assertEqual(template, command["template"].replace("\r\n", "\n"))
+
+    def test_config_hook_keeps_existing_commands(self):
+        result = self.run_config_hook(
+            {"command": {"other": {"template": "keep me"}}}
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        config = json.loads(result.stdout)
+        self.assertEqual("keep me", config["command"]["other"]["template"])
+        self.assertIn("i-have-adhd", config["command"])
 
 
 if __name__ == "__main__":

--- a/tests/test_opencode_plugin.py
+++ b/tests/test_opencode_plugin.py
@@ -118,6 +118,13 @@ class OpenCodePluginTest(unittest.TestCase):
         self.assertEqual("keep me", config["command"]["other"]["template"])
         self.assertIn("i-have-adhd", config["command"])
 
+    def test_config_hook_tolerates_missing_command_file(self):
+        (self.plugin_root / ".opencode" / "command" / "i-have-adhd.md").unlink()
+        result = self.run_config_hook({})
+        self.assertEqual(0, result.returncode, result.stderr)
+        config = json.loads(result.stdout)
+        self.assertNotIn("i-have-adhd", config.get("command", {}))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

OpenCode's documented `/i-have-adhd` command never appears after a global plugin install.

`INSTALL.md` says the plugin registers the command and the Verify step is "type `/` and confirm `i-have-adhd` appears." The plugin only appended the skills directory to `config.skills.paths`. OpenCode auto-discovers `.opencode/command/*.md` in project scope, so a plugin loaded from an absolute path never sees that file. Skills registered through `skills.paths` also stay out of the TUI `/` menu (`source === "skill"`).

The plugin now reads `.opencode/command/i-have-adhd.md` and sets `config.command["i-have-adhd"]` (description + template). OpenCode treats that as `source === "command"`, which the menu shows. Existing `config.command` entries are left in place. A missing markdown file is ignored so plugin load still succeeds.

Fixes #140

## Authorship and provenance — select exactly one

- [ ] **Human-authored** — substantive implementation and text were produced by a human.
- [x] **Autonomous agent-authored** — an agent planned and produced most of the substantive change.
- [ ] **Hybrid** — a human and one or more agents both made substantive contributions.

**Agent/tool and model/version:** Hermes Agent (Nous Research)

**Agent contribution:** Root-cause against the OpenCode plugin `config` hook, implementation, regression tests, and this description.

**Human verification:** Diff reviewed before opening. Commands actually run are listed below. Live OpenCode TUI was not run.

**Known limitations or uncertain results:** The TUI `/` menu was not checked in a live OpenCode session. Three existing always-on plugin tests still fail on Windows because `tests/opencode_plugin_driver.mjs` passes a `c:` path to `import()` (tracked in #132 / PR #135). This change does not touch that driver.

## Labels

**Target label:** Target:Integrations

**Author label:** Author:AI

**Workflow labels:** bug

## Safety and side effects

- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [x] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [x] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects, permissions, network access, and cost:**

Reads `.opencode/command/i-have-adhd.md` next to the plugin (same checkout). Missing file is caught and skipped. No network, no writes outside the repo, no new dependencies.

## Compatibility

- [x] This is not a breaking change.
- [ ] This is a breaking change; it was discussed, and migration/deprecation documentation is included below.
- [x] Canonical and mirrored skill files are synchronized when applicable.
- [x] Relevant platform manifests and installation documentation were reviewed.

**Migration or rollback notes:**

None. Additive `config.command` registration. Skill files unchanged. `INSTALL.md` already documents `/i-have-adhd`; behavior now matches that contract.

## Verification

- `python -m unittest tests.test_opencode_plugin.OpenCodePluginTest.test_config_hook_registers_slash_command tests.test_opencode_plugin.OpenCodePluginTest.test_config_hook_keeps_existing_commands tests.test_opencode_plugin.OpenCodePluginTest.test_config_hook_tolerates_missing_command_file -v` — 3 passed. Without the plugin change the first two fail (`command` is `None` / `'i-have-adhd' not found`). Without the try/catch around the markdown read, the missing-file test fails with `ENOENT`. With the change all three pass.
- `python -m unittest tests.test_opencode_plugin -v` — the three new tests pass. The three always-on tests fail on Windows with `ERR_UNSUPPORTED_ESM_URL_SCHEME` from the existing driver (`opencode_plugin_driver.mjs`). Same failure on the untouched driver; not introduced here.
- `python -m unittest discover -s tests -v` — 43 tests, 6 failures. 3 are the Windows driver issue above. 3 are `test_judge.EndToEndTest` (`cat` on a Windows temp path). Unrelated to this change. After the extra missing-file test the class has 6 methods; discover count may be 44.
- `python3 scripts/run_evals.py validate` — not run (eval harness untouched).
- Live OpenCode TUI `/` menu — not run.

**Behavior evals:** Not run. This is plugin command registration, not a skill-behavior change.

## Final accountability

- [x] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content.
- [x] All failed, skipped, or unrun checks are disclosed above.
