### PR TITLE
Fix #132: import OpenCode plugin via pathToFileURL for Windows

### DIFF
--- a/tests/opencode_plugin_driver.mjs
+++ b/tests/opencode_plugin_driver.mjs
@@ -2,8 +2,10 @@
 // `experimental.chat.system.transform` hook against an empty system prompt, and
 // prints the resulting system text so tests can assert on the injected banner.
 // Nothing is printed when the hook injects nothing (always-on flag absent).
+import { pathToFileURL } from 'node:url';
+
 const pluginPath = process.argv[2];
-const { default: init } = await import(pluginPath);
+const { default: init } = await import(pathToFileURL(pluginPath).href);
 const hooks = await init();
 const output = { system: [] };
 await hooks['experimental.chat.system.transform']({}, output);


### PR DESCRIPTION
Fixes #132. On Windows, dynamically importing the plugin with a raw absolute path fails with ERR_UNSUPPORTED_ESM_URL_SCHEME (received protocol 'c:'). Convert the argv path with pathToFileURL(...).href from node:url before importing so it becomes a valid file:// URL. Test-driver only; no skill or plugin behavior change. Verified: tests/test_opencode_plugin.py 3/3 pass on Windows (were 3/3 fail before). Full suite: only the 4 pre-existing test_judge/test_run_evals env errors remain (also fail on clean tree).