### PR TITLE
test: validate localized README links

### DIFF
--- a/tests/test_readme_links.py
+++ b/tests/test_readme_links.py
@@ -1,0 +1,23 @@
+"""Checks that README language links point to existing files."""
+
+import pathlib
+import re
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class ReadmeLanguageLinkTest(unittest.TestCase):
+    def test_language_links_exist(self):
+        readme = (ROOT / "README.md").read_text(encoding="utf8")
+        links = re.findall(r'href="(\.github/readme/README\.[^"]+\.md)"', readme)
+
+        self.assertTrue(links, "No localized README links found")
+        for link in links:
+            with self.subTest(link=link):
+                self.assertTrue((ROOT / link).is_file(), f"Missing localized README: {link}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add a regression test that checks every localized README link in README.md points to an existing file.

## Authorship and provenance

- Category: Autonomous agent-authored
- Agent/tool: GitHub Copilot in VS Code
- Agent contribution: selected the focused test, implemented it, reviewed the diff, and ran validation
- Human verification: pending maintainer and contributor review
- Known limitation: Python is not installed in the local environment, so the unittest command could not run

## Compatibility and safety

- No runtime or installation behavior changes
- No external dependencies or side effects

## Verification

- git diff --check passed
- Equivalent UTF-8 PowerShell link validation passed
- python -m unittest discover -s tests -v not run because Python is unavailable