### PR TITLE
fix(evals): handle non-object judge responses (#151)

### DIFF
--- a/scripts/judge.py
+++ b/scripts/judge.py
@@ -118,12 +118,16 @@ def parse_judge_scores(
     """Turn one judge response into score rows keyed by condition, not label."""
     case_id, trial = group_key
     verdicts = json.loads(_strip_code_fence(payload))
+    if not isinstance(verdicts, dict):
+        raise ValueError(f"{case_id}/trial {trial}: judge response must be a JSON object")
     rows = []
     for condition, label in sorted(labels.items()):
         where = f"{case_id}/trial {trial}/label {label}"
         if label not in verdicts:
             raise ValueError(f"{where}: judge returned no verdict for label {label}")
         verdict = verdicts[label]
+        if not isinstance(verdict, dict):
+            raise ValueError(f"{where}: verdict must be a JSON object")
         row: dict[str, Any] = {"case_id": case_id, "trial": trial, "condition": condition}
         for dimension in DIMENSIONS:
             value = verdict.get(dimension)

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -111,6 +112,38 @@ class ParseJudgeScoresTest(unittest.TestCase):
                 payload, ("direct-answer", 1), {"baseline": "B", "candidate": "A"}
             )
 
+    def test_non_object_document_is_a_contextual_validation_error(self):
+        for value in (None, True, 42, 1.5, "A", [], ["A", "B"]):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(ValueError, "direct-answer/trial 1:.*JSON object"):
+                    judge.parse_judge_scores(
+                        json.dumps(value),
+                        ("direct-answer", 1),
+                        {"baseline": "A", "candidate": "B"},
+                    )
+
+    def test_non_object_verdict_is_a_contextual_validation_error(self):
+        for value in (None, False, 42, 1.5, "unknown", [], [1, 2]):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(ValueError, "direct-answer/trial 1/label A:.*JSON object"):
+                    judge.parse_judge_scores(
+                        json.dumps({"A": value, "B": self._verdict(4)}),
+                        ("direct-answer", 1),
+                        {"baseline": "A", "candidate": "B"},
+                    )
+
+    def test_non_object_reply_is_retried_and_can_recover(self):
+        valid = json.dumps({"A": self._verdict(4), "B": self._verdict(5)})
+        with patch.object(judge, "invoke_judge", side_effect=[("null", 0.0), (valid, 0.0)]) as invoke:
+            with patch.object(judge.time, "sleep"):
+                rows, _ = judge._judge_group(
+                    ["unused-stub"], "text", "fixture prompt", ("direct-answer", 1),
+                    {"baseline": "A", "candidate": "B"}, retries=1,
+                )
+
+        self.assertEqual(2, invoke.call_count)
+        self.assertEqual([4, 5], [row["correctness"] for row in rows])
+
 
 class GraderRubricTest(unittest.TestCase):
     def test_only_the_marked_grader_section_is_extracted(self):
@@ -186,6 +219,42 @@ class EndToEndTest(unittest.TestCase):
         "blocker": False,
         "notes": "fixture",
     }
+
+    def test_non_object_verdict_exhausts_retries_without_stopping_later_groups(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            responses = root / "responses.jsonl"
+            responses.write_text(
+                "".join(
+                    json.dumps({
+                        "case_id": case_id, "trial": 1, "condition": condition,
+                        "runner": "stub", "response": "fixture response",
+                    }) + "\n"
+                    for case_id in ("casual-message", "direct-answer")
+                    for condition in ("baseline", "candidate")
+                ), encoding="utf-8",
+            )
+            config = root / "runners.json"
+            config.write_text(json.dumps({
+                "stub": {"command": ["unused-stub"], "response_format": "text"},
+            }), encoding="utf-8")
+            output = root / "scores.jsonl"
+            valid = json.dumps({"A": self.VERDICT, "B": self.VERDICT})
+            replies = [(' {"A": null, "B": null}', 0.0)] * 2 + [(valid, 0.0)]
+
+            with patch.object(judge, "invoke_judge", side_effect=replies) as invoke:
+                with patch.object(judge.time, "sleep"):
+                    exit_code = judge.main([
+                        "--responses", str(responses), "--output", str(output),
+                        "--runner-config", str(config), "--runner", "stub", "--retries", "1",
+                    ])
+
+            self.assertEqual(1, exit_code)
+            self.assertEqual(3, invoke.call_count)
+            rows = run_evals.read_jsonl(output)
+            self.assertEqual({"direct-answer"}, {row["case_id"] for row in rows})
+            self.assertEqual({"baseline", "candidate"}, {row["condition"] for row in rows})
+            self.assertEqual(2, len(rows))
 
     def test_judging_produces_paired_rows_the_scorer_accepts(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

Fixes #151.

Valid JSON such as `null` or `{"A": null}` can raise an uncaught `TypeError` or `AttributeError` in `parse_judge_scores()`, stopping the whole batch.

Validate the response and each verdict as objects, raising a contextual `ValueError` so the existing retry and skip handling can continue with later groups. Add four regression tests for invalid shapes, retry recovery, and batch continuation.

## Authorship and provenance — select exactly one

- [ ] **Human-authored** — substantive implementation and text were produced by a human.
- [x] **Autonomous agent-authored** — an agent planned and produced most of the substantive change.
- [ ] **Hybrid** — a human and one or more agents both made substantive contributions.

**Agent/tool and model/version:** OpenAI Codex, GPT-6.

**Agent contribution:** Bug reproduction, implementation, tests, and issue/PR text.

**Human verification:** The submitter selected the bug and requested submission. Full diff review and independent test execution are unconfirmed; draft pending human review.

**Known limitations or uncertain results:** Four existing Windows tests fail because `sh` is unavailable (`WinError 2`), as also reported in #146.

## Labels

**Target label:** Target:Evals

**Author label:** Author:AI

**Workflow labels:** bug

Requested labels; upstream label permissions are unavailable.

## Safety and side effects

- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [x] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [x] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects, permissions, network access, and cost:** No new dependencies or permissions. Tests use temporary files and mocks; no network or provider costs.

## Compatibility

- [x] This is not a breaking change.
- [ ] This is a breaking change; it was discussed, and migration/deprecation documentation is included below.
- [x] Canonical and mirrored skill files are synchronized when applicable.
- [x] Relevant platform manifests and installation documentation were reviewed.

**Migration or rollback notes:** None. Valid verdicts retain the same output format. Skill files, manifests, and installation instructions are unchanged.

## Verification

Windows, Python 3.12.10 embedded. `python` below denotes the interpreter invoked by its full path.

- `python -B -m unittest discover -s tests -p test_judge.py -k non_object -v` — four new tests fail before the fix and pass afterward.
- `python -B -m unittest discover -s tests -v` — 41 passed, four pre-existing `sh`-dependent errors, 45 total.
- `python -B scripts/run_evals.py validate` — passed.
- `git diff --check` — passed.

**Behavior evals:** Not applicable; skill rules are unchanged. No paid evaluations were run.

## Final accountability

- [ ] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content.
- [x] All failed, skipped, or unrun checks are disclosed above.
