### PR TITLE
docs(install): fix Hermes activation instructions (#118)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -304,7 +304,7 @@ Exceptions: explain fully when asked to explain. Confirm before destructive acti
 hermes skills install ayghri/i-have-adhd/skills/i-have-adhd
 ```
 
-Type `/i-have-adhd`. The skill installs into `~/.hermes/skills/` and is exposed as a slash command at the next session start.
+The skill installs into `~/.hermes/skills/`. Hermes has no per-skill slash-command registry, so `/i-have-adhd` is not a recognized command — activate it by asking the agent directly (e.g. "use i-have-adhd mode" or "apply the i-have-adhd skill"), or let Hermes load it automatically when the conversation matches the skill's description. Say "stop adhd mode" or "normal mode" to turn it off.
 
 Prefer to browse first? Add this repo as a skill source (a "tap"), then search and install:
 


### PR DESCRIPTION
## Summary

Hermes has no per-skill slash-command registry (confirmed in #118), so `/i-have-adhd` doesn't do anything there — INSTALL.md's Hermes section tells users to type it anyway. This swaps that line for the real activation path: ask the agent directly, or let Hermes load the skill from its description.

## Authorship and provenance — select exactly one

- [ ] **Human-authored**
- [x] **Autonomous agent-authored**
- [ ] **Hybrid**

**Agent/tool and model/version:** Claude Code, Sonnet 5 (claude-sonnet-5)

**Agent contribution:** Read the issue and reproduced the described Hermes behavior against INSTALL.md, then wrote the doc fix.

**Human verification:** The repo owner (wakqasahmed) directed this fix and will review the diff; not independently re-verified against a live Hermes install beyond the issue's own repro.

**Known limitations or uncertain results:** None known.

## Labels

**Target label:** Target:Docs

**Author label:** Author:AI

**Workflow labels:** bug

## Safety and side effects

- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [x] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [x] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects, permissions, network access, and cost:** None — one line of documentation.

## Compatibility

- [x] This is not a breaking change.
- [ ] This is a breaking change
- [ ] Canonical and mirrored skill files are synchronized when applicable.
- [x] Relevant platform manifests and installation documentation were reviewed.

**Migration or rollback notes:** None.

## Verification

- `python3 -m unittest discover -s tests -v` — 41 tests, OK
- `python3 scripts/run_evals.py validate` — cases valid
- `git diff --check` — clean

## Final accountability

- [x] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content.
- [x] All failed, skipped, or unrun checks are disclosed above.
