### PR TITLE
fix:fallback to args for SessionStart when CLAUDE_PLUGIN_ROOT env is …

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"(async()=>{const root=process.env.CLAUDE_PLUGIN_ROOT||process.env.PLUGIN_ROOT;if(root)await import(require('node:url').pathToFileURL(require('node:path').join(root,'hooks','always-on.mjs')).href)})().catch(()=>{})\"",
+            "command": "node",
+            "args": [
+              "-e",
+              "(async()=>{const root=process.env.CLAUDE_PLUGIN_ROOT||process.env.PLUGIN_ROOT||process.argv[1];if(root&&!root.startsWith('$'))await import(require('node:url').pathToFileURL(require('node:path').join(root,'hooks','always-on.mjs')).href);else console.error('i-have-adhd: SessionStart always-on hook skipped (missing CLAUDE_PLUGIN_ROOT)')})().catch(()=>{})",
+              "${CLAUDE_PLUGIN_ROOT}"
+            ],
             "timeout": 30,
             "statusMessage": "Checking i-have-adhd always-on flag..."
           }

--- a/tests/test_always_on_hooks.py
+++ b/tests/test_always_on_hooks.py
@@ -61,8 +61,9 @@ class AlwaysOnHookTest(unittest.TestCase):
         plugin_root = plugin_root or self.plugin_root
         env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
         env["PLUGIN_ROOT"] = str(plugin_root)
+        cmd = [hook["command"]] + hook.get("args", [])
         return subprocess.run(
-            hook["command"],
+            cmd,
             check=False,
             capture_output=True,
             env=env,
@@ -74,7 +75,6 @@ class AlwaysOnHookTest(unittest.TestCase):
                     "source": "startup",
                 }
             ),
-            shell=True,
             text=True,
         )
 
@@ -160,13 +160,16 @@ class AlwaysOnHookTest(unittest.TestCase):
         config = json.loads((ROOT / "hooks" / "hooks.json").read_text())
         hook = config["hooks"]["SessionStart"][0]["hooks"][0]
 
-        self.assertNotIn("args", hook)
-        command = hook["command"]
-        self.assertRegex(command, r'^node(?: --input-type=module)? -e "')
-        self.assertIn("process.env.CLAUDE_PLUGIN_ROOT", command)
-        self.assertIn("process.env.PLUGIN_ROOT", command)
-        self.assertIn("await import", command)
-        self.assertIn(".catch", command)
+        self.assertIn("args", hook)
+        self.assertEqual("node", hook["command"])
+        args = hook["args"]
+        self.assertEqual("-e", args[0])
+        self.assertIn("process.env.CLAUDE_PLUGIN_ROOT", args[1])
+        self.assertIn("process.env.PLUGIN_ROOT", args[1])
+        self.assertIn("process.argv[1]", args[1])
+        self.assertIn("await import", args[1])
+        self.assertIn(".catch", args[1])
+        self.assertEqual("${CLAUDE_PLUGIN_ROOT}", args[2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Fixes #129. 

The `SessionStart` always-on hook silently fails on the Claude Code desktop app (macOS) because the app does not export `CLAUDE_PLUGIN_ROOT` into the hook process environment (it only substitutes it into the hook arguments). 

This PR modifies `hooks/hooks.json` to safely re-introduce the `args` array while keeping the `node -e` script. It allows the hook to fall back to `process.argv[1]` when the environment variables are missing, ensuring the ADHD mode flag check loads correctly on the desktop app. A visible `console.error` has also been added in the rare case that the variable is completely absent.

Unit tests (`tests/test_always_on_hooks.py`) have been updated to support the new `args` array configuration without breaking Codex compatibility.

## Authorship and provenance — select exactly one
- [ ] Human-authored — substantive implementation and text were produced by a human.
- [ ] Autonomous agent-authored — an agent planned and produced most of the substantive change.
- [x] Hybrid — a human and one or more agents both made substantive contributions.

**Agent/tool and model/version:**
Antigravity IDE (Gemini)

**Agent contribution:**
Investigated the root cause in the git history, identified the need for a fallback via `args` in `hooks.json`, updated the unit tests to pass the new command structure, and verified the fix locally.

**Human verification:**
Approved the implementation plan, reviewed the test results, created the branch, and pushed the commit.

**Known limitations or uncertain results:**
None.

## Labels
**Target label:**
`type: bug`

**Author label:**
`author: community`

**Workflow labels:**
`status: review-ready`

## Safety and side effects
- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [x] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [x] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects, permissions, network access, and cost:**
No side effects. This executes entirely locally.

## Compatibility
- [x] This is not a breaking change.
- [ ] This is a breaking change; it was discussed, and migration/deprecation documentation is included below.
- [x] Canonical and mirrored skill files are synchronized when applicable.
- [x] Relevant platform manifests and installation documentation were reviewed.

**Migration or rollback notes:**
N/A

## Verification
`python -m unittest discover -s tests -v` — `Ran 50 tests in 32.890s. OK`

**Behavior evals:**
N/A (Hooks configuration change, unit test coverage is sufficient)

## Final accountability
- [x] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content.
- [x] All failed, skipped, or unrun checks are disclosed above.
