### PR TITLE
fix(hooks): warn on stderr when plugin root is unresolved (#129)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"(async()=>{const root=process.env.CLAUDE_PLUGIN_ROOT||process.env.PLUGIN_ROOT;if(root)await import(require('node:url').pathToFileURL(require('node:path').join(root,'hooks','always-on.mjs')).href)})().catch(()=>{})\"",
+            "command": "node -e \"(async()=>{const fs=require('node:fs'),os=require('node:os'),path=require('node:path');const cfgDir=process.env.CLAUDE_CONFIG_DIR||path.join(os.homedir(),'.claude');const flagged=fs.existsSync(path.join(cfgDir,'.i-have-adhd-always'));const root=process.env.CLAUDE_PLUGIN_ROOT||process.env.PLUGIN_ROOT;if(root){await import(require('node:url').pathToFileURL(path.join(root,'hooks','always-on.mjs')).href)}else if(flagged){process.stderr.write('i-have-adhd: always-on is enabled but CLAUDE_PLUGIN_ROOT/PLUGIN_ROOT was not provided to the SessionStart hook, so the ruleset was not injected this session (see https://github.com/ayghri/i-have-adhd/issues/129).\\n')}})().catch(()=>{})\"",
             "timeout": 30,
             "statusMessage": "Checking i-have-adhd always-on flag..."
           }

--- a/tests/test_always_on_hooks.py
+++ b/tests/test_always_on_hooks.py
@@ -53,14 +53,21 @@ class AlwaysOnHookTest(unittest.TestCase):
             env=env,
         )
 
-    def run_codex_hook(self, plugin_root=None):
+    def run_codex_hook(self, plugin_root=None, unset_plugin_root=False):
         config = json.loads((ROOT / "hooks" / "hooks.json").read_text())
         hook = config["hooks"]["SessionStart"][0]["hooks"][0]
         env = os.environ.copy()
         env["CLAUDE_CONFIG_DIR"] = str(self.config_dir)
-        plugin_root = plugin_root or self.plugin_root
-        env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
-        env["PLUGIN_ROOT"] = str(plugin_root)
+        if unset_plugin_root:
+            # Simulates the Claude Code desktop app (#129): it substitutes
+            # ${CLAUDE_PLUGIN_ROOT} into hook args but does not export either
+            # variable into the hook's process environment.
+            env.pop("CLAUDE_PLUGIN_ROOT", None)
+            env.pop("PLUGIN_ROOT", None)
+        else:
+            plugin_root = plugin_root or self.plugin_root
+            env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
+            env["PLUGIN_ROOT"] = str(plugin_root)
         return subprocess.run(
             hook["command"],
             check=False,
@@ -155,6 +162,28 @@ class AlwaysOnHookTest(unittest.TestCase):
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertEqual("", result.stderr)
         self.assertEqual("", result.stdout)
+
+    def test_codex_command_stays_silent_when_plugin_root_missing_and_not_opted_in(self):
+        # No opt-in flag and no plugin-root env var: most users on a host
+        # that never exports it (#129). Nothing to report, so stay silent.
+        result = self.run_codex_hook(unset_plugin_root=True)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("", result.stdout)
+        self.assertEqual("", result.stderr)
+
+    def test_codex_command_warns_on_stderr_when_opted_in_but_plugin_root_missing(self):
+        # Regression test for #129: previously this combination failed
+        # completely silently (exit 0, no stdout, no stderr), indistinguishable
+        # from "always-on is off". Opted-in users now get a diagnostic.
+        (self.config_dir / ".i-have-adhd-always").touch()
+
+        result = self.run_codex_hook(unset_plugin_root=True)
+
+        self.assertEqual(0, result.returncode, result.stdout)
+        self.assertEqual("", result.stdout)
+        self.assertIn("CLAUDE_PLUGIN_ROOT", result.stderr)
+        self.assertIn("issues/129", result.stderr)
 
     def test_hook_uses_a_shared_claude_and_codex_launcher(self):
         config = json.loads((ROOT / "hooks" / "hooks.json").read_text())


### PR DESCRIPTION
## Summary

On the Claude Code desktop app, `CLAUDE_PLUGIN_ROOT`/`PLUGIN_ROOT` never reach the SessionStart hook's process environment (#129), so the always-on hook did nothing at all — no banner, no error, exit 0. A user with always-on enabled had no way to tell it from always-on simply being off.

Full architectural fixes (resolving the plugin root from the hook script's own location, or switching to host-side `${CLAUDE_PLUGIN_ROOT}` substitution in `args`) would need real desktop-app testing I don't have access to here, and the existing test suite locks in the current single-`command`-string shape specifically because that's what unbroke Codex in #91 — reintroducing `args` risks that regression again without a way to verify it against Codex either. So this takes the reporter's own explicitly-stated fallback instead: the hook now checks the opt-in flag first (independent of plugin root — it's a plain file-existence check under `CLAUDE_CONFIG_DIR`) and only writes a one-line stderr diagnostic when a user who *has* opted in also hits the missing-root case. Everyone who hasn't opted into always-on sees no behavior change at all.

## Authorship and provenance — select exactly one

- [ ] **Human-authored**
- [x] **Autonomous agent-authored**
- [ ] **Hybrid**

**Agent/tool and model/version:** Claude Code, Sonnet 5 (claude-sonnet-5)

**Agent contribution:** Wrote the fix and tests, and manually exercised all four flag/root combinations against the real hook command in a shell before writing them up as tests.

**Human verification:** The repo owner (wakqasahmed) directed this fix and will review the diff. Not verified against the real desktop app itself — only against the hook command run standalone with the desktop app's reported environment shape (no `CLAUDE_PLUGIN_ROOT`/`PLUGIN_ROOT`, opt-in flag present/absent).

**Known limitations or uncertain results:** This doesn't make always-on actually work on the desktop app — it only makes the failure visible instead of silent, which is the reporter's own stated "at minimum" ask. Making it actually work needs a maintainer decision on #129's fuller options (a real fallback-resolution mechanism or a second chained hook entry), plus desktop-app access to verify.

## Labels

**Target label:** Target:Integrations

**Author label:** Author:AI

**Workflow labels:** bug

## Safety and side effects

- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [x] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [x] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects, permissions, network access, and cost:** None. Adds one `fs.existsSync` check (same flag-file check `always-on.mjs` already does) and one conditional `stderr.write`; still exits 0 in every case.

## Compatibility

- [x] This is not a breaking change.
- [ ] This is a breaking change
- [ ] Canonical and mirrored skill files are synchronized when applicable.
- [x] Relevant platform manifests and installation documentation were reviewed.

**Migration or rollback notes:** None. Users who never opted into always-on see byte-identical behavior (verified by test and by hand). Opted-in users only gain a stderr line in the one case that was previously silently broken.

## Verification

- `python3 -m unittest discover -s tests -v` — 43 tests, OK (2 new: silent when not opted in and root missing; stderr diagnostic when opted in and root missing)
- `python3 scripts/run_evals.py validate` — cases valid
- `git diff --check` — clean
- Manually ran the exact hook command from `hooks/hooks.json` through all 4 flag×root combinations in a shell before writing the corresponding tests; output matched what's asserted (silent / banner / silent / stderr diagnostic).

## Final accountability

- [x] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content.
- [x] All failed, skipped, or unrun checks are disclosed above.
