### PR TITLE
perf: stop scanning stale session markers (#153)

### DIFF
--- a/extensions/context-compat.ts
+++ b/extensions/context-compat.ts
@@ -43,19 +43,21 @@ export function latestMarkerIsActive(
   activeType: string,
   disabledType: string,
 ): boolean {
-  let active = false;
-
-  for (const message of messages) {
+  // Only the newest relevant marker determines the state. Walking backwards
+  // avoids scanning the older context once that marker is found.
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
     if (message.role !== "custom" && message.type !== "custom_message") {
       continue;
     }
 
     if (message.customType === activeType) {
-      active = true;
-    } else if (message.customType === disabledType) {
-      active = false;
+      return true;
+    }
+    if (message.customType === disabledType) {
+      return false;
     }
   }
 
-  return active;
+  return false;
 }

--- a/extensions/i-have-adhd.ts
+++ b/extensions/i-have-adhd.ts
@@ -79,20 +79,23 @@ function loadRules(): string {
 }
 
 function getSavedState(ctx: ExtensionContext): boolean | undefined {
-  let savedState: boolean | undefined;
+  const branch = ctx.sessionManager.getBranch();
 
-  for (const entry of ctx.sessionManager.getBranch()) {
+  // State entries are append-only. The newest entry wins, so walk backwards
+  // and avoid inspecting the stale history after the current state.
+  for (let index = branch.length - 1; index >= 0; index--) {
+    const entry = branch[index];
     if (entry.type !== "custom" || entry.customType !== STATE_ENTRY_TYPE) {
       continue;
     }
 
     const data = entry.data as Partial<AdhdModeState> | undefined;
     if (typeof data?.enabled === "boolean") {
-      savedState = data.enabled;
+      return data.enabled;
     }
   }
 
-  return savedState;
+  return undefined;
 }
 
 /**

--- a/scripts/check_context_compat.ts
+++ b/scripts/check_context_compat.ts
@@ -84,4 +84,25 @@ assert(
   "Ordinary messages must not activate the rules",
 );
 
+let inspected = 0;
+const recentMarker = new Proxy(
+  [{ role: "custom", customType: ACTIVE }, { role: "custom", customType: DISABLED }],
+  {
+    get(target, property, receiver) {
+      if (typeof property === "string" && /^\d+$/.test(property)) {
+        inspected += 1;
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  },
+);
+assert(
+  !latestMarkerIsActive(recentMarker, ACTIVE, DISABLED),
+  "the newest marker should win",
+);
+assert(
+  inspected === 1,
+  `latest marker lookup inspected ${inspected} entries instead of stopping at the newest marker`,
+);
+
 console.log("Pi/OMP context compatibility checks passed");


### PR DESCRIPTION
## Summary

Address the session/history scan portion of issue #153. State restoration and context-marker lookup now walk from the newest entry backwards and stop at the first relevant marker, avoiding traversal of stale history while preserving the existing latest-marker semantics. A compatibility check covers the short-circuit behavior.

This is a focused first increment for #153; it does not claim to implement the issue's broader evaluation parallelism, context-size, or persistent-index proposals.

## Authorship and provenance — select exactly one

- [ ] **Human-authored**
- [x] **Autonomous agent-authored**
- [ ] **Hybrid**

**Agent/tool and model/version:** Codex (model/version not exposed in this session).

**Agent contribution:** Reviewed the performance analysis, selected the smallest behavior-preserving scan optimization, implemented it, added a short-circuit check, and ran the checks below.

**Human verification:** The submitting user authorized direct submission and reviewed the requested scope. The complete diff was reviewed by the agent; no independent human test execution is claimed.

**Known limitations or uncertain results:** No provider-backed benchmark was run, so this PR makes no quantified latency claim. The remaining performance proposals require separate acceptance criteria and measurement.

## Labels

**Target label:** Target:Integrations

**Author label:** Author:AI

**Workflow labels:** enhancement

## Safety and side effects

- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [x] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [x] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects, permissions, network access, and cost:** None. The changes alter only traversal order and stop once the newest relevant state marker is found; output semantics remain unchanged.

## Compatibility

- [x] This is not a breaking change.
- [ ] This is a breaking change; it was discussed, and migration/deprecation documentation is included below.
- [ ] Canonical and mirrored skill files are synchronized when applicable.
- [x] Relevant platform manifests and installation documentation were reviewed.

**Migration or rollback notes:** None. If no relevant marker exists, both functions retain their previous default state.

## Verification

- `python -m unittest discover -s tests -v` — 39 passed; 4 existing Windows eval-runner tests fail with `FileNotFoundError: [WinError 2]`, reproduced on upstream `main`.
- `python scripts/run_evals.py validate` — passed.
- `bun scripts/check_context_compat.ts` — passed.
- `git diff --check` — passed.

**Behavior evals:** Not run; this is an internal traversal optimization with no response-rule change.

## Final accountability

- [x] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content.
- [x] All failed, skipped, or unrun checks are disclosed above.
