### PR TITLE
fix(hooks): support Codex always-on config (#91)

### DIFF
--- a/.github/install/INSTALL.zh-CN.md
+++ b/.github/install/INSTALL.zh-CN.md
@@ -123,6 +123,18 @@ codex plugin marketplace add ayghri/i-have-adhd --ref main
 codex plugin add i-have-adhd@i-have-adhd
 ```
 
+### 始终启用（可选）
+
+SessionStart 钩子也会检查 Codex 配置目录中的启用标记：
+
+```bash
+touch "${CODEX_HOME:-$HOME/.codex}/.i-have-adhd-always"
+```
+
+未设置 `CODEX_HOME` 时，钩子使用 `~/.codex`。如果两个运行环境变量都未设置，
+钩子会依次检查 `~/.claude` 和 `~/.codex`。删除该标记即可在后续会话中关闭默认启用；
+没有标记时钩子保持静默。
+
 明确输入 `$i-have-adhd` 来启用此技能。Codex 不会自动调用它。
 
 ### 验证

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -126,6 +126,19 @@ codex plugin add i-have-adhd@i-have-adhd
 Invoke the skill explicitly by typing `$i-have-adhd`. Codex will not activate
 it automatically.
 
+### Always-on (optional)
+
+The SessionStart hook also checks the Codex config directory for an opt-in flag:
+
+```bash
+touch "${CODEX_HOME:-$HOME/.codex}/.i-have-adhd-always"
+```
+
+When `CODEX_HOME` is unset, the hook uses `~/.codex`. If neither host-specific
+environment variable is set, it checks `~/.claude` and then `~/.codex`. Remove
+the flag to turn always-on off for future sessions. The hook remains silent when
+no flag exists.
+
 ### Verify
 
 ```bash

--- a/hooks/always-on.mjs
+++ b/hooks/always-on.mjs
@@ -1,5 +1,7 @@
 // SessionStart hook: injects the full i-have-adhd ruleset when the user has
-// opted in by creating $CLAUDE_CONFIG_DIR/.i-have-adhd-always (default ~/.claude).
+// opted in by creating a .i-have-adhd-always flag in the active host's config
+// directory (Claude: CLAUDE_CONFIG_DIR or ~/.claude; Codex: CODEX_HOME or
+// ~/.codex).
 // Never blocks session start: any failure exits 0.
 //
 // Runs under Node so it works on macOS, Linux, and Windows. The shared Claude
@@ -13,11 +15,16 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 try {
-  const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
-  const flagPath = path.join(claudeDir, ".i-have-adhd-always");
+  const configuredDir = process.env.CLAUDE_CONFIG_DIR || process.env.CODEX_HOME;
+  const configDirs = configuredDir
+    ? [configuredDir]
+    : [path.join(os.homedir(), ".claude"), path.join(os.homedir(), ".codex")];
+  const flagPath = configDirs
+    .map((configDir) => path.join(configDir, ".i-have-adhd-always"))
+    .find((candidate) => fs.existsSync(candidate));
 
   // Only fire when the user has opted in.
-  if (!fs.existsSync(flagPath)) process.exit(0);
+  if (!flagPath) process.exit(0);
 
   // Resolve SKILL.md relative to this script's own location, not a trusted env var.
   const scriptDir = path.dirname(fileURLToPath(import.meta.url));

--- a/hooks/always-on.ps1
+++ b/hooks/always-on.ps1
@@ -1,17 +1,31 @@
 # SessionStart hook fallback for Windows PowerShell. Injects the full
-# i-have-adhd ruleset when the user has opted in by creating
-# $CLAUDE_CONFIG_DIR/.i-have-adhd-always (default ~/.claude).
+# i-have-adhd ruleset when the user has opted in by creating a
+# .i-have-adhd-always flag in the active host's config directory
+# (Claude: CLAUDE_CONFIG_DIR or ~/.claude; Codex: CODEX_HOME or ~/.codex).
 # Never blocks session start: any failure exits 0.
 
 try {
-  $claudeDir = if ($env:CLAUDE_CONFIG_DIR) {
-    $env:CLAUDE_CONFIG_DIR
+  $profileDir = [Environment]::GetFolderPath("UserProfile")
+  $configDirs = if ($env:CLAUDE_CONFIG_DIR) {
+    @($env:CLAUDE_CONFIG_DIR)
+  } elseif ($env:CODEX_HOME) {
+    @($env:CODEX_HOME)
   } else {
-    Join-Path ([Environment]::GetFolderPath("UserProfile")) ".claude"
+    @(
+      (Join-Path $profileDir ".claude")
+      (Join-Path $profileDir ".codex")
+    )
   }
-  $flagPath = Join-Path $claudeDir ".i-have-adhd-always"
+  $flagPath = $null
+  foreach ($configDir in $configDirs) {
+    $candidateFlagPath = Join-Path $configDir ".i-have-adhd-always"
+    if (Test-Path -LiteralPath $candidateFlagPath -PathType Leaf) {
+      $flagPath = $candidateFlagPath
+      break
+    }
+  }
 
-  if (-not (Test-Path -LiteralPath $flagPath -PathType Leaf)) {
+  if (-not $flagPath) {
     exit 0
   }
 

--- a/hooks/always-on.sh
+++ b/hooks/always-on.sh
@@ -1,16 +1,32 @@
 #!/usr/bin/env sh
 # SessionStart hook: injects the full i-have-adhd ruleset when the user has
-# opted in by creating $CLAUDE_CONFIG_DIR/.i-have-adhd-always (default ~/.claude).
+# opted in by creating a .i-have-adhd-always flag in the active host's config
+# directory (Claude: CLAUDE_CONFIG_DIR or ~/.claude; Codex: CODEX_HOME or
+# ~/.codex).
 # Never blocks session start: any failure exits 0.
 #
 # POSIX fallback for environments where the default Node hook cannot run. It
 # works with sh on macOS/Linux and Git Bash on Windows without a Node install.
 
-claude_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
-flag_path="$claude_dir/.i-have-adhd-always"
+flag_path=""
+if [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
+  candidate_flag_path="$CLAUDE_CONFIG_DIR/.i-have-adhd-always"
+  [ -f "$candidate_flag_path" ] && flag_path="$candidate_flag_path"
+elif [ -n "${CODEX_HOME:-}" ]; then
+  candidate_flag_path="$CODEX_HOME/.i-have-adhd-always"
+  [ -f "$candidate_flag_path" ] && flag_path="$candidate_flag_path"
+else
+  for config_dir in "$HOME/.claude" "$HOME/.codex"; do
+    candidate_flag_path="$config_dir/.i-have-adhd-always"
+    if [ -f "$candidate_flag_path" ]; then
+      flag_path="$candidate_flag_path"
+      break
+    fi
+  done
+fi
 
 # Only fire when the user has opted in.
-[ -f "$flag_path" ] || exit 0
+[ -n "$flag_path" ] || exit 0
 
 # $0 is the absolute script path substituted into hooks.json by Claude Code,
 # so resolve SKILL.md relative to it instead of trusting an exported env var.

--- a/tests/test_always_on_hooks.py
+++ b/tests/test_always_on_hooks.py
@@ -42,9 +42,16 @@ class AlwaysOnHookTest(unittest.TestCase):
             )
         return runtimes
 
-    def run_hook(self, command):
+    def run_hook(self, command, *, config_dir=None, codex_home=None):
         env = os.environ.copy()
-        env["CLAUDE_CONFIG_DIR"] = str(self.config_dir)
+        env.pop("CLAUDE_CONFIG_DIR", None)
+        env.pop("CODEX_HOME", None)
+        if config_dir is None and codex_home is None:
+            config_dir = self.config_dir
+        if config_dir is not None:
+            env["CLAUDE_CONFIG_DIR"] = str(config_dir)
+        if codex_home is not None:
+            env["CODEX_HOME"] = str(codex_home)
         return subprocess.run(
             [str(part) for part in command],
             check=False,
@@ -53,11 +60,18 @@ class AlwaysOnHookTest(unittest.TestCase):
             env=env,
         )
 
-    def run_codex_hook(self, plugin_root=None):
+    def run_codex_hook(self, plugin_root=None, *, config_dir=None, codex_home=None):
         config = json.loads((ROOT / "hooks" / "hooks.json").read_text())
         hook = config["hooks"]["SessionStart"][0]["hooks"][0]
         env = os.environ.copy()
-        env["CLAUDE_CONFIG_DIR"] = str(self.config_dir)
+        env.pop("CLAUDE_CONFIG_DIR", None)
+        env.pop("CODEX_HOME", None)
+        if config_dir is None and codex_home is None:
+            config_dir = self.config_dir
+        if config_dir is not None:
+            env["CLAUDE_CONFIG_DIR"] = str(config_dir)
+        if codex_home is not None:
+            env["CODEX_HOME"] = str(codex_home)
         plugin_root = plugin_root or self.plugin_root
         env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
         env["PLUGIN_ROOT"] = str(plugin_root)
@@ -148,6 +162,29 @@ class AlwaysOnHookTest(unittest.TestCase):
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertEqual("", result.stderr)
         self.assertEqual("", result.stdout)
+
+    def test_runtimes_support_codex_home_flag(self):
+        codex_home = Path(self.temp_dir.name) / "codex config"
+        codex_home.mkdir()
+        (codex_home / ".i-have-adhd-always").touch()
+
+        for name, command in self.runtimes():
+            with self.subTest(runtime=name):
+                result = self.run_hook(command, codex_home=codex_home)
+                self.assertEqual(0, result.returncode)
+                self.assertEqual("", result.stderr)
+                self.assertIn("ADHD MODE ACTIVE (always-on)", result.stdout)
+
+    def test_codex_command_supports_codex_home_flag(self):
+        codex_home = Path(self.temp_dir.name) / "codex config"
+        codex_home.mkdir()
+        (codex_home / ".i-have-adhd-always").touch()
+
+        result = self.run_codex_hook(config_dir=None, codex_home=codex_home)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("", result.stderr)
+        self.assertIn("ADHD MODE ACTIVE (always-on)", result.stdout)
 
     def test_codex_command_swallows_missing_plugin_errors(self):
         result = self.run_codex_hook(self.plugin_root / "missing plugin")


### PR DESCRIPTION
## Summary

Support the Codex-side always-on flag described by issue #91. The hook previously checked only `CLAUDE_CONFIG_DIR` (or `~/.claude`), so a Codex-only install could run successfully while silently ignoring its opt-in flag. The Node, POSIX, and PowerShell fallbacks now honor `CODEX_HOME` (or `~/.codex`) and keep the existing Claude behavior. The English and Simplified Chinese install guides document the Codex flag.

This addresses #91.

## Authorship and provenance — select exactly one

- [ ] **Human-authored**
- [x] **Autonomous agent-authored**
- [ ] **Hybrid**

**Agent/tool and model/version:** Codex (model/version not exposed in this session).

**Agent contribution:** Investigated the issue and current hook behavior, implemented the cross-runtime path resolution, updated tests and bilingual installation documentation, and ran the checks below.

**Human verification:** The submitting user authorized direct submission and reviewed the requested scope. The complete diff was reviewed by the agent; no independent human test execution is claimed.

**Known limitations or uncertain results:** The hook was tested in isolated temporary configurations on this Windows host, including the available Node, POSIX shell, and PowerShell runtimes. A live Codex session on another host was not run.

## Labels

**Target label:** Target:Integrations

**Author label:** Author:AI

**Workflow labels:** bug

## Safety and side effects

- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [x] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [x] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects, permissions, network access, and cost:** None. The hook checks only the documented host config paths for the existing opt-in flag and remains silent when no flag exists.

## Compatibility

- [x] This is not a breaking change.
- [ ] This is a breaking change; it was discussed, and migration/deprecation documentation is included below.
- [ ] Canonical and mirrored skill files are synchronized when applicable.
- [x] Relevant platform manifests and installation documentation were reviewed.

**Migration or rollback notes:** Existing `CLAUDE_CONFIG_DIR` behavior is unchanged. Removing the Codex flag returns the hook to its silent state.

## Verification

- `python -m unittest tests/test_always_on_hooks.py -v` — 9 passed.
- `git diff --check` — passed.
- `python -m unittest discover -s tests -v` — 41 passed; 4 existing Windows eval-runner tests fail with `FileNotFoundError: [WinError 2]`, reproduced on upstream `main`.

**Behavior evals:** Not run; this changes hook path selection, not response rules.

## Final accountability

- [x] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content.
- [x] All failed, skipped, or unrun checks are disclosed above.
