### PR TITLE
fix(hooks): keep the sh fallback at LF on checkout so it runs on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Force LF on checkout for POSIX shell scripts.
+#
+# hooks/always-on.sh ships inside the plugin and is the fallback for
+# environments without Node. With no attribute set, a Windows checkout with the
+# default core.autocrlf=true rewrites it to CRLF, and /bin/sh then fails on
+# every line -- the carriage return is part of the token, so it is read as a
+# command and the script dies with exit 255 instead of injecting the ruleset:
+#
+#   hooks/always-on.sh: line 8: \r: command not found
+#   hooks/always-on.sh: line 13: exit: 0\r: numeric argument required
+#
+# The Node and PowerShell hooks tolerate CRLF; the shell one cannot.
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,13 +1,2 @@
-# Force LF on checkout for POSIX shell scripts.
-#
-# hooks/always-on.sh ships inside the plugin and is the fallback for
-# environments without Node. With no attribute set, a Windows checkout with the
-# default core.autocrlf=true rewrites it to CRLF, and /bin/sh then fails on
-# every line -- the carriage return is part of the token, so it is read as a
-# command and the script dies with exit 255 instead of injecting the ruleset:
-#
-#   hooks/always-on.sh: line 8: \r: command not found
-#   hooks/always-on.sh: line 13: exit: 0\r: numeric argument required
-#
-# The Node and PowerShell hooks tolerate CRLF; the shell one cannot.
+# Preserve LF line endings so POSIX shells can parse scripts after checkout.
 *.sh text eol=lf


### PR DESCRIPTION
## Summary

With `core.autocrlf=true`, Git checks out `hooks/always-on.sh` with CRLF line endings. Executing that copy with a POSIX shell fails to emit the rules and produces errors. Adding `*.sh text eol=lf` preserves LF on checkout and restores correct opt-in behavior.

This protects the shell script when invoked directly or by an integration configured to use it. The current `hooks/hooks.json` launcher invokes Node; this PR does not add automatic fallback when Node is unavailable. Failure exit codes vary by shell, so no universal code is claimed.

## Scope and compatibility

Only `.gitattributes` changes: one explanatory comment and one attribute. No shell logic, skill rules, manifests, tests, or dependencies change. The attribute applies to tracked `*.sh` files; it does not impose a repository-wide line-ending policy.

Fresh checkouts receive LF shell scripts. For an existing CRLF installation, reinstall into a fresh directory, preserving any local customizations first. This change does not repair files converted to CRLF outside Git's checkout process.

## Authorship and provenance

- [ ] **Human-authored**
- [ ] **Autonomous agent-authored**
- [x] **Hybrid**

Original contributor: Matthew-Selvam. Hermes Agent (deepseek-v4.1-flash) identified the issue, wrote the attribute, and reported reproducing it with `core.autocrlf=true` on macOS. The contributor reported reviewing the diff and running those checks.

The repository owner's Codex maintainer agent independently tested the PR and current main on Linux, shortened the comment, and corrected this description. The original contributor's commit is preserved; the owner reviews and merges manually.

## Verification

Maintainer checks used isolated Git clones with `core.autocrlf=true` and `false`, testing both main and the PR:

- CRLF main: both `sh` and Bash emitted errors and no rules, with the flag present or absent. Node continued to work. Exit codes differed between shells.
- PR: shell script checked out as LF under both settings. `sh`, Bash, and Node emitted the complete skill when enabled and were silent without the opt-in flag.
- `python3 -m unittest discover -s tests -p test_always_on_hooks.py -v` — failed on CRLF main; passed on LF main and both PR checkouts.
- Applied only the PR attribute to current main `6f1f982d0a47c65899af3c5a7450b7098bc65325` in the CRLF fixture and rechecked out the shell script: normalized output was identical across `sh`, Bash, and Node. `git ls-files --eol` confirmed only the shell script's working-tree line endings changed.
- `python3 -m unittest discover -s tests -v` — all **51 tests passed** on that current-main-plus-fix fixture. This count refers to the integration fixture, not the older PR base.
- `git check-attr text eol -- hooks/always-on.sh` — `text: set`, `eol: lf` after the comment amendment.
- `git diff --check` — passed after the amendment. Only comments changed after runtime verification; the tested attribute is unchanged.

Limitations: maintainer runtime checks ran on Linux with Windows-style Git checkout settings, not native Windows. PowerShell was not tested by the maintainer. No model calls or behavior evaluations were needed for this checkout-only change.

## Safety and side effects

Testing used temporary clones and temporary opt-in configuration, without modifying user Git settings or accessing provider credentials. The change controls Git checkout line endings for shell files and adds no runtime network access or cost.

**Labels:** `Target:Integrations`, `Author:Hybrid`, `bug`.
