### PR TITLE
fix(hooks): ship hooks.codex.json so Codex session start gets a JSON envelope

### DIFF
--- a/hooks/codex-session-start.mjs
+++ b/hooks/codex-session-start.mjs
@@ -1,0 +1,31 @@
+// Codex-only SessionStart wrapper. Codex requires SessionStart hooks to emit
+// either empty stdout or a single JSON envelope, unlike Claude Code, which
+// accepts always-on.mjs's plain-text output directly. This captures that
+// plain text and re-emits it wrapped, without changing always-on.mjs itself.
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const root = process.env.CLAUDE_PLUGIN_ROOT || process.env.PLUGIN_ROOT;
+if (!root) process.exit(0);
+
+const chunks = [];
+const originalWrite = process.stdout.write.bind(process.stdout);
+process.stdout.write = (chunk) => {
+  chunks.push(chunk);
+  return true;
+};
+
+try {
+  await import(pathToFileURL(path.join(root, "hooks", "always-on.mjs")).href);
+} finally {
+  process.stdout.write = originalWrite;
+}
+
+const text = chunks.join("");
+if (text) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: { hookEventName: "SessionStart", additionalContext: text },
+    }),
+  );
+}

--- a/hooks/hooks.codex.json
+++ b/hooks/hooks.codex.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"(async()=>{const root=process.env.CLAUDE_PLUGIN_ROOT||process.env.PLUGIN_ROOT;if(root)await import(require('node:url').pathToFileURL(require('node:path').join(root,'hooks','codex-session-start.mjs')).href)})().catch(()=>{})\"",
+            "timeout": 30,
+            "statusMessage": "Checking i-have-adhd always-on flag..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_always_on_hooks.py
+++ b/tests/test_always_on_hooks.py
@@ -54,7 +54,7 @@ class AlwaysOnHookTest(unittest.TestCase):
         )
 
     def run_codex_hook(self, plugin_root=None):
-        config = json.loads((ROOT / "hooks" / "hooks.json").read_text())
+        config = json.loads((ROOT / "hooks" / "hooks.codex.json").read_text())
         hook = config["hooks"]["SessionStart"][0]["hooks"][0]
         env = os.environ.copy()
         env["CLAUDE_CONFIG_DIR"] = str(self.config_dir)
@@ -133,14 +133,16 @@ class AlwaysOnHookTest(unittest.TestCase):
 
         self.assertEqual(1, len(set(outputs.values())))
 
-    def test_codex_command_runs_the_hook_instead_of_parsing_session_json(self):
+    def test_codex_command_wraps_the_hook_output_in_the_session_start_envelope(self):
         (self.config_dir / ".i-have-adhd-always").touch()
 
         result = self.run_codex_hook()
 
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertEqual("", result.stderr)
-        self.assertIn("ADHD MODE ACTIVE (always-on)", result.stdout)
+        envelope = json.loads(result.stdout)
+        self.assertEqual("SessionStart", envelope["hookSpecificOutput"]["hookEventName"])
+        self.assertIn("ADHD MODE ACTIVE (always-on)", envelope["hookSpecificOutput"]["additionalContext"])
 
     def test_codex_command_is_silent_without_opt_in_flag(self):
         result = self.run_codex_hook()
@@ -156,7 +158,7 @@ class AlwaysOnHookTest(unittest.TestCase):
         self.assertEqual("", result.stderr)
         self.assertEqual("", result.stdout)
 
-    def test_hook_uses_a_shared_claude_and_codex_launcher(self):
+    def test_claude_hook_uses_a_launcher(self):
         config = json.loads((ROOT / "hooks" / "hooks.json").read_text())
         hook = config["hooks"]["SessionStart"][0]["hooks"][0]
 
@@ -167,6 +169,20 @@ class AlwaysOnHookTest(unittest.TestCase):
         self.assertIn("process.env.PLUGIN_ROOT", command)
         self.assertIn("await import", command)
         self.assertIn(".catch", command)
+        self.assertIn("always-on.mjs", command)
+
+    def test_codex_hook_uses_a_launcher(self):
+        config = json.loads((ROOT / "hooks" / "hooks.codex.json").read_text())
+        hook = config["hooks"]["SessionStart"][0]["hooks"][0]
+
+        self.assertNotIn("args", hook)
+        command = hook["command"]
+        self.assertRegex(command, r'^node(?: --input-type=module)? -e "')
+        self.assertIn("process.env.CLAUDE_PLUGIN_ROOT", command)
+        self.assertIn("process.env.PLUGIN_ROOT", command)
+        self.assertIn("await import", command)
+        self.assertIn(".catch", command)
+        self.assertIn("codex-session-start.mjs", command)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #156.

## What changed and why
Codex requires SessionStart hook output to be either empty stdout or a single JSON envelope. It rejects the plain-text output that always-on.mjs writes, which Claude Code accepts directly, and silently drops the entire ruleset with no indication of which hook failed.

Codex reads hooks/hooks.codex.json in preference to hooks/hooks.json when present, the same mechanism the issue points to in remember@claude-plugins-official. Added hooks/codex-session-start.mjs, a thin wrapper that runs the existing always-on.mjs unchanged, captures its stdout, and re-emits it as a hookSpecificOutput envelope when non-empty. hooks.json and always-on.mjs are untouched, so Claude Code keeps receiving plain text exactly as before.

## Observable behavior before and after
Before: a Codex session with the always-on flag set shows "Hook failed: hook returned invalid session start JSON output" and the ruleset never reaches the model.
After: the same session receives a valid hookSpecificOutput envelope containing the same ruleset text, with no hook failure.

## Safety and compatibility
No change to always-on.mjs, hooks.json, or the sh/PowerShell fallbacks. The new wrapper only intercepts stdout for the duration of the import and restores it immediately after, matching the existing opt-in/fail-safe/no-network behavior of the hook it wraps. If always-on.mjs exits early with no output (no opt-in flag, missing skill file, or an internal error), the wrapper also emits nothing, preserving the existing silent no-op behavior.

## Verification performed
Ran the full hooks test suite locally (Node available, sh/PowerShell not on this machine): python -m pytest tests/test_always_on_hooks.py -v, 8 passed. Updated run_codex_hook to read hooks.codex.json instead of hooks.json, added test_codex_command_wraps_the_hook_output_in_the_session_start_envelope asserting the parsed JSON envelope shape and hookEventName, and added test_codex_hook_uses_a_launcher alongside the renamed test_claude_hook_uses_a_launcher so both launcher shapes are covered independently. The two existing silent-output tests (no opt-in flag, missing plugin) needed no changes since the wrapper already emits nothing when always-on.mjs produces no text.

## Authorship and provenance
Autonomous agent-authored. I read the issue, the existing hooks.json launcher pattern, and always-on.mjs, then implemented and tested the fix with no human writing code. A human reviewed the diff and the test run before this PR was opened. No failed checks to report; the full existing test file plus the new/updated cases all pass locally.