### PR TITLE
docs(install): point Zed users at ~/.agents/skills, the only directory Zed scans

### DIFF
--- a/.github/install/INSTALL.ja.md
+++ b/.github/install/INSTALL.ja.md
@@ -626,6 +626,7 @@ https://github.com/ayghri/i-have-adhd/blob/main/skills/i-have-adhd/SKILL.md
 
 ```bash
 git clone https://github.com/ayghri/i-have-adhd
+mkdir -p ~/.agents/skills
 cp -R i-have-adhd/skills/i-have-adhd ~/.agents/skills/
 ```
 

--- a/.github/install/INSTALL.ja.md
+++ b/.github/install/INSTALL.ja.md
@@ -626,7 +626,7 @@ https://github.com/ayghri/i-have-adhd/blob/main/skills/i-have-adhd/SKILL.md
 
 ```bash
 git clone https://github.com/ayghri/i-have-adhd
-cp -R i-have-adhd/skills/i-have-adhd ~/.config/zed/skills/
+cp -R i-have-adhd/skills/i-have-adhd ~/.agents/skills/
 ```
 
 ### 確認
@@ -639,7 +639,7 @@ Agent Panel で Skills マネージャーを開き、`i-have-adhd` が一覧に�
 
 ### アンインストール
 
-Skills マネージャーから `i-have-adhd` を削除するか、`~/.config/zed/skills/i-have-adhd` を削除します。
+Skills マネージャーから `i-have-adhd` を削除するか、`~/.agents/skills/i-have-adhd` を削除します。
 
 ### 常時有効（任意）
 

--- a/.github/install/INSTALL.ko.md
+++ b/.github/install/INSTALL.ko.md
@@ -519,6 +519,7 @@ https://github.com/ayghri/i-have-adhd/blob/main/skills/i-have-adhd/SKILL.md
 
 ```bash
 git clone https://github.com/ayghri/i-have-adhd
+mkdir -p ~/.agents/skills
 cp -R i-have-adhd/skills/i-have-adhd ~/.agents/skills/
 ```
 

--- a/.github/install/INSTALL.ko.md
+++ b/.github/install/INSTALL.ko.md
@@ -519,7 +519,7 @@ https://github.com/ayghri/i-have-adhd/blob/main/skills/i-have-adhd/SKILL.md
 
 ```bash
 git clone https://github.com/ayghri/i-have-adhd
-cp -R i-have-adhd/skills/i-have-adhd ~/.config/zed/skills/
+cp -R i-have-adhd/skills/i-have-adhd ~/.agents/skills/
 ```
 
 ### 확인
@@ -532,7 +532,7 @@ Agent Panel에서 Skills 관리자를 열어 `i-have-adhd`가 목록에 있는�
 
 ### 제거
 
-Skills 관리자에서 `i-have-adhd`를 제거하거나 `~/.config/zed/skills/i-have-adhd`를 삭제하세요.
+Skills 관리자에서 `i-have-adhd`를 제거하거나 `~/.agents/skills/i-have-adhd`를 삭제하세요.
 
 ### 항상 활성화(선택 사항)
 

--- a/.github/install/INSTALL.pt-BR.md
+++ b/.github/install/INSTALL.pt-BR.md
@@ -519,6 +519,7 @@ Prefere o sistema de arquivos? Clone o repositório e coloque a pasta da skill n
 
 ```bash
 git clone https://github.com/ayghri/i-have-adhd
+mkdir -p ~/.agents/skills
 cp -R i-have-adhd/skills/i-have-adhd ~/.agents/skills/
 ```
 

--- a/.github/install/INSTALL.pt-BR.md
+++ b/.github/install/INSTALL.pt-BR.md
@@ -519,7 +519,7 @@ Prefere o sistema de arquivos? Clone o repositório e coloque a pasta da skill n
 
 ```bash
 git clone https://github.com/ayghri/i-have-adhd
-cp -R i-have-adhd/skills/i-have-adhd ~/.config/zed/skills/
+cp -R i-have-adhd/skills/i-have-adhd ~/.agents/skills/
 ```
 
 ### Verificar
@@ -532,7 +532,7 @@ Importe novamente pela mesma URL (sobrescreve) ou copie a pasta de novo após `g
 
 ### Desinstalar
 
-Remova `i-have-adhd` do gerenciador de Skills ou exclua `~/.config/zed/skills/i-have-adhd`.
+Remova `i-have-adhd` do gerenciador de Skills ou exclua `~/.agents/skills/i-have-adhd`.
 
 ### Sempre ativo (opcional)
 

--- a/.github/install/INSTALL.vi.md
+++ b/.github/install/INSTALL.vi.md
@@ -519,7 +519,7 @@ Muốn dùng hệ thống tệp? Clone repo và đặt thư mục skill vào th�
 
 ```bash
 git clone https://github.com/ayghri/i-have-adhd
-cp -R i-have-adhd/skills/i-have-adhd ~/.config/zed/skills/
+cp -R i-have-adhd/skills/i-have-adhd ~/.agents/skills/
 ```
 
 ### Xác minh
@@ -532,7 +532,7 @@ Nhập lại từ cùng URL (ghi đè), hoặc sao chép lại thư mục sau `g
 
 ### Gỡ cài đặt
 
-Xóa `i-have-adhd` khỏi trình quản lý Skills, hoặc xóa `~/.config/zed/skills/i-have-adhd`.
+Xóa `i-have-adhd` khỏi trình quản lý Skills, hoặc xóa `~/.agents/skills/i-have-adhd`.
 
 ### Luôn bật (không bắt buộc)
 

--- a/.github/install/INSTALL.vi.md
+++ b/.github/install/INSTALL.vi.md
@@ -519,6 +519,7 @@ Muốn dùng hệ thống tệp? Clone repo và đặt thư mục skill vào th�
 
 ```bash
 git clone https://github.com/ayghri/i-have-adhd
+mkdir -p ~/.agents/skills
 cp -R i-have-adhd/skills/i-have-adhd ~/.agents/skills/
 ```
 

--- a/.github/install/INSTALL.zh-CN.md
+++ b/.github/install/INSTALL.zh-CN.md
@@ -519,7 +519,7 @@ https://github.com/ayghri/i-have-adhd/blob/main/skills/i-have-adhd/SKILL.md
 
 ```bash
 git clone https://github.com/ayghri/i-have-adhd
-cp -R i-have-adhd/skills/i-have-adhd ~/.config/zed/skills/
+cp -R i-have-adhd/skills/i-have-adhd ~/.agents/skills/
 ```
 
 ### 验证
@@ -532,7 +532,7 @@ cp -R i-have-adhd/skills/i-have-adhd ~/.config/zed/skills/
 
 ### 卸载
 
-从 Skills 管理器中移除 `i-have-adhd`，或删除 `~/.config/zed/skills/i-have-adhd`。
+从 Skills 管理器中移除 `i-have-adhd`，或删除 `~/.agents/skills/i-have-adhd`。
 
 ### 始终启用（可选）
 

--- a/.github/install/INSTALL.zh-CN.md
+++ b/.github/install/INSTALL.zh-CN.md
@@ -519,6 +519,7 @@ https://github.com/ayghri/i-have-adhd/blob/main/skills/i-have-adhd/SKILL.md
 
 ```bash
 git clone https://github.com/ayghri/i-have-adhd
+mkdir -p ~/.agents/skills
 cp -R i-have-adhd/skills/i-have-adhd ~/.agents/skills/
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -631,7 +631,7 @@ Prefer the filesystem? Clone the repo and drop the skill folder into your user s
 
 ```bash
 git clone https://github.com/ayghri/i-have-adhd
-cp -R i-have-adhd/skills/i-have-adhd ~/.config/zed/skills/
+cp -R i-have-adhd/skills/i-have-adhd ~/.agents/skills/
 ```
 
 ### Verify
@@ -644,7 +644,7 @@ Re-import from the same URL (overwrites), or re-copy the folder after `git pull`
 
 ### Uninstall
 
-Remove `i-have-adhd` from the Skills manager, or delete `~/.config/zed/skills/i-have-adhd`.
+Remove `i-have-adhd` from the Skills manager, or delete `~/.agents/skills/i-have-adhd`.
 
 ### Always-on (optional)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -631,6 +631,7 @@ Prefer the filesystem? Clone the repo and drop the skill folder into your user s
 
 ```bash
 git clone https://github.com/ayghri/i-have-adhd
+mkdir -p ~/.agents/skills
 cp -R i-have-adhd/skills/i-have-adhd ~/.agents/skills/
 ```
 

--- a/tests/test_install_docs.py
+++ b/tests/test_install_docs.py
@@ -4,7 +4,7 @@
 Zed loads skills from `~/.agents/skills/` and `<worktree>/.agents/skills/` and
 supports no custom search paths, so that is the only directory INSTALL can tell
 a user to copy into. The English file and its five translations are edited by
-hand, and two of them had already drifted to `~/.config/zed/skills/` (a
+hand, and all six had drifted to `~/.config/zed/skills/` (a
 directory Zed does not read) with no check catching it. These tests fail if any
 locale points at a directory Zed ignores, or if a locale half-updates and keeps
 both spellings.
@@ -12,6 +12,10 @@ both spellings.
 
 from __future__ import annotations
 
+import shlex
+import shutil
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -27,6 +31,36 @@ RIGHT_ZED_SKILLS_PATH = "~/.agents/skills"
 
 
 class ZedInstallPathTest(unittest.TestCase):
+    def test_filesystem_install_creates_discoverable_skill(self) -> None:
+        for path in INSTALL_FILES:
+            for agents_exists in (False, True):
+                with self.subTest(file=path.name, agents_exists=agents_exists):
+                    text = path.read_text(encoding="utf-8")
+                    block = text.split("<summary><strong>Zed</strong></summary>", 1)[1]
+                    block = block.split("</details>", 1)[0]
+                    commands = [
+                        shlex.split(line) for line in block.splitlines()
+                        if line.startswith(("mkdir ", "cp "))
+                    ]
+                    self.assertTrue(commands)
+                    with tempfile.TemporaryDirectory() as directory:
+                        base = Path(directory)
+                        home = base / "test home"
+                        home.mkdir()
+                        if agents_exists:
+                            (home / ".agents").mkdir()
+                        source = base / "i-have-adhd/skills/i-have-adhd"
+                        shutil.copytree(ROOT / "skills/i-have-adhd", source)
+                        for _ in range(2):  # Installation and re-copy update.
+                            for command in commands:
+                                args = [
+                                    str(home) + arg[1:] if arg.startswith("~/") else arg
+                                    for arg in command
+                                ]
+                                subprocess.run(args, cwd=base, check=True, capture_output=True)
+                            installed = home / ".agents/skills/i-have-adhd/SKILL.md"
+                            self.assertEqual((source / "SKILL.md").read_bytes(), installed.read_bytes())
+
     def test_every_locale_is_discovered(self) -> None:
         # Guards the glob above: a rename that silently drops files would make
         # the checks below vacuous.

--- a/tests/test_install_docs.py
+++ b/tests/test_install_docs.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Guards against locale drift in the Zed install instructions.
+
+Zed loads skills from `~/.agents/skills/` and `<worktree>/.agents/skills/` and
+supports no custom search paths, so that is the only directory INSTALL can tell
+a user to copy into. The English file and its five translations are edited by
+hand, and two of them had already drifted to `~/.config/zed/skills/` (a
+directory Zed does not read) with no check catching it. These tests fail if any
+locale points at a directory Zed ignores, or if a locale half-updates and keeps
+both spellings.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALL_FILES = (
+    ROOT / "INSTALL.md",
+    *sorted((ROOT / ".github" / "install").glob("INSTALL.*.md")),
+)
+# Zed reads skills only from these two roots; a custom path is not supported.
+WRONG_ZED_SKILLS_PATH = "~/.config/zed/skills"
+RIGHT_ZED_SKILLS_PATH = "~/.agents/skills"
+
+
+class ZedInstallPathTest(unittest.TestCase):
+    def test_every_locale_is_discovered(self) -> None:
+        # Guards the glob above: a rename that silently drops files would make
+        # the checks below vacuous.
+        self.assertEqual(6, len(INSTALL_FILES))
+
+    def test_no_locale_points_zed_at_a_path_it_does_not_read(self) -> None:
+        for path in INSTALL_FILES:
+            with self.subTest(file=path.name):
+                self.assertNotIn(
+                    WRONG_ZED_SKILLS_PATH,
+                    path.read_text(encoding="utf-8"),
+                    f"{path.name} tells Zed users to copy into "
+                    f"{WRONG_ZED_SKILLS_PATH}, which Zed does not scan",
+                )
+
+    def test_every_locale_documents_the_directory_zed_actually_reads(self) -> None:
+        # The <summary> wrapper is identical in every locale, unlike prose, so
+        # scope the assertion to the Zed block instead of the whole file.
+        for path in INSTALL_FILES:
+            with self.subTest(file=path.name):
+                text = path.read_text(encoding="utf-8")
+                start = text.find("<summary><strong>Zed</strong></summary>")
+                self.assertNotEqual(-1, start, f"{path.name} has no Zed block")
+                end = text.find("</details>", start)
+                self.assertNotEqual(-1, end, f"{path.name} has an unclosed Zed block")
+                block = text[start:end]
+                self.assertIn(
+                    RIGHT_ZED_SKILLS_PATH,
+                    block,
+                    f"{path.name} does not mention {RIGHT_ZED_SKILLS_PATH} "
+                    "in its Zed block",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_install_docs.py
+++ b/tests/test_install_docs.py
@@ -1,98 +1,32 @@
-#!/usr/bin/env python3
-"""Guards against locale drift in the Zed install instructions.
+"""Checks Zed installation paths across the installation guides."""
 
-Zed loads skills from `~/.agents/skills/` and `<worktree>/.agents/skills/` and
-supports no custom search paths, so that is the only directory INSTALL can tell
-a user to copy into. The English file and its five translations are edited by
-hand, and all six had drifted to `~/.config/zed/skills/` (a
-directory Zed does not read) with no check catching it. These tests fail if any
-locale points at a directory Zed ignores, or if a locale half-updates and keeps
-both spellings.
-"""
-
-from __future__ import annotations
-
-import shlex
-import shutil
-import subprocess
-import tempfile
+import pathlib
 import unittest
-from pathlib import Path
 
 
-ROOT = Path(__file__).resolve().parents[1]
-INSTALL_FILES = (
-    ROOT / "INSTALL.md",
-    *sorted((ROOT / ".github" / "install").glob("INSTALL.*.md")),
-)
-# Zed reads skills only from these two roots; a custom path is not supported.
-WRONG_ZED_SKILLS_PATH = "~/.config/zed/skills"
-RIGHT_ZED_SKILLS_PATH = "~/.agents/skills"
+ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 
 class ZedInstallPathTest(unittest.TestCase):
-    def test_filesystem_install_creates_discoverable_skill(self) -> None:
-        for path in INSTALL_FILES:
-            for agents_exists in (False, True):
-                with self.subTest(file=path.name, agents_exists=agents_exists):
-                    text = path.read_text(encoding="utf-8")
-                    block = text.split("<summary><strong>Zed</strong></summary>", 1)[1]
-                    block = block.split("</details>", 1)[0]
-                    commands = [
-                        shlex.split(line) for line in block.splitlines()
-                        if line.startswith(("mkdir ", "cp "))
-                    ]
-                    self.assertTrue(commands)
-                    with tempfile.TemporaryDirectory() as directory:
-                        base = Path(directory)
-                        home = base / "test home"
-                        home.mkdir()
-                        if agents_exists:
-                            (home / ".agents").mkdir()
-                        source = base / "i-have-adhd/skills/i-have-adhd"
-                        shutil.copytree(ROOT / "skills/i-have-adhd", source)
-                        for _ in range(2):  # Installation and re-copy update.
-                            for command in commands:
-                                args = [
-                                    str(home) + arg[1:] if arg.startswith("~/") else arg
-                                    for arg in command
-                                ]
-                                subprocess.run(args, cwd=base, check=True, capture_output=True)
-                            installed = home / ".agents/skills/i-have-adhd/SKILL.md"
-                            self.assertEqual((source / "SKILL.md").read_bytes(), installed.read_bytes())
-
-    def test_every_locale_is_discovered(self) -> None:
-        # Guards the glob above: a rename that silently drops files would make
-        # the checks below vacuous.
-        self.assertEqual(6, len(INSTALL_FILES))
-
-    def test_no_locale_points_zed_at_a_path_it_does_not_read(self) -> None:
-        for path in INSTALL_FILES:
+    def test_zed_install_paths(self):
+        translations = sorted((ROOT / ".github/install").glob("INSTALL.*.md"))
+        self.assertTrue(translations, "No translated installation guides found")
+        for path in [ROOT / "INSTALL.md", *translations]:
             with self.subTest(file=path.name):
-                self.assertNotIn(
-                    WRONG_ZED_SKILLS_PATH,
-                    path.read_text(encoding="utf-8"),
-                    f"{path.name} tells Zed users to copy into "
-                    f"{WRONG_ZED_SKILLS_PATH}, which Zed does not scan",
-                )
+                text = path.read_text(encoding="utf8")
+                marker = "<summary><strong>Zed</strong></summary>"
+                self.assertIn(marker, text)
+                section = text.split(marker, 1)[1]
+                self.assertIn("</details>", section)
+                section = section.split("</details>", 1)[0]
 
-    def test_every_locale_documents_the_directory_zed_actually_reads(self) -> None:
-        # The <summary> wrapper is identical in every locale, unlike prose, so
-        # scope the assertion to the Zed block instead of the whole file.
-        for path in INSTALL_FILES:
-            with self.subTest(file=path.name):
-                text = path.read_text(encoding="utf-8")
-                start = text.find("<summary><strong>Zed</strong></summary>")
-                self.assertNotEqual(-1, start, f"{path.name} has no Zed block")
-                end = text.find("</details>", start)
-                self.assertNotEqual(-1, end, f"{path.name} has an unclosed Zed block")
-                block = text[start:end]
+                self.assertNotIn("~/.config/zed/skills", section)
                 self.assertIn(
-                    RIGHT_ZED_SKILLS_PATH,
-                    block,
-                    f"{path.name} does not mention {RIGHT_ZED_SKILLS_PATH} "
-                    "in its Zed block",
+                    "mkdir -p ~/.agents/skills\n"
+                    "cp -R i-have-adhd/skills/i-have-adhd ~/.agents/skills/",
+                    section,
                 )
+                self.assertIn("~/.agents/skills/i-have-adhd", section)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The Zed filesystem instructions copied the skill to `~/.config/zed/skills/`, which Zed does not scan. This change uses `~/.agents/skills/` in the English guide and all five installation translations, including removal instructions.

The commands also create the destination directory before copying. Without `mkdir -p`, a fresh installation either fails when `.agents` is absent or places `SKILL.md` directly under `skills/` when only `.agents` exists, instead of in the required skill subfolder.

## Scope and compatibility

Six installation guides and `tests/test_install_docs.py`. No runtime, manifest, or skill-rule changes. Existing URL-import instructions are unchanged. Users of the old filesystem instructions should re-copy the skill into the corrected location. Other pre-existing translation differences remain outside this path fix.

A small read-only regression test checks the Zed section of every installation guide for the correct install/removal paths and directory creation before copying. It uses only pathlib and unittest, without a hardcoded locale count or shell execution.

## Authorship and provenance

- [x] **Hybrid**

Original contributor: Matthew-Selvam. Hermes Agent (deepseek-v4.1-flash) identified the path error and wrote the original correction and tests. The contributor reported reviewing the diff and running the original checks.

The repository owner's Codex maintainer agent independently reviewed the official release source, tested Zed, added directory creation and simplified the documentation regression test, and pushed a follow-up commit preserving the original contributor's commit. The owner reviews and merges manually.

## Verification

- Official documentation and Zed v1.19.2 release source confirm `~/.agents/skills/` as the global skills root: https://zed.dev/docs/ai/skills and https://github.com/zed-industries/zed/blob/v1.19.2/crates/agent_skills/agent_skills.rs.
- Actual Zed 1.19.2 on Linux, in Xvfb with a temporary home: after initializing the Agent Panel, the old-path copy did not appear; the corrected copy appeared in Skills settings and slash-command completion. Removing and restoring the corrected copy updated the UI live.
- Independent filesystem probes reproduced both fresh-install failures before the mkdir amendment.
- `python3 -m unittest discover -s tests -p test_install_docs.py -v` — 1 test passed across all six guides.
- `python3 -m unittest discover -s tests -v` — 44 tests passed on this PR branch after consolidating the documentation checks.
- Mutation checks in temporary fixtures: removing the English mkdir command or restoring the wrong skills path each caused an assertion failure.
- `pylint --disable=missing-class-docstring,missing-function-docstring tests/test_install_docs.py` — passed (test docstrings follow existing repository conventions).
- `git diff --check` — passed.

Limitations: runtime verification covered Linux only. No model prompts were submitted, no provider-backed behavior evaluations were run, and no claim of response-quality validation is made. The skills settings index was empty before opening the Agent Panel; discovery was verified after initialization.

## Safety and side effects

The added regression test only reads the installation guides. It executes no documentation commands and performs no network requests or filesystem writes. Runtime validation used the official Zed release with a temporary home and telemetry disabled, without signing in or configuring provider credentials. Zed and its virtual display were stopped afterward. Following the documentation intentionally installs the skill under `~/.agents/skills/`; removing its `i-have-adhd` folder uninstalls it.
