### PR TITLE
fix(evals): reject NaN evaluation budgets

### DIFF
--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -268,7 +268,7 @@ def run_evaluations(args: argparse.Namespace) -> int:
         if row.get("condition") == args.condition and row.get("runner") == args.runner
     )
 
-    if args.budget_usd <= 0 or args.budget_usd > 25:
+    if not 0 < args.budget_usd <= 25:
         raise ValueError("--budget-usd must be greater than 0 and no more than 25")
 
     args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -274,6 +274,52 @@ class EvaluationHarnessTest(unittest.TestCase):
             self.assertEqual(0, run_evals.run_evaluations(args))
             self.assertTrue(marker.exists())
 
+    def test_budget_range_is_enforced_before_runner_invocation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            runner_config = tmp_path / "runners.json"
+            runner_config.write_text(
+                json.dumps({
+                    "stub": {
+                        "command": ["stub-runner"],
+                        "response_format": "claude-json",
+                        "budget_flag": "--max-budget-usd",
+                    }
+                }),
+                encoding="utf-8",
+            )
+            completed = subprocess.CompletedProcess(
+                args=["stub-runner"], returncode=0,
+                stdout=json.dumps({"result": "102", "total_cost_usd": 0.01}),
+                stderr="",
+            )
+            invalid_budgets = ("nan", "NaN", "inf", "-inf", "0", "-1", "25.01")
+            for index, budget in enumerate((*invalid_budgets, "0.01", "25")):
+                with self.subTest(budget=budget):
+                    output = tmp_path / f"results-{index}" / "responses.jsonl"
+                    args = run_evals._build_parser().parse_args([
+                        "run", "--runner-config", str(runner_config),
+                        "--runner", "stub", "--condition", "baseline",
+                        "--case", "direct-answer", "--trials", "1", "--retries", "0",
+                        f"--budget-usd={budget}", "--output", str(output),
+                    ])
+                    with mock.patch.object(
+                        run_evals.subprocess, "run", return_value=completed
+                    ) as runner:
+                        if budget in invalid_budgets:
+                            with self.assertRaisesRegex(ValueError, "--budget-usd must be"):
+                                run_evals.run_evaluations(args)
+                            runner.assert_not_called()
+                            self.assertFalse(output.parent.exists())
+                        else:
+                            self.assertEqual(0, run_evals.run_evaluations(args))
+                            runner.assert_called_once()
+                            self.assertEqual(
+                                ["--max-budget-usd", f"{float(budget):.4f}"],
+                                runner.call_args.args[0][1:3],
+                            )
+                            self.assertEqual(1, len(run_evals.read_jsonl(output)))
+
     def test_generation_runs_outside_the_repository(self):
         # An agent CLI adopts its working directory as project context. Run it
         # in this checkout and it answers prompts by inspecting the harness,


### PR DESCRIPTION
## Summary

`--budget-usd nan` passes the current range check: both `nan <= 0` and `nan > 25` are false. That lets an invalid budget reach the runner and makes the remaining-budget comparisons ineffective.

Require the budget to satisfy `0 < budget <= 25` instead. NaN is then rejected before any runner call or output-directory creation. Valid budgets and the existing error message stay unchanged.

The regression test exercises nine CLI inputs, including NaN, infinities, out-of-range values, and valid budgets of $0.01 and $25. It also checks that valid budgets are still forwarded to the runner. This does not change `--allow-unmetered` or claim to resolve #181.

## Authorship and provenance — select exactly one

- [ ] **Human-authored**
- [x] **Autonomous agent-authored**
- [ ] **Hybrid**

**Agent/tool and model/version:** OpenAI Codex; exact model/version identifier is not available in this session.

**Agent contribution:** Found and reproduced the validation gap, implemented the fix and regression test, ran the checks below, and prepared this PR. A separate Codex agent reviewed the diff and ran the evaluation-harness tests.

**Human verification:** I reviewed the complete two-file diff and authorized submission. The tests below were run by Codex; I am not claiming separate human test execution.

**Known limitations or uncertain results:** Tested on macOS with Python 3.14.6 and Node 25.9.0, not Windows or Linux. Hook tests exercised Node and sh; PowerShell was unavailable. No live provider calls were made.

## Labels

**Target label:** Target:Evals

**Author label:** Author:AI

**Workflow labels:** bug

## Safety and side effects

- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [x] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [x] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects, permissions, network access, and cost:** No new dependencies, network calls, or configuration changes. The new test uses a mocked runner and temporary files, with no provider cost.

## Compatibility

- [x] This is not a breaking change.
- [ ] This is a breaking change; it was discussed, and migration/deprecation documentation is included below.

Canonical and mirrored skills, platform manifests, hooks, and installation documentation are unchanged. No synchronization or integration changes are needed.

**Migration or rollback notes:** No migration required. Only a budget outside the existing valid range is newly rejected.

## Verification

- `python3 -m unittest discover -s tests -v` — 52 tests passed, with `TMPDIR=/private/tmp/adhd-contrib.hWDPkB` to avoid macOS temporary-path aliases.
- `python3 -m unittest discover -s tests -p test_run_evals.py -k budget_range -v` — passed all nine budget subtests. Before the fix, both NaN inputs failed with `ValueError not raised`.
- `python3 scripts/run_evals.py validate` — evaluation cases valid.
- `git diff --check main...HEAD` — clean.

**Behavior evals:** Not run: this changes input validation in the evaluation harness, not the response rules. Pi/OMP and Claude CLI validation were not run because no integrations changed.

## Final accountability

- [x] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content.
- [x] All failed, skipped, or unrun checks are disclosed above.
