### PR TITLE
docs(install): document AstronClaw custom skill import

### DIFF
--- a/.github/install/INSTALL.zh-CN.md
+++ b/.github/install/INSTALL.zh-CN.md
@@ -56,6 +56,56 @@ agy plugin uninstall i-have-adhd
 </details>
 
 <details>
+<summary><strong>AstronClaw（自定义技能）</strong></summary>
+
+AstronClaw 支持将 Markdown 文件导入为自定义技能。此方式使用现有的 `SKILL.md`；
+上传和管理入口参见[官方技能指南](https://github.com/iflytek/astronclaw-tutorial/blob/main/docs/guide/astronclaw/skills.md)。
+
+### 安装
+
+1. 下载[技能源文件 SKILL.md](https://raw.githubusercontent.com/ayghri/i-have-adhd/main/skills/i-have-adhd/SKILL.md)，保存为 `SKILL.md`，上传前先阅读文件内容。
+2. 在 AstronClaw 中打开**我的技能**，选择**新建**，上传该 `.md` 文件。
+3. 确认导入后的技能名称为 `i-have-adhd`，通过**启用/禁用**控制技能是否可用。
+
+只需上传技能 Markdown 文件。上传会将该文件发送给 AstronClaw；
+本仓库的插件清单和钩子不参与此安装流程。
+
+### 验证与启用
+
+确认**我的技能**中出现 `i-have-adhd`，通过**下载**将导入后的指令与原始技能对照检查，
+然后启用并尝试输入：
+
+```text
+请在本次对话中使用 i-have-adhd 技能。说明如何在新文件夹中创建一个空的 Git 仓库。
+```
+
+检查回复是否先给出行动，并为步骤编号。这是对导入技能的手动检查；
+上传成功本身不能证明回复规则已经生效。
+
+### 启用说明
+
+AstronClaw 支持指定调用和自动调用技能。官方指南未说明是否遵循
+`disable-model-invocation: true`，因此不希望技能可用时，请使用**禁用**开关。
+无需依赖 `/i-have-adhd` 斜杠命令。
+
+技能要求助手在本次对话中保持该回复风格，直到你说 `stop adhd mode` 或
+`normal mode`。这条指令不会更改平台开关；如需开始不使用该技能的新会话，
+请禁用技能并开启新对话。
+
+### 更新
+
+下载最新的技能源文件 `SKILL.md`。如果修改过已导入的副本，请先使用**下载**
+保存备份。如需完整替换，请删除旧的 `i-have-adhd` 条目，重新导入文件，
+并在新对话中运行验证提示词。
+
+### 卸载
+
+在**我的技能**中选择 `i-have-adhd`，点击**删除**，然后开启新对话。
+如需保留已导入的副本以便以后使用，可选择**禁用**。
+
+</details>
+
+<details>
 <summary><strong>Claude Code</strong></summary>
 
 ### 安装

--- a/.github/install/INSTALL.zh-CN.md
+++ b/.github/install/INSTALL.zh-CN.md
@@ -61,6 +61,9 @@ agy plugin uninstall i-have-adhd
 AstronClaw 支持将 Markdown 文件导入为自定义技能。此方式使用现有的 `SKILL.md`；
 上传和管理入口参见[官方技能指南](https://github.com/iflytek/astronclaw-tutorial/blob/main/docs/guide/astronclaw/skills.md)。
 
+以下步骤依据 AstronClaw 官方文档编写，但尚未使用本技能进行实际测试。
+启用前，请检查导出的技能指令。
+
 ### 安装
 
 1. 下载[技能源文件 SKILL.md](https://raw.githubusercontent.com/ayghri/i-have-adhd/main/skills/i-have-adhd/SKILL.md)，保存为 `SKILL.md`，上传前先阅读文件内容。

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -62,6 +62,9 @@ AstronClaw supports importing a Markdown file as a custom skill. This route uses
 the existing `SKILL.md`; see its [official skills guide](https://github.com/iflytek/astronclaw-tutorial/blob/main/docs/guide/astronclaw/skills.md)
 for the upload and management controls.
 
+This procedure follows AstronClaw's documentation but has not been tested with
+this skill. Check the exported instructions before enabling it.
+
 ### Install
 
 1. Download the [canonical SKILL.md](https://raw.githubusercontent.com/ayghri/i-have-adhd/main/skills/i-have-adhd/SKILL.md) and save it as `SKILL.md`. Review its contents before uploading.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,6 +56,61 @@ Exceptions: explain fully when asked to explain. Confirm before destructive acti
 </details>
 
 <details>
+<summary><strong>AstronClaw (custom skill)</strong></summary>
+
+AstronClaw supports importing a Markdown file as a custom skill. This route uses
+the existing `SKILL.md`; see its [official skills guide](https://github.com/iflytek/astronclaw-tutorial/blob/main/docs/guide/astronclaw/skills.md)
+for the upload and management controls.
+
+### Install
+
+1. Download the [canonical SKILL.md](https://raw.githubusercontent.com/ayghri/i-have-adhd/main/skills/i-have-adhd/SKILL.md) and save it as `SKILL.md`. Review its contents before uploading.
+2. In AstronClaw, open **我的技能 (My skills)**, choose **新建 (New)**, and upload that `.md` file.
+3. Check that the imported skill is named `i-have-adhd`. Use **启用/禁用 (Enable/Disable)** to control its availability.
+
+Only the skill Markdown is needed. Uploading sends that file to AstronClaw;
+the repository's plugin manifests and hooks are not part of this setup.
+
+### Verify and activate
+
+Confirm `i-have-adhd` appears in **My skills**. Use **下载 (Download)** to review
+the imported instructions against the original skill, then enable it and try:
+
+```text
+Use the i-have-adhd skill for this conversation. Explain how to create an empty Git repository in a new folder.
+```
+
+Check that the reply leads with the action and numbers the steps. This is a
+manual check of the imported skill; a successful upload alone does not verify
+that its response rules are being applied.
+
+### Activation note
+
+AstronClaw supports both explicit requests and automatic skill invocation.
+Its guide does not specify whether it honors `disable-model-invocation: true`,
+so use **Disable** when you do not want the skill available. There is no need
+to rely on a `/i-have-adhd` slash command.
+
+The skill instructs the assistant to keep the style for the conversation until
+you say `stop adhd mode` or `normal mode`. That instruction does not change the
+platform toggle; disable the skill and start a new conversation for a fresh
+session without it.
+
+### Update
+
+Download the latest canonical `SKILL.md`. If you customized the imported copy,
+use **下载 (Download)** to keep a backup first. For a clean replacement, delete
+the old `i-have-adhd` entry, repeat the import, and run the verification prompt
+in a new conversation.
+
+### Uninstall
+
+In **My skills**, select `i-have-adhd` and choose **删除 (Delete)**, then start a
+new conversation. To keep the imported copy for later, choose **Disable** instead.
+
+</details>
+
+<details>
 <summary><strong>Claude Code</strong></summary>
 
 ### Install


### PR DESCRIPTION
## Summary

Document AstronClaw's custom Markdown import route in the English and Simplified Chinese installation guides. Users can import the canonical skill, inspect the generated instructions, check its output, and manage updates, disabling, and removal.

The existing generic instructions assume local skill directories and slash commands. This section instead follows the [official custom-skill workflow](https://github.com/iflytek/astronclaw-tutorial/blob/c06b3a5ef1fc675f3db64e0f54ed8b8dc8f20e2d/docs/guide/astronclaw/skills.md), and explains that automatic invocation is possible and `disable-model-invocation` enforcement is undocumented.

Closes #168.

## Authorship and provenance — select exactly one

- [ ] **Human-authored** — substantive implementation and text were produced by a human.
- [x] **Autonomous agent-authored** — an agent planned and produced most of the substantive change.
- [ ] **Hybrid** — a human and one or more agents both made substantive contributions.

**Agent/tool and model/version:** Codex (GPT-6).

**Agent contribution:** Researched the platform sources, wrote both documentation sections, ran link/content/markup checks, and reviewed the complete diff. A separate agent reviewed the instructions and translation for unsupported claims.

**Human verification:** The submitting user confirmed review of the complete diff at commit a3af1004646eef5f3e0e48b235848e11ed4220c7 and explicitly authorized submitting this PR. No human execution of the cloud smoke test is claimed.

**Known limitations or uncertain results:** No authenticated AstronClaw cloud import or live conversation was run. The documentation provides a manual smoke test and does not claim cloud validation, marketplace availability, or slash-command support.

## Labels

**Target label:** Target:Docs

**Author label:** Author:AI

**Workflow labels:** enhancement

These labels are requested for maintainer triage; the submitting account does not have permission to apply labels.

## Safety and side effects

- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [x] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [x] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects, permissions, network access, and cost:** Documentation only. Following the steps downloads a public Markdown file and explicitly uploads it to the user's AstronClaw account. Imported skills persist until disabled or deleted. Replacement instructions preserve customized copies by downloading a backup. No code, dependency, hook, or provider-backed evaluation was added or run.

## Compatibility

- [x] This is not a breaking change.
- [ ] This is a breaking change; it was discussed, and migration/deprecation documentation is included below.
- [x] Canonical and mirrored skill files are synchronized when applicable.
- [x] Relevant platform manifests and installation documentation were reviewed.

**Migration or rollback notes:** No migration; existing sections and runtime files are unchanged. Disable or delete the imported skill to undo the documented setup.

## Verification

- `git diff --check` — passed.
- Temporary Python documentation check — passed: both edits are additive sections only, Markdown fences and details tags are balanced, and both translations use the same links.
- HTTP checks — both linked pages returned 200; the raw downloaded skill matched the canonical checkout after line-ending normalization.
- Canonical skill and Cursor mirror — unchanged and byte-identical.
- Source review — all upload formats, invocation modes, and named controls checked against the official guide linked above.

**Behavior evals:** Not run; no skill rules or runtime behavior changed. Python/runtime suites were not run for this documentation-only change. Live AstronClaw testing was not run because no authenticated cloud session was available. Existing pull-request CI workflows filter for runtime files and do not target these documentation paths.

## Final accountability

- [x] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content.
- [x] All failed, skipped, or unrun checks are disclosed above.