### PR TITLE
fix(tests): keep stub runner paths shell-safe so test_judge passes on Windows

### DIFF
--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -1,4 +1,5 @@
 import json
+import shlex
 import sys
 import tempfile
 import unittest
@@ -10,6 +11,20 @@ sys.path.insert(0, str(ROOT / "scripts"))
 
 import judge  # noqa: E402
 import run_evals  # noqa: E402
+
+
+def shell_path(path: Path) -> str:
+    """Render a path for embedding in a POSIX shell command string.
+
+    The end-to-end tests below hand a stub runner to `sh -c`, so a path
+    interpolated into that string is parsed by the shell rather than by Python.
+    On Windows `str(Path)` uses backslash separators, which the shell reads as
+    escape characters: `cat > C:\\Users\\...` redirects to a mangled path and
+    still exits 0, so the stub runner looks like it ran while having written
+    nothing. Separately, a path containing a space splits into two arguments.
+    Forward slashes plus POSIX quoting name the same file on every platform.
+    """
+    return shlex.quote(path.as_posix())
 
 
 class LabelAssignmentTest(unittest.TestCase):
@@ -223,7 +238,11 @@ class EndToEndTest(unittest.TestCase):
                             # Reads the prompt from stdin, not argv: a trailing
                             # option such as `--tools ""` otherwise swallows a
                             # prompt appended to the command line.
-                            "command": ["sh", "-c", f"cat > {captured}; cat {payload}"],
+                            "command": [
+                                "sh",
+                                "-c",
+                                f"cat > {shell_path(captured)}; cat {shell_path(payload)}",
+                            ],
                             "response_format": "text",
                         }
                     }
@@ -291,7 +310,7 @@ class EndToEndTest(unittest.TestCase):
                                 # `blocker` omitted for the casual-message group.
                                 f'p=$(cat); case "$p" in *casual-message*)'
                                 f' echo \'{{"A":{{"correctness":3}},"B":{{"correctness":3}}}}\';;'
-                                f" *) cat {good};; esac",
+                                f" *) cat {shell_path(good)};; esac",
                             ],
                             "response_format": "text",
                         }
@@ -387,7 +406,7 @@ class EndToEndTest(unittest.TestCase):
                             "command": [
                                 "sh",
                                 "-c",
-                                f'p=$(cat); case "$p" in *direct-answer*) exit 7;; *) cat {verdict};; esac',
+                                f'p=$(cat); case "$p" in *direct-answer*) exit 7;; *) cat {shell_path(verdict)};; esac',
                             ],
                             "response_format": "text",
                         }


### PR DESCRIPTION
## Summary

Three end-to-end tests in `tests/test_judge.py` fail on Windows on an unmodified `ff690b6`:

```text
FAIL: test_judging_produces_paired_rows_the_scorer_accepts
FAIL: test_a_malformed_verdict_skips_its_group_instead_of_killing_the_run
FAIL: test_runner_failure_skips_its_group_and_continues
Ran 17 tests ... FAILED (failures=3)
```

Those three tests build their stub judge runner as an `sh -c` command string and interpolate a `Path` into it with an f-string. On Windows `str(Path)` yields backslash separators, and the shell reads a backslash as an escape character:

```console
$ sh -c 'printf payload > C:\Users\me\AppData\Local\Temp\tmpbl_g_9zt\prompt.txt'
$ echo $?
0
$ ls 'C:UsersmeAppDataLocalTemptmpbl_g_9ztprompt.txt'
C:UsersmeAppDataLocalTemptmpbl_g_9ztprompt.txt
```

The redirect **exits 0** while writing to a mangled path, so the stub runner looks like it ran and wrote nothing. The `cat C:\Users\...` that follows then fails, the group is skipped, and `judge.main` returns 1 — the three tests fail for a reason unrelated to what they assert.

The same interpolation splits on whitespace if a path contains a space, which is reachable when `%TEMP%` sits under a user name with a space:

```console
$ sh -c 'printf payload > .../dir with spaces/out.json'
cat: with: No such file or directory
cat: spaces/out.json: No such file or directory
```

Fix: render every interpolated path with `Path.as_posix()` and `shlex.quote()`. Both are no-ops on POSIX, so Linux and macOS behavior is unchanged.

Before → after, same Windows machine, same checkout:

| command | before | after |
| --- | --- | --- |
| `python -m unittest tests.test_judge -v` | `Ran 17 tests` — `FAILED (failures=3)` | `Ran 17 tests` — `OK` |
| `python -m unittest discover -s tests -v` | `Ran 41 tests` — `FAILED (failures=3)` | `Ran 41 tests` — `OK` |

This is test-fixture only. `scripts/judge.py`, `scripts/run_evals.py`, the skill, the hooks, and every manifest are untouched.

## Authorship and provenance — select exactly one

- [ ] **Human-authored** — substantive implementation and text were produced by a human.
- [x] **Autonomous agent-authored** — an agent planned and produced most of the substantive change.
- [ ] **Hybrid** — a human and one or more agents both made substantive contributions.

**Agent/tool and model/version:** WorkBuddy agent harness; model DeepSeek-V4.1-Flash.

**Agent contribution:** Located the three failing tests, diagnosed the cause, wrote the `shell_path` helper and its three call sites, ran the before/after comparisons on Windows, and drafted this PR.

**Human verification:** The submitter was given the diagnosis, the diff, and the before/after results, selected the authorship category above, and approved submission. The submitter did not personally re-run the commands; every run reported under Verification was performed by the agent that wrote the change.

**Known limitations or uncertain results:** Checks ran on Windows (Python 3.13.12). `Path.as_posix()` and `shlex.quote()` are no-ops for the POSIX temp paths used on Linux and macOS, so those runs should be unaffected, but no Linux or macOS run was performed here. The three tests still require a POSIX `sh` on `PATH`; a Windows machine without Git Bash errors rather than skips, and this PR does not change that.

## Labels

**Target label:** Target:Evals

**Author label:** Author:AI

**Workflow labels:** bug

## Safety and side effects

- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [x] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [x] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects, permissions, network access, and cost:** None. Test-fixture string construction only; no new dependencies, network calls, or provider costs. The tests keep using temporary directories and delete them as before.

## Compatibility

- [x] This is not a breaking change.
- [ ] This is a breaking change; it was discussed, and migration/deprecation documentation is included below.
- [ ] Canonical and mirrored skill files are synchronized when applicable.
- [ ] Relevant platform manifests and installation documentation were reviewed.

**Migration or rollback notes:** None required. `Path.as_posix()` and `shlex.quote()` are identity operations for the POSIX temp paths currently used in CI, so the Ubuntu run is byte-identical.

## Verification

- `python -m unittest tests.test_judge -v` on Windows before the fix — `Ran 17 tests`, `FAILED (failures=3)` (clean `ff690b6`).
- `python -m unittest tests.test_judge -v` on Windows after the fix — `Ran 17 tests`, `OK`.
- `python -m unittest discover -s tests -v` on Windows after the fix — `Ran 41 tests`, `OK`.
- `python -m unittest tests.test_judge` with `TEMP`/`TMP`/`TMPDIR` pointed at a directory containing a space — `Ran 17 tests`, `OK`.
- `python scripts/run_evals.py validate` — `Evaluation cases are valid.`
- `git diff --check` — clean.

The three tests failed before the change on the same machine and pass after it; no test was skipped, deleted, or weakened.

**Why this stayed red:** no workflow runs this file. `plugin-load-check.yml` invokes `tests.test_always_on_hooks` on a `[ubuntu-latest, windows-latest]` matrix, `pi-load-check.yml` runs `scripts/check_pi_extension.py`, and `cursor-skill-sync.yml` watches the skill files. `grep -rn "test_judge\|discover" .github/workflows/` returns nothing, so `tests/test_judge.py` is not executed on any runner.

**Behavior evals:** Not applicable; no skill-behavior, runner, or plugin-runtime change.

## Final accountability

- [x] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content.
- [x] All failed, skipped, or unrun checks are disclosed above.
