### PR TITLE
fix(evals): reject unenforceable unmetered budgets

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -30,7 +30,7 @@ python3 scripts/run_evals.py run \
   --output evals/results/responses.jsonl
 ```
 
-The default Claude runner reports dollar cost and receives the remaining condition budget on every call. Runners without cost reporting are rejected unless `--allow-unmetered` is supplied; use that flag only when the provider account has its own hard cap.
+The default Claude runner reports dollar cost and receives the remaining condition budget on every call. Metered runners use a $25 harness budget when `--budget-usd` is omitted. Runners without cost reporting are rejected unless `--allow-unmetered` is supplied. Because the harness cannot enforce a cumulative dollar budget for an unmetered runner, do not combine `--allow-unmetered` with an explicit `--budget-usd`; rely on the provider account's own hard spending cap instead. Unmetered runs report cost as unavailable rather than `$0.0000`.
 
 Both example runners isolate the call from the operator's own agent configuration: `--setting-sources ""` for Claude, `--ignore-user-config --ephemeral` for Codex. Keep that isolation when adding runners: without it, user-level plugins, hooks, memory, and output styles leak into every condition and shape the responses being judged. The sharpest case is this repo's own always-on flag (`~/.claude/.i-have-adhd-always`), which would inject the full i-have-adhd ruleset into the **baseline** condition and make the comparison measure the skill against itself.
 

--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -254,21 +254,32 @@ def run_evaluations(args: argparse.Namespace) -> int:
     runner = config[args.runner]
     command = list(runner["command"])
     response_format = runner.get("response_format", "text")
-    if response_format != "claude-json" and not args.allow_unmetered:
-        raise RuntimeError(
-            f"The {response_format!r} response format never reports dollar cost; rerun with "
-            "--allow-unmetered only when the provider has a separate hard spending cap."
-        )
-    reported_cost = 0.0
+    budget_was_explicit = args.budget_usd is not None
+    budget_usd = 25.0 if args.budget_usd is None else args.budget_usd
+    if response_format != "claude-json":
+        if not args.allow_unmetered:
+            raise RuntimeError(
+                f"The {response_format!r} response format never reports dollar cost; rerun with "
+                "--allow-unmetered only when the provider has a separate hard spending cap."
+            )
+        if budget_was_explicit:
+            raise RuntimeError(
+                "--budget-usd cannot be enforced for an unmetered runner; remove it and rely on "
+                "the provider's hard spending cap when using --allow-unmetered."
+            )
     prior_rows = read_jsonl(args.output) if args.output.exists() else []
     done = completed_keys(prior_rows)
-    reported_cost = sum(
-        float(row.get("cost_usd") or 0)
+    relevant_prior_rows = [
+        row
         for row in prior_rows
         if row.get("condition") == args.condition and row.get("runner") == args.runner
+    ]
+    reported_cost = sum(float(row.get("cost_usd") or 0) for row in relevant_prior_rows)
+    cost_reporting_available = response_format == "claude-json" and all(
+        row.get("cost_usd") is not None for row in relevant_prior_rows
     )
 
-    if args.budget_usd <= 0 or args.budget_usd > 25:
+    if budget_usd <= 0 or budget_usd > 25:
         raise ValueError("--budget-usd must be greater than 0 and no more than 25")
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
@@ -281,7 +292,7 @@ def run_evaluations(args: argparse.Namespace) -> int:
                 if key in done:
                     print(f"skip completed {args.condition} trial {trial}: {case['id']}")
                     continue
-                remaining = args.budget_usd - reported_cost
+                remaining = budget_usd - reported_cost
                 if remaining <= 0:
                     print("Budget exhausted; stopping.", file=sys.stderr)
                     return 2
@@ -319,11 +330,18 @@ def run_evaluations(args: argparse.Namespace) -> int:
                         f"({shlex.join(invocation[:-1])}):\n{detail}"
                     )
                 text, usage, cost = _parse_response(completed.stdout, response_format)
-                if cost is None and not args.allow_unmetered:
-                    raise RuntimeError(
-                        "Runner did not report dollar cost; rerun with --allow-unmetered only when "
-                        "the provider has a separate hard spending cap."
-                    )
+                if cost is None:
+                    cost_reporting_available = False
+                    if not args.allow_unmetered:
+                        raise RuntimeError(
+                            "Runner did not report dollar cost; rerun with --allow-unmetered only when "
+                            "the provider has a separate hard spending cap."
+                        )
+                    if budget_was_explicit:
+                        raise RuntimeError(
+                            "--budget-usd cannot be enforced because the runner did not report dollar "
+                            "cost; rerun without --budget-usd and rely on a provider hard spending cap."
+                        )
                 reported_cost += float(cost or 0)
                 row = {
                     "case_id": case["id"],
@@ -337,7 +355,10 @@ def run_evaluations(args: argparse.Namespace) -> int:
                 destination.write(json.dumps(row, ensure_ascii=False) + "\n")
                 destination.flush()
                 print(f"{args.condition} trial {trial}: {case['id']}")
-    print(f"Reported cost: ${reported_cost:.4f}")
+    if cost_reporting_available:
+        print(f"Reported cost: ${reported_cost:.4f}")
+    else:
+        print("Reported cost: unavailable (runner did not report dollar cost)")
     return 0
 
 
@@ -365,7 +386,7 @@ def _build_parser() -> argparse.ArgumentParser:
     run.add_argument("--case", action="append")
     run.add_argument("--trials", type=int, default=3)
     run.add_argument("--retries", type=int, default=2)
-    run.add_argument("--budget-usd", type=float, default=25.0)
+    run.add_argument("--budget-usd", type=float, default=None)
     run.add_argument("--allow-unmetered", action="store_true")
     run.add_argument("--output", type=Path, required=True)
     run.set_defaults(handler=run_evaluations)

--- a/tests/test_run_evals.py
+++ b/tests/test_run_evals.py
@@ -1,4 +1,6 @@
 import argparse
+from contextlib import redirect_stdout
+import io
 import json
 import subprocess
 import sys
@@ -271,8 +273,105 @@ class EvaluationHarnessTest(unittest.TestCase):
             self.assertFalse((tmp_path / "out.jsonl").exists())
 
             args.allow_unmetered = True
-            self.assertEqual(0, run_evals.run_evaluations(args))
+            args.budget_usd = None
+            captured = io.StringIO()
+            with redirect_stdout(captured):
+                self.assertEqual(0, run_evals.run_evaluations(args))
             self.assertTrue(marker.exists())
+            self.assertIn("Reported cost: unavailable", captured.getvalue())
+
+    def test_unmetered_runner_rejects_an_explicit_budget_before_any_call(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            marker = tmp_path / "ran"
+            runner_config = tmp_path / "runners.json"
+            runner_config.write_text(
+                json.dumps(
+                    {
+                        "stub": {
+                            "command": [
+                                sys.executable,
+                                "-c",
+                                f"from pathlib import Path; Path({str(marker)!r}).touch(); print('hi')",
+                            ],
+                            "response_format": "text",
+                        }
+                    }
+                )
+            )
+            args = argparse.Namespace(
+                cases=ROOT / "evals" / "cases.jsonl",
+                runner_config=runner_config,
+                runner="stub",
+                condition="baseline",
+                condition_skill=None,
+                case=["direct-answer"],
+                trials=1,
+                retries=0,
+                budget_usd=5.0,
+                allow_unmetered=True,
+                output=tmp_path / "out.jsonl",
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "cannot be enforced"):
+                run_evals.run_evaluations(args)
+
+            self.assertFalse(marker.exists(), "runner was invoked before the rejection")
+            self.assertFalse((tmp_path / "out.jsonl").exists())
+
+    def test_metered_runner_keeps_the_default_budget(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            runner_config = tmp_path / "runners.json"
+            runner_config.write_text(
+                json.dumps(
+                    {
+                        "stub": {
+                            "command": ["stub-runner"],
+                            "response_format": "claude-json",
+                            "budget_flag": "--max-budget-usd",
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            output = tmp_path / "responses.jsonl"
+            args = run_evals._build_parser().parse_args(
+                [
+                    "run",
+                    "--runner-config",
+                    str(runner_config),
+                    "--runner",
+                    "stub",
+                    "--condition",
+                    "baseline",
+                    "--case",
+                    "direct-answer",
+                    "--trials",
+                    "1",
+                    "--retries",
+                    "0",
+                    "--output",
+                    str(output),
+                ]
+            )
+            completed = subprocess.CompletedProcess(
+                args=["stub-runner"],
+                returncode=0,
+                stdout=json.dumps({"result": "102", "usage": {}, "total_cost_usd": 0.01}),
+                stderr="",
+            )
+
+            with mock.patch.object(
+                run_evals.subprocess, "run", return_value=completed
+            ) as runner:
+                self.assertEqual(0, run_evals.run_evaluations(args))
+
+            self.assertIsNone(args.budget_usd)
+            self.assertEqual(
+                ["--max-budget-usd", "25.0000"],
+                runner.call_args.args[0][1:3],
+            )
 
     def test_generation_runs_outside_the_repository(self):
         # An agent CLI adopts its working directory as project context. Run it
@@ -294,7 +393,7 @@ class EvaluationHarnessTest(unittest.TestCase):
                 case=["direct-answer"],
                 trials=1,
                 retries=0,
-                budget_usd=1.0,
+                budget_usd=None,
                 allow_unmetered=True,
                 output=output,
             )


### PR DESCRIPTION
## Summary

Addresses #181.

`--allow-unmetered` permits runners such as Codex that do not report dollar cost. In that mode the harness cannot enforce a cumulative `--budget-usd`, so treating the budget as active is misleading and can give users a false sense of cost protection.

This change:

- rejects an explicit `--budget-usd` before invoking a known-unmetered runner;
- preserves the effective $25 default budget for metered runners;
- reports unmetered cost as unavailable instead of `$0.0000`;
- adds regression coverage for both unmetered rejection and the metered default-budget path;
- documents the resulting CLI behavior.

## Authorship and provenance — select exactly one

- [ ] **Human-authored**
- [x] **Autonomous agent-authored**
- [ ] **Hybrid**

**Agent/tool and model/version:** ChatGPT, GPT-5.6 Sol.

**Agent contribution:** Investigated #181 and the current evaluation harness, implemented the focused fix, added regression tests and documentation, reviewed the resulting diff, and prepared this pull request.

**Human verification:** The submitting human authorized the implementation and submission. The test suite was not independently executed by the human.

**Known limitations or uncertain results:** The full test suite could not be executed in the connected environment, so no unexecuted test is claimed as passing. No provider-backed model calls were made. PR #182 modifies nearby budget-validation code and may require a small rebase if it lands first.

## Labels

**Target label:** `Target:Evals`

**Author label:** `Author:AI`

**Workflow labels:** `bug`

## Safety and side effects

- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals remain bounded and do not introduce surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action is introduced.
- [x] No new network access, third-party dependency, or permission is introduced.
- [x] No prompt or fixture weakens safety or expands agent authority.

**Side effects, permissions, network access, and cost:** None. The change only affects evaluation-harness budget validation/accounting, tests, and documentation.

## Compatibility

- [x] This is not a breaking change.
- [ ] This is a breaking change; it was discussed, and migration/deprecation documentation is included below.
- [x] Canonical and mirrored skill files are unaffected.
- [x] Platform manifests and installation behavior are unaffected.

**Migration or rollback notes:** No migration is required. Users combining `--allow-unmetered` with an explicit `--budget-usd` should remove the unenforceable harness budget and rely on a provider-side hard spending cap.

## Verification

Regression tests were added for:

- rejecting an explicit budget before a known-unmetered runner is invoked;
- allowing unmetered execution without an explicit harness budget;
- reporting unmetered cost as unavailable;
- preserving the $25 default budget passed to a metered runner.

The following checks were not executed in the connected environment and are not claimed as passing:

- `python3 -m unittest discover -s tests -v`
- `python3 scripts/run_evals.py validate`
- `git diff --check`

**Behavior evals:** Not run. This changes evaluation-harness validation/accounting rather than the response-style rules.

## Final accountability

- [ ] I independently reviewed the complete diff and ran the relevant checks.
- [x] All failed, skipped, or unrun checks are disclosed above.