### PR TITLE
fix(hooks): trim trailing blank lines in the PowerShell always-on hook (#172)

### DIFF
--- a/hooks/always-on.ps1
+++ b/hooks/always-on.ps1
@@ -41,6 +41,10 @@ try {
     ""
   }
 
+  # Drop trailing newlines so a skill file ending in blank lines produces the
+  # same banner as the Node and sh hooks, which both already trim them.
+  $body = $body.TrimEnd([char]13, [char]10)
+
   $banner = 'ADHD MODE ACTIVE (always-on). The ruleset below applies to every response. ' +
     '"stop adhd mode" turns it off for this session; delete '
   [Console]::Out.Write($banner + $flagPath + " to turn always-on off for good.`n`n" + $body + "`n")

--- a/tests/test_always_on_hooks.py
+++ b/tests/test_always_on_hooks.py
@@ -113,6 +113,28 @@ class AlwaysOnHookTest(unittest.TestCase):
 
         self.assertEqual(1, len(set(outputs.values())))
 
+    def test_runtimes_trim_trailing_blank_lines_from_the_body(self):
+        # The sh hook drops trailing newlines through command substitution and
+        # the Node hook through an explicit replace, so a skill file ending in
+        # blank lines must not make the runtimes disagree on the banner.
+        skill_path = self.plugin_root / "skills" / "i-have-adhd" / "SKILL.md"
+        skill_path.write_text("---\nname: fixture\n---\nFixture body.\n\n\n")
+        (self.config_dir / ".i-have-adhd-always").touch()
+        outputs = {}
+
+        for name, command in self.runtimes():
+            with self.subTest(runtime=name):
+                result = self.run_hook(command)
+                self.assertEqual(0, result.returncode)
+                self.assertEqual("", result.stderr)
+                normalized = self.normalize(result.stdout)
+                self.assertTrue(
+                    normalized.endswith("\n\nFixture body.\n"), repr(normalized)
+                )
+                outputs[name] = normalized
+
+        self.assertEqual(1, len(set(outputs.values())))
+
     def test_runtimes_keep_content_when_frontmatter_is_unclosed(self):
         # An opening --- with no closing delimiter is not frontmatter. Keeping
         # the whole file beats injecting a banner that promises "the ruleset


### PR DESCRIPTION
## Summary

`hooks/always-on.ps1` joins `[System.IO.File]::ReadAllLines()` with `[Environment]::NewLine` and never trims trailing newlines, while the Node hook trims with `.replace(/(?:\r?\n)+$/, "")` and the sh hook gets the same result from `$(...)` command substitution.

Before: a `SKILL.md` that ends in blank lines made the PowerShell fallback inject a banner ending `Fixture body.\n\n\n`, where node and sh both produced `Fixture body.\n`.

After: all three runtimes emit byte-identical output, which is what `tests/test_always_on_hooks.py` already asserts for its two existing fixtures — neither of which ended the body in a blank line, so the divergence was uncovered.

`hooks/always-on.ps1` also becomes consistent with `.opencode/plugins/i-have-adhd.mjs` and `extensions/i-have-adhd.ts`, which trim as well.

This fixes #172.

## Authorship and provenance — select exactly one

- [ ] **Human-authored**
- [x] **Autonomous agent-authored**
- [ ] **Hybrid**

**Agent/tool and model/version:** Claude Code harness, model `deepseek-flash` (RepoStew worker).

**Agent contribution:** Located the divergence, reproduced it across all three runtimes on Windows, wrote the fix and the regression test, and ran the checks below.

**Human verification:** The submitting user authorized direct submission and reviewed the requested scope. The complete diff was reviewed by the agent; no independent human test execution is claimed.

**Known limitations or uncertain results:** Everything ran on Windows 10 with Node v24.14.1 and Windows PowerShell; macOS and Linux were not exercised. `scripts/check_pi_extension.py` was not run because the `pi` executable is not installed on this host. `hooks/always-on.ps1` and `tests/test_always_on_hooks.py` are also touched by #170 (same submitter, a different defect) and rewritten by #114, so whichever of the three lands first will need the others rebased. The impact today is cosmetic: the shipped `skills/i-have-adhd/SKILL.md` ends with a single newline, so no current install emits a different banner.

## Labels

**Target label:** Target:Integrations

**Author label:** Author:AI

**Workflow labels:** bug

## Safety and side effects

- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [x] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [x] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects, permissions, network access, and cost:** None. The hook trims trailing newline characters from a string it already assembles locally; no file, network, or process behaviour changes.

## Compatibility

- [x] This is not a breaking change.
- [ ] This is a breaking change; it was discussed, and migration/deprecation documentation is included below.
- [x] Canonical and mirrored skill files are synchronized when applicable.
- [x] Relevant platform manifests and installation documentation were reviewed.

**Migration or rollback notes:** None needed. Reverting the commit restores the previous output exactly, and only for skill files that end in blank lines.

## Verification

- `python -m unittest tests.test_always_on_hooks -v` — 8 tests, `OK`. The new `test_runtimes_trim_trailing_blank_lines_from_the_body` fails on `runtime='powershell'` before the fix (`...Fixture body.\n\n\n`) and passes after it.
- `python -m unittest discover -s tests` — 44 tests, 3 failures. All three are the pre-existing Windows `test_judge.EndToEndTest` failures, reproduced on unmodified `99dee367`; they are unrelated to this change and tracked by #159.
- `python scripts/run_evals.py validate` — `Evaluation cases are valid.`
- `bun scripts/check_context_compat.ts` — `Pi/OMP context compatibility checks passed`
- `claude plugin validate .` — `Validation passed`
- `git diff --check` — clean

**Behavior evals:** Not run. The change affects hook output only for skill files ending in blank lines; the shipped `SKILL.md` ends with one newline, so no eval case observes a difference.

## Final accountability

- [x] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content.
- [x] All failed, skipped, or unrun checks are disclosed above.
