### PR TITLE
feat: add reversible multi-agent installation manager

### DIFF
--- a/.github/workflows/manage-install.yml
+++ b/.github/workflows/manage-install.yml
@@ -1,0 +1,35 @@
+name: Unified installer
+
+on:
+  pull_request:
+    paths:
+      - scripts/manage_install.py
+      - tests/test_manage_install.py
+      - skills/**
+      - INSTALL.md
+      - MANAGE_INSTALL.md
+      - .github/workflows/manage-install.yml
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  installer:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python: ["3.11", "3.13"]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - run: python -m unittest tests.test_manage_install -v
+      - run: python scripts/run_evals.py validate

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,11 @@
 # How to install
 
+For multiple agents, the optional [unified installation manager](MANAGE_INSTALL.md)
+provides preview-first install, update, removal, both activation modes and
+portable Markdown export from a reviewed checkout. Its capability matrix
+distinguishes automatic filesystem routes from guided native/UI procedures.
+Existing methods below remain supported.
+
 <details>
 <summary><strong>Antigravity (<code>agy</code>)</strong></summary>
 

--- a/MANAGE_INSTALL.md
+++ b/MANAGE_INSTALL.md
@@ -1,0 +1,146 @@
+# Unified installation manager
+
+Run from a reviewed checkout with **Python 3.11+**. No pip packages, network
+requests, agent CLI execution, background processes or npm publication are needed.
+Existing native/plugin installation methods in [INSTALL.md](INSTALL.md) remain valid.
+
+## Commands
+
+```sh
+python scripts/manage_install.py list
+python scripts/manage_install.py install --agent claude --agent codex --user --mode always-on
+python scripts/manage_install.py install --agent claude --agent codex --user --mode always-on --apply
+python scripts/manage_install.py status --agent claude --agent codex --user
+python scripts/manage_install.py update --agent claude --agent codex --user --apply
+python scripts/manage_install.py uninstall --agent claude --agent codex --user --apply
+python scripts/manage_install.py export
+```
+
+For a project, replace `--user` with `--project ./your-project`; the directory must
+already exist. Omit `--apply` to preview any mutation, including update and removal.
+Repeated `--agent` selects multiple agents; duplicated selections are ignored.
+Install defaults to `--mode on-demand`. Re-run install with the other mode to
+transition. Update keeps the recorded mode and reads the current checkout;
+it never pulls or upgrades other packages. Export prints the complete canonical
+Markdown body without YAML frontmatter. Use the original
+[SKILL.md](skills/i-have-adhd/SKILL.md) for interfaces requiring skill metadata.
+
+Exit codes: **0** completed/previewed, **1** conflict or error, **2** manual work
+or an unsupported combination remains. A batch keeps successful agents and
+reports individual failures. Status checks managed hashes, not model behavior,
+and cannot establish the absence of native/UI installations.
+
+## Coverage
+
+A = automatic file management for install/update/uninstall/status.
+G = guided, no installation mutation. U = unsupported mode/scope; portable export
+is available without promising equivalent activation.
+Columns describe this manager, not every capability of the agent itself.
+
+| Agent | Project: on-demand / always-on | User: on-demand / always-on |
+| --- | --- | --- |
+| Antigravity | U / U | G / A |
+| AstronClaw | G / U | G / U |
+| Claude Code | A / A | A / A |
+| Codex | A / A | A / A |
+| Gemini CLI | G / G | A / A |
+| GitHub Copilot | A / A | A / G |
+| Hermes | G / A | A / G |
+| Kimi Code CLI | G / U | G / U |
+| OpenCode | A / G | A / A |
+| Pi | U / U | G / G |
+| Oh My Pi (OMP) | U / U | G / U |
+| Qwen Code | U / U | G / U |
+| Zed | G / G | A / A |
+| Cursor | A / A | A / G |
+| Amp | G / U | G / U |
+| Generic | G / G | G / G |
+
+Guided native/UI routes deliberately stay under their original installer:
+this script cannot hash or safely undo changes inside an opaque package store.
+It prints the source file, relevant procedure and missing CLI dependency.
+It does not install that dependency, execute displayed commands, import through
+a UI, or record manual work as completed. The proposed v1 therefore automates
+filesystem routes, not native package-manager mutations.
+
+## Automatic destinations
+
+All paths below are relative to the selected project or user home. The preview
+prints absolute destinations before applying. Automatic skill routes copy the
+whole canonical skill directory, including its agent metadata.
+
+| Agent | Project on-demand | User on-demand | Project always-on | User always-on |
+| --- | --- | --- | --- | --- |
+| Antigravity | — | — | — | .gemini/GEMINI.md |
+| Claude Code | .claude/skills/i-have-adhd/ | .claude/skills/i-have-adhd/ | CLAUDE.md | .claude/CLAUDE.md |
+| Codex | .agents/skills/i-have-adhd/ | .agents/skills/i-have-adhd/ | AGENTS.md | .codex/AGENTS.md |
+| Gemini CLI | — | .gemini/commands/i-have-adhd.toml | — | .gemini/GEMINI.md |
+| Copilot | .github/skills/i-have-adhd/ | .copilot/skills/i-have-adhd/ | .github/copilot-instructions.md | — |
+| Hermes | — | .hermes/skills/i-have-adhd/ | AGENTS.md | — |
+| OpenCode | .agents/skills/i-have-adhd/ | .agents/skills/i-have-adhd/ | — | .config/opencode/AGENTS.md |
+| Zed | — | .agents/skills/i-have-adhd/ | — | .config/zed/AGENTS.md |
+| Cursor | .cursor/skills/i-have-adhd/ | .cursor/skills/i-have-adhd/ | .cursor/rules/i-have-adhd.mdc | — |
+
+These are standalone skill/instruction routes, not native plugin installations.
+Claude always-on uses its documented CLAUDE.md mechanism, so no hook is required.
+Gemini's TOML prompt is generated from the full canonical body. Cursor's project
+rule uses `alwaysApply: true`. Other persistent Markdown files receive a
+delimited managed block. Always-on installs persistent instructions rather than
+a second on-demand copy; transitioning removes only the previous owned content.
+
+Shared paths are shared in the agent too: an AGENTS.md block or .agents skill may
+be discovered by other agents using the same directory. Selecting one agent
+cannot make a shared instruction file private to it. Native plugins, other
+scopes, or manual rules may also affect activation. Start a new session after
+changing mode and verify behavior yourself. Hermes invocation has an open
+[documentation issue #118](https://github.com/ayghri/i-have-adhd/issues/118);
+filesystem presence does not resolve that issue.
+
+Path references: the existing INSTALL.md file, [Claude skills](https://code.claude.com/docs/en/skills),
+[Claude memory](https://code.claude.com/docs/en/memory), and
+[Codex skills](https://developers.openai.com/codex/skills).
+When known configuration overrides (such as CODEX_HOME, CLAUDE_CONFIG_DIR or
+XDG_CONFIG_HOME) are set, user-scope operations fall back to guidance without
+reading or changing the default destination. Custom configuration locations are not migrated; use the guided instructions
+when the default destinations are not the ones your agent loads.
+
+## Ownership, conflicts and recovery
+
+The scope-local `.i-have-adhd-install/manifest.json` records modes, relative
+destinations, SHA-256 hashes, block separators and owners. It stores no credentials.
+Do not edit the manifest to adopt an existing installation. Back up or reconcile
+an existing manual/native installation using its documented method first.
+
+A pre-existing skill/file is not overwritten, even if its contents match.
+Unmanaged i-have-adhd blocks are not duplicated. Shared Markdown preserves bytes
+outside the managed markers, including CRLF and subsequent external edits.
+Edited or missing managed content blocks update, mode transition and removal.
+Extra files added to a skill directory are preserved. Empty directories and the
+empty ownership manifest may remain after removal.
+
+Shared resources are written once and kept until their final owner is removed.
+When updating changed shared rules, select all their recorded owners in the same
+command. A later agent failure does not roll back earlier successful agents.
+
+Each agent is preflighted before writing. Files and the manifest use atomic
+replacement; ordinary write failures restore previously changed files for that
+agent. Concurrent installer runs are rejected using a scope-local lock. Stop
+editors/other writers while applying; this is not a filesystem-wide transaction.
+Abrupt termination may leave a lock and partial files: review those destinations
+and restore from your backup before removing the stale lock and retrying.
+Do not delete a live run's lock. Symlink/junction descendants, hard-linked files,
+out-of-scope manifest destinations and files over 4 MiB are rejected.
+
+## Verification
+
+```sh
+python -m unittest tests.test_manage_install -v
+python -m unittest discover -s tests -v
+python scripts/run_evals.py validate
+git diff --check
+```
+
+Installer tests use temporary roots; native tools are not required. The added
+workflow runs the installer suite on Windows, Linux and macOS. CI results must
+be observed before claiming those platforms passed. No paid model calls are made,
+and file roundtrips do not prove a particular agent loaded the rules.

--- a/scripts/manage_install.py
+++ b/scripts/manage_install.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Preview-first, offline management of the canonical skill. Python 3.11+."""
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import shutil
+import stat
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+NAME = "i-have-adhd"
+STATE = ".i-have-adhd-install"
+BEGIN = b"<!-- i-have-adhd:managed:start -->"
+END = b"<!-- i-have-adhd:managed:end -->"
+MODES = ("on-demand", "always-on")
+URL = "https://github.com/ayghri/i-have-adhd"
+
+# Paths are relative to the explicitly selected project or home directory.
+# None means a guided route, never an invented automatic installation path.
+# The native plugin alternatives are documented in INSTALL.md.
+AGENTS = {
+    "antigravity": ("Antigravity", None, None, None, ".gemini/GEMINI.md"),
+    "astronclaw": ("AstronClaw", None, None, None, None),
+    "claude": ("Claude Code", ".claude/skills", ".claude/skills", "CLAUDE.md", ".claude/CLAUDE.md"),
+    "codex": ("Codex", ".agents/skills", ".agents/skills", "AGENTS.md", ".codex/AGENTS.md"),
+    "gemini": ("Gemini CLI", None, "command", None, ".gemini/GEMINI.md"),
+    "copilot": ("GitHub Copilot", ".github/skills", ".copilot/skills", ".github/copilot-instructions.md", None),
+    "hermes": ("Hermes", None, ".hermes/skills", "AGENTS.md", None),
+    "kimi": ("Kimi Code CLI", None, None, None, None),
+    "opencode": ("OpenCode", ".agents/skills", ".agents/skills", None, ".config/opencode/AGENTS.md"),
+    "pi": ("Pi", None, None, None, None),
+    "omp": ("Oh My Pi (OMP)", None, None, None, None),
+    "qwen": ("Qwen Code", None, None, None, None),
+    "zed": ("Zed", None, ".agents/skills", None, ".config/zed/AGENTS.md"),
+    "cursor": ("Cursor", ".cursor/skills", ".cursor/skills", ".cursor/rules/i-have-adhd.mdc", None),
+    "amp": ("Amp", None, None, None, None),
+    "generic": ("Portable Markdown", None, None, None, None),
+}
+
+# Native operations remain guided: their private package stores are not owned
+# by our manifest. Commands are displayed as argv, NEVER evaluated in a shell.
+NATIVE = {
+    "antigravity": (["agy", "plugin", "install", URL], ["agy", "plugin", "uninstall", NAME]),
+    "claude": (["claude", "plugin", "install", NAME + "@" + NAME], ["claude", "plugin", "uninstall", NAME]),
+    "codex": (["codex", "plugin", "add", NAME + "@" + NAME], ["codex", "plugin", "remove", NAME]),
+    "pi": (["pi", "install", URL], ["pi", "remove", URL]),
+    "omp": (["omp", "plugin", "install", "--scope", "user", NAME + "@" + NAME],
+            ["omp", "plugin", "uninstall", "--scope", "user", NAME + "@" + NAME]),
+    "qwen": (["qwen", "extensions", "install", "ayghri/" + NAME], ["qwen", "extensions", "uninstall", NAME]),
+}
+
+
+class Conflict(ValueError):
+    """A conflict requires user review; do not overwrite or adopt it."""
+
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def body(source=ROOT):
+    text = (source / "skills" / NAME / "SKILL.md").read_text(encoding="utf-8")
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        raise Conflict("Canonical skill is missing frontmatter")
+    for i, line in enumerate(lines[1:], 1):
+        if line.strip() == "---":
+            return "".join(lines[i + 1:]).lstrip("\n")
+    raise Conflict("Canonical skill has unterminated frontmatter")
+
+
+def route(agent, scope, mode):
+    entry = AGENTS[agent]
+    return entry[(1 if scope == "project" else 2) if mode == MODES[0]
+                 else (3 if scope == "project" else 4)]
+
+
+def capability(agent, scope, mode):
+    if route(agent, scope, mode):
+        return "automatic"
+    if agent == "generic":
+        return "guided"
+    # Unknown scope/mode combinations must not be described as supported.
+    if mode == "always-on" and agent in {"astronclaw", "kimi", "omp", "qwen", "amp"}:
+        return "unsupported"
+    if scope == "project" and agent in {"antigravity", "pi", "omp", "qwen"}:
+        return "unsupported"
+    return "guided"
+
+
+def custom_location(agent, scope):
+    if scope != "user":
+        return None
+    variables = {
+        "claude": ("CLAUDE_CONFIG_DIR",), "codex": ("CODEX_HOME",),
+        "gemini": ("GEMINI_CLI_HOME",), "hermes": ("HERMES_HOME",),
+        "opencode": ("XDG_CONFIG_HOME", "OPENCODE_CONFIG", "OPENCODE_CONFIG_DIR"),
+        "zed": ("XDG_CONFIG_HOME",), "antigravity": ("GEMINI_CLI_HOME",),
+    }
+    active = [name for name in variables.get(agent, ()) if os.environ.get(name)]
+    return ", ".join(active) if active else None
+
+
+def linked(path):
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return False
+    return stat.S_ISLNK(info.st_mode) or bool(
+        getattr(info, "st_file_attributes", 0) & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0))
+
+
+def guidance(agent, scope, mode, action):
+    result = [f"{capability(agent, scope, mode)}: {mode}, {scope}; no installation changes made."]
+    if agent in NATIVE and capability(agent, scope, mode) != "unsupported":
+        args = NATIVE[agent][1 if action == "uninstall" else 0]
+        if action == "update":
+            result.append("Use the package-specific Update procedure in INSTALL.md; do not reinstall over edits.")
+        else:
+            result.append("Native alternative (check prerequisites in INSTALL.md): " + json.dumps(args))
+        if shutil.which(args[0]) is None:
+            result.append(f"Dependency missing: {args[0]}; install it separately if using the native route.")
+    if agent == "astronclaw":
+        result.append("My skills: import SKILL.md, review, then Enable. Update: download/review your copy first; remove with Delete.")
+    elif agent == "kimi":
+        result.append("Kimi /plugins: Custom -> repository URL -> Trust and install. Update: R; uninstall: D.")
+    elif agent == "amp":
+        result.append("Use the existing npx skills procedure with -a amp (and -g for user scope).")
+    elif agent == "zed":
+        result.append("Zed Skills manager: Create skill from URL, choose Project. Update/reimport or remove there.")
+    elif agent == "cursor" and mode == "always-on":
+        result.append("Cursor Settings -> Rules -> User Rules: paste exported Markdown; later replace/remove only your pasted text.")
+    elif agent == "hermes":
+        result.append("Follow the Hermes section; activation is disputed in #118. User always-on requires choosing your persona SOUL.md manually.")
+    if mode == "always-on" and agent == "pi":
+        result.append("After native install, use the documented .i-have-adhd-always flag in Pi's agent directory; remove it to undo.")
+    result += ["Full skill for imports: " + str(ROOT / "skills" / NAME / "SKILL.md"),
+               "Portable body: python scripts/manage_install.py export",
+               "Review the matching INSTALL.md section for mode, scope, activation and undo. Runtime behavior is not verified."]
+    return "\n  ".join(result)
+
+
+def desired(agent, scope, mode, source=ROOT):
+    """Return relative path -> (file/block, bytes); no I/O in the destination."""
+    target = route(agent, scope, mode)
+    if target is None:
+        return {}
+    if mode == "always-on":
+        if target.endswith(".mdc"):
+            return {target: ("file", ("---\nalwaysApply: true\n---\n\n" + body(source)).encode())}
+        return {target: ("block", body(source).encode())}
+    if target == "command":
+        # JSON string escaping is also valid for this TOML basic string. Use
+        # the full canonical body instead of the older abbreviated TOML copy.
+        prompt = json.dumps(body(source) + "\n{{args}}\n", ensure_ascii=False)
+        return {".gemini/commands/i-have-adhd.toml":
+                ("file", ('description = "ADHD-friendly output"\nprompt = ' + prompt + "\n").encode())}
+    result = {}
+    tree = source / "skills" / NAME
+    for file in sorted(tree.rglob("*")):
+        if file.is_symlink():
+            raise Conflict("Symlink in canonical skill: " + str(file))
+        if file.is_file():
+            result[f"{target}/{NAME}/{file.relative_to(tree).as_posix()}"] = ("file", file.read_bytes())
+    return result
+
+
+def safe_path(root, relative):
+    rel = PurePosixPath(relative)
+    if not relative or rel.is_absolute() or ".." in rel.parts or "\\" in relative or ":" in relative:
+        raise Conflict("Invalid destination: " + relative)
+    path = root
+    for part in rel.parts:
+        path = path / part
+        if linked(path):
+            raise Conflict("Linked destination requires manual review: " + str(path))
+    if path.exists() and path.is_file() and path.stat().st_nlink > 1:
+        raise Conflict("Hard-linked destination requires manual review: " + str(path))
+    if not path.resolve().is_relative_to(root.resolve()):
+        raise Conflict("Destination escapes selected scope: " + relative)
+    return path
+
+
+def read(path):
+    if not path.exists():
+        return None
+    if path.stat().st_size > 4 * 1024 * 1024:
+        raise Conflict("File exceeds 4 MiB limit: " + str(path))
+    return path.read_bytes()
+
+
+def block_bounds(data):
+    if data.count(BEGIN) != 1 or data.count(END) != 1:
+        raise Conflict("Managed markers missing, duplicated or malformed")
+    start = data.index(BEGIN)
+    end = data.index(END) + len(END)
+    if end <= start:
+        raise Conflict("Managed markers out of order")
+    return start, end
+
+
+def verify(data, record):
+    if data is None:
+        raise Conflict("Managed content is missing; restore it before changing the installation")
+    owned = data
+    if record["kind"] == "block":
+        start, end = block_bounds(data)
+        owned = data[start:end]
+    if digest(owned) != record["sha256"]:
+        raise Conflict("Managed content was edited; preserve/reconcile your edits before retrying")
+
+
+def replace_content(data, record, kind, content):
+    """Preserve bytes outside our block, including the original line endings."""
+    if kind == "file":
+        return content, digest(content), ""
+    eol = b"\r\n" if data and b"\r\n" in data else b"\n"
+    rendered = BEGIN + eol + content.replace(b"\r\n", b"\n").replace(b"\n", eol) + END
+    if record:
+        start, end = block_bounds(data)
+        return data[:start] + rendered + data[end:], digest(rendered), record["separator"]
+    existing = data or b""
+    if BEGIN in existing or END in existing or NAME.encode() in existing or b"The reader has ADHD" in existing:
+        raise Conflict("Existing unmanaged skill/rules detected; use the existing INSTALL.md procedure")
+    separator = eol * 2 if existing else b""
+    return existing + separator + rendered, digest(rendered), separator.decode()
+
+
+def remove_content(data, record):
+    if record["kind"] == "file":
+        return None
+    start, end = block_bounds(data)
+    separator = record["separator"].encode()
+    if separator and data[:start].endswith(separator):
+        start -= len(separator)
+    remaining = data[:start] + data[end:]
+    return None if record["created"] and not remaining else remaining
+
+
+def empty_state():
+    return {"version": 1, "agents": {}, "resources": {}}
+
+
+def load_state(root, scope):
+    path = safe_path(root, STATE + "/manifest.json")
+    raw = read(path)
+    if raw is None:
+        return empty_state()
+    state = json.loads(raw)
+    if not isinstance(state, dict) or state.get("version") != 1:
+        raise Conflict("Unsupported installation manifest")
+    if not isinstance(state.get("agents"), dict) or not isinstance(state.get("resources"), dict):
+        raise Conflict("Invalid installation manifest")
+    for agent, mode in state["agents"].items():
+        if agent not in AGENTS or mode not in MODES or route(agent, scope, mode) is None:
+            raise Conflict("Invalid agent/mode in manifest")
+    for rel, rec in state["resources"].items():
+        safe_path(root, rel)
+        if not isinstance(rec, dict) or rec.get("kind") not in {"file", "block"}:
+            raise Conflict("Invalid resource in manifest")
+        if not isinstance(rec.get("owners"), list) or not rec["owners"]:
+            raise Conflict("Invalid resource owners")
+        if not isinstance(rec.get("sha256"), str) or len(rec["sha256"]) != 64:
+            raise Conflict("Invalid resource hash")
+        if type(rec.get("created")) is not bool or rec.get("separator") not in {"", "\n\n", "\r\n\r\n"}:
+            raise Conflict("Invalid resource metadata")
+        for agent in rec["owners"]:
+            if agent not in state["agents"]:
+                raise Conflict("Unknown resource owner")
+            target = route(agent, scope, state["agents"][agent])
+            if state["agents"][agent] == "always-on":
+                allowed = rel == target
+            elif target == "command":
+                allowed = rel == ".gemini/commands/i-have-adhd.toml"
+            else:
+                allowed = rel.startswith(target + "/" + NAME + "/")
+            if not allowed:
+                raise Conflict("Manifest destination does not belong to its adapter: " + rel)
+    return state
+
+
+def plan(root, scope, state, agent, action, mode, source=ROOT, selected=None, overlay=None):
+    """Preflight one complete agent before returning any mutations."""
+    next_state = copy.deepcopy(state)
+    selected = set(selected or [agent])
+    overlay = overlay or {}
+    old_mode = state["agents"].get(agent)
+    if action in {"update", "uninstall"} and not old_mode:
+        raise Conflict("Not managed here; use INSTALL.md for an existing native/manual installation")
+    wanted = {} if action == "uninstall" else desired(agent, scope, mode, source)
+    previous = {p for p, r in state["resources"].items() if agent in r["owners"]}
+    changes = {}
+    # Detect a pre-existing skill directory even if only an extra file remains.
+    target = route(agent, scope, mode)
+    if action != "uninstall" and mode == "on-demand" and target != "command":
+        directory = safe_path(root, target + "/" + NAME)
+        managed_tree = any(p.startswith(target + "/" + NAME + "/") for p in state["resources"])
+        if directory.exists() and any(linked(p) or p.is_file() for p in directory.rglob("*")) and not managed_tree:
+            raise Conflict("Unmanaged skill directory exists: " + str(directory))
+    for rel in sorted(previous | set(wanted)):
+        path = safe_path(root, rel)
+        data = overlay[rel] if rel in overlay else read(path)
+        record = state["resources"].get(rel)
+        if record:
+            verify(data, record)
+        elif data is not None and wanted[rel][0] == "file":
+            raise Conflict("Unmanaged file exists: " + str(path))
+        if rel in wanted:
+            kind, content = wanted[rel]
+            if record and record["kind"] != kind:
+                raise Conflict("Conflicting adapter resource kinds")
+            updated, sha, separator = replace_content(data, record, kind, content)
+            owners = sorted(set((record or {}).get("owners", [])) | {agent})
+            # Shared bytes cannot change behind another agent's recorded state.
+            if record and set(record["owners"]) - selected and sha != record["sha256"]:
+                raise Conflict("Shared content changed; select all owners to update: " + rel)
+            next_state["resources"][rel] = {"kind": kind, "sha256": sha, "owners": owners,
+                "created": record["created"] if record else data is None, "separator": separator}
+        else:
+            remaining = [owner for owner in record["owners"] if owner != agent]
+            if remaining:
+                next_state["resources"][rel]["owners"] = remaining
+                updated = data
+            else:
+                updated = remove_content(data, record)
+                del next_state["resources"][rel]
+        if updated != data:
+            changes[rel] = (data, updated)
+    if action == "uninstall":
+        next_state["agents"].pop(agent, None)
+    else:
+        next_state["agents"][agent] = mode
+    return next_state, changes
+
+
+def write_atomic(path, content):
+    if content is None:
+        path.unlink()
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=".i-have-adhd-", dir=path.parent)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if path.exists():
+            shutil.copymode(path, temporary)
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def commit(root, state, changes):
+    """Rollback ordinary write failures; keep other completed agents intact."""
+    mutations = dict(changes)
+    manifest = STATE + "/manifest.json"
+    mutations[manifest] = (read(safe_path(root, manifest)),
+                          (json.dumps(state, indent=2, sort_keys=True) + "\n").encode())
+    completed = []
+    try:
+        for rel, (before, after) in mutations.items():
+            path = safe_path(root, rel)
+            if read(path) != before:
+                raise Conflict("File changed since preview: " + rel)
+            if before == after:
+                continue
+            write_atomic(path, after)
+            completed.append(rel)
+    except BaseException as error:
+        failures = []
+        for rel in reversed(completed):
+            try:
+                path = safe_path(root, rel)
+                if read(path) != mutations[rel][1]:
+                    raise Conflict("Concurrent edit prevents rollback")
+                write_atomic(path, mutations[rel][0])
+            except (OSError, ValueError) as rollback_error:
+                failures.append(f"{rel}: {rollback_error}")
+        if failures:
+            raise Conflict("Rollback incomplete; manual recovery required: " + "; ".join(failures)) from error
+        raise
+
+
+def status(root, scope, state, agent, source=ROOT):
+    mode = state["agents"].get(agent)
+    if mode:
+        try:
+            paths = [p for p, r in state["resources"].items() if agent in r["owners"]]
+            if not paths:
+                raise Conflict("Manifest has no managed resources")
+            for rel in paths:
+                verify(read(safe_path(root, rel)), state["resources"][rel])
+        except (ValueError, OSError) as error:
+            return f"managed {mode}, drift: {error}"
+        return f"managed {mode}, hashes match; runtime behavior not verified"
+    for candidate in MODES:
+        for rel, (kind, _) in desired(agent, scope, candidate, source).items():
+            data = read(safe_path(root, rel))
+            if data is not None and (kind == "file" or NAME.encode() in data or b"The reader has ADHD" in data):
+                return "unmanaged/shared installation detected; review INSTALL.md before changing it"
+    return "not managed; native/UI installations not inspected; consult INSTALL.md or export"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="action", required=True)
+    sub.add_parser("list", help="Show capability matrix")
+    sub.add_parser("export", help="Print canonical Markdown body to stdout")
+    for action in ("install", "update", "uninstall", "status"):
+        cmd = sub.add_parser(action)
+        cmd.add_argument("--agent", action="append", choices=sorted(AGENTS), required=True)
+        scope = cmd.add_mutually_exclusive_group(required=True)
+        scope.add_argument("--project", type=Path)
+        scope.add_argument("--user", action="store_true")
+        if action != "status":
+            cmd.add_argument("--apply", action="store_true", help="Opt in to writes in the selected scope")
+        if action == "install":
+            cmd.add_argument("--mode", choices=MODES, default="on-demand")
+    args = parser.parse_args(argv)
+    if args.action == "export":
+        sys.stdout.write(body())
+        return 0
+    if args.action == "list":
+        print("agent | project on-demand / always-on | user on-demand / always-on")
+        for agent in AGENTS:
+            columns = [" / ".join(capability(agent, scope, m) for m in MODES) for scope in ("project", "user")]
+            print(agent + " | " + " | ".join(columns))
+        print("Automatic: install/update/uninstall/status. Guided: manual steps only. Unsupported: export fallback.")
+        return 0
+    scope = "user" if args.user else "project"
+    root = (Path.home() if args.user else args.project).absolute()
+    if not root.is_dir():
+        parser.error("Selected scope must be an existing directory")
+    # Resolving the explicitly chosen root permits macOS /var -> /private/var;
+    # every descendant is still checked for symlinks/junctions.
+    root = root.resolve()
+    apply = getattr(args, "apply", False)
+    lock = None
+    result = 0
+    try:
+        lock_path = safe_path(root, STATE + "/lock")
+        if lock_path.exists():
+            raise Conflict("Installer lock exists; stop other runs and review partial changes before removing " + str(lock_path))
+        if apply:
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            lock = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        state = load_state(root, scope)
+        overlay = {}
+        print(f"{'Apply' if apply else 'Read-only'}; scope: {root}")
+        for agent in dict.fromkeys(args.agent):
+            try:
+                override = custom_location(agent, scope)
+                if override:
+                    print(f"{agent}: custom configuration ({override}); default paths not inspected or changed. Use INSTALL.md and export.")
+                    result = 2 if result == 0 else result
+                    continue
+                if args.action == "status":
+                    print(f"{agent}: {status(root, scope, state, agent)}")
+                    continue
+                mode = getattr(args, "mode", state["agents"].get(agent, "on-demand"))
+                if not route(agent, scope, mode):
+                    print(f"{agent}: " + guidance(agent, scope, mode, args.action))
+                    result = 2 if result == 0 else result
+                    continue
+                new_state, changes = plan(root, scope, state, agent, args.action, mode, selected=args.agent, overlay=overlay)
+                print(f"{agent}: {args.action} {mode}; {len(changes)} file change(s)")
+                for rel, (before, after) in changes.items():
+                    verb = "remove" if after is None else "create" if before is None else "update"
+                    print(f"  {verb}: {safe_path(root, rel)}")
+                print("  manifest: " + str(root / STATE / "manifest.json"))
+                if apply:
+                    commit(root, new_state, changes)
+                    print("  Applied. Start a new agent session; runtime behavior not verified.")
+                state = new_state
+                if not apply:
+                    overlay.update({p: after for p, (_, after) in changes.items()})
+            except (OSError, ValueError) as error:
+                print(f"{agent}: {error}", file=sys.stderr)
+                result = 1
+        return result
+    except (OSError, ValueError) as error:
+        print(str(error), file=sys.stderr)
+        return 1
+    finally:
+        if lock is not None:
+            os.close(lock)
+            lock_path.unlink()
+            try:
+                lock_path.parent.rmdir()
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_manage_install.py
+++ b/tests/test_manage_install.py
@@ -1,0 +1,347 @@
+"""Offline installer tests; all destinations are disposable directories."""
+import contextlib
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("manage_install", ROOT / "scripts/manage_install.py")
+m = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(m)
+
+
+class InstallerTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="adhd space ")
+        self.root = Path(self.temp.name).resolve()
+        self.state = m.empty_state()
+        self.config_patch = mock.patch.dict(os.environ, {key: "" for key in ("CLAUDE_CONFIG_DIR", "CODEX_HOME", "GEMINI_CLI_HOME", "HERMES_HOME", "XDG_CONFIG_HOME", "OPENCODE_CONFIG", "OPENCODE_CONFIG_DIR")})
+        self.config_patch.start()
+
+    def tearDown(self):
+        self.config_patch.stop()
+        self.temp.cleanup()
+
+    def apply(self, agent="codex", mode="on-demand", action="install", scope="project", source=ROOT, selected=None):
+        state, changes = m.plan(self.root, scope, self.state, agent, action, mode, source, selected)
+        m.commit(self.root, state, changes)
+        self.state = state
+        return changes
+
+    def cli(self, *args):
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            result = m.main(list(args))
+        return result, out.getvalue(), err.getvalue()
+
+    def test_export_is_exact_body(self):
+        code, out, err = self.cli("export")
+        self.assertEqual((code, err), (0, ""))
+        self.assertEqual(out, m.body())
+        self.assertNotIn("disable-model-invocation:", out)
+        self.assertTrue(out.startswith("# i-have-adhd"))
+
+    def test_capability_registry_covers_documented_agents(self):
+        docs = (ROOT / "INSTALL.md").read_text(encoding="utf-8")
+        for key, entry in m.AGENTS.items():
+            if key != "generic":
+                self.assertIn(entry[0], docs)
+            for scope in ("user", "project"):
+                for mode in m.MODES:
+                    self.assertIn(m.capability(key, scope, mode), ("automatic", "guided", "unsupported"))
+
+    def test_all_automatic_routes_roundtrip(self):
+        for agent in m.AGENTS:
+            for scope in ("project", "user"):
+                for mode in m.MODES:
+                    if not m.route(agent, scope, mode):
+                        continue
+                    with self.subTest(agent=agent, scope=scope, mode=mode):
+                        with tempfile.TemporaryDirectory() as temp:
+                            root = Path(temp).resolve()
+                            state, changes = m.plan(root, scope, m.empty_state(), agent, "install", mode)
+                            m.commit(root, state, changes)
+                            m.load_state(root, scope)
+                            self.assertIn("hashes match", m.status(root, scope, state, agent))
+                            state, changes = m.plan(root, scope, state, agent, "uninstall", mode)
+                            m.commit(root, state, changes)
+                            self.assertEqual(state, m.empty_state())
+
+    def test_repeated_install_and_reinstall_after_uninstall(self):
+        self.apply()
+        self.assertEqual(self.apply(), {})
+        self.apply(action="uninstall")
+        self.apply()
+        self.assertTrue((self.root / ".agents/skills/i-have-adhd/SKILL.md").exists())
+
+    def test_block_preserves_crlf_and_external_edits(self):
+        path = self.root / "AGENTS.md"
+        original = b"# My instructions\r\nPreserve this.\r\n"
+        path.write_bytes(original)
+        self.apply(mode="always-on")
+        self.assertTrue(path.read_bytes().startswith(original))
+        path.write_bytes(path.read_bytes() + b"\r\nLater instruction\r\n")
+        self.apply(mode="always-on", action="update")
+        self.apply(mode="always-on", action="uninstall")
+        self.assertEqual(path.read_bytes(), original + b"\r\nLater instruction\r\n")
+
+    def test_empty_existing_file_remains_after_uninstall(self):
+        (self.root / "AGENTS.md").write_bytes(b"")
+        self.apply(mode="always-on")
+        self.apply(mode="always-on", action="uninstall")
+        self.assertEqual((self.root / "AGENTS.md").read_bytes(), b"")
+
+    def test_mode_transition_removes_previous_resources(self):
+        self.apply()
+        self.apply(mode="always-on")
+        self.assertFalse((self.root / ".agents/skills/i-have-adhd/SKILL.md").exists())
+        self.assertTrue((self.root / "AGENTS.md").exists())
+        self.apply()
+        self.assertFalse((self.root / "AGENTS.md").exists())
+
+    def test_edit_blocks_update_remove_and_transition(self):
+        self.apply()
+        target = self.root / ".agents/skills/i-have-adhd/SKILL.md"
+        target.write_bytes(target.read_bytes() + b"my edits")
+        for action, mode in (("update", "on-demand"), ("uninstall", "on-demand"), ("install", "always-on")):
+            with self.subTest(action=action):
+                with self.assertRaisesRegex(m.Conflict, "edited"):
+                    self.apply(action=action, mode=mode)
+        self.assertTrue(target.read_bytes().endswith(b"my edits"))
+
+    def test_block_edit_and_missing_markers_rejected(self):
+        self.apply(mode="always-on")
+        target = self.root / "AGENTS.md"
+        original = target.read_bytes()
+        for content in (original.replace(b"# i-have-adhd", b"# changed"), original.replace(m.END, b""), original + m.END):
+            target.write_bytes(content)
+            with self.assertRaises(m.Conflict):
+                self.apply(mode="always-on", action="uninstall")
+        target.write_bytes(original)
+
+    def test_unmanaged_files_and_skill_directories_are_not_adopted(self):
+        target = self.root / ".agents/skills/i-have-adhd"
+        target.mkdir(parents=True)
+        (target / "notes.txt").write_text("keep", encoding="utf-8")
+        with self.assertRaisesRegex(m.Conflict, "Unmanaged"):
+            self.apply()
+        self.assertEqual((target / "notes.txt").read_text(), "keep")
+
+    def test_unmanaged_rules_are_not_duplicated(self):
+        (self.root / "AGENTS.md").write_text("# i-have-adhd\nmanual rules", encoding="utf-8")
+        with self.assertRaisesRegex(m.Conflict, "unmanaged"):
+            self.apply(mode="always-on")
+
+    def test_shared_files_reference_counted(self):
+        self.apply()
+        self.apply(agent="opencode")
+        rel = ".agents/skills/i-have-adhd/SKILL.md"
+        self.assertEqual(self.state["resources"][rel]["owners"], ["codex", "opencode"])
+        self.apply(action="uninstall")
+        self.assertTrue((self.root / rel).exists())
+        self.apply(agent="opencode", action="uninstall")
+        self.assertFalse((self.root / rel).exists())
+
+    def test_shared_block_survives_removing_one_owner(self):
+        self.apply(mode="always-on")
+        self.apply(agent="hermes", mode="always-on")
+        self.apply(mode="always-on", action="uninstall")
+        self.assertTrue((self.root / "AGENTS.md").exists())
+        self.apply(agent="hermes", mode="always-on", action="uninstall")
+        self.assertFalse((self.root / "AGENTS.md").exists())
+
+    def test_update_from_checkout_and_shared_owners(self):
+        self.apply()
+        self.apply(agent="opencode")
+        candidate = self.root / "candidate"
+        shutil.copytree(ROOT / "skills", candidate / "skills")
+        skill = candidate / "skills/i-have-adhd/SKILL.md"
+        skill.write_bytes(skill.read_bytes() + b"\nUpdated source\n")
+        with self.assertRaisesRegex(m.Conflict, "all owners"):
+            self.apply(action="update", source=candidate)
+        self.apply(action="update", source=candidate, selected=["codex", "opencode"])
+        self.apply(agent="opencode", action="update", source=candidate, selected=["codex", "opencode"])
+        self.assertIn(b"Updated source", (self.root / ".agents/skills/i-have-adhd/SKILL.md").read_bytes())
+
+    def test_update_removes_only_old_owned_source_files(self):
+        self.apply()
+        candidate = self.root / "candidate"
+        shutil.copytree(ROOT / "skills", candidate / "skills")
+        (candidate / "skills/i-have-adhd/agents/gemini.toml").unlink()
+        directory = self.root / ".agents/skills/i-have-adhd"
+        (directory / "personal.txt").write_text("keep", encoding="utf-8")
+        self.apply(action="update", source=candidate)
+        self.assertFalse((directory / "agents/gemini.toml").exists())
+        self.assertEqual((directory / "personal.txt").read_text(), "keep")
+
+    def test_preview_never_writes_and_deduplicates_shared_paths(self):
+        args = ("install", "--project", str(self.root), "--agent", "codex", "--agent", "opencode")
+        code, out, err = self.cli(*args)
+        self.assertEqual((code, err), (0, ""))
+        self.assertEqual(list(self.root.iterdir()), [])
+        self.assertEqual(out.count("create: " + str(self.root / ".agents/skills/i-have-adhd/SKILL.md")), 1)
+        self.assertIn("opencode: install on-demand; 0 file change(s)", out)
+
+    def test_partial_agent_failure_keeps_successful_agent(self):
+        bad = self.root / ".cursor/skills/i-have-adhd"
+        bad.mkdir(parents=True)
+        (bad / "SKILL.md").write_text("mine")
+        code, out, err = self.cli("install", "--project", str(self.root), "--agent", "codex", "--agent", "cursor", "--apply")
+        self.assertEqual(code, 1)
+        state = m.load_state(self.root, "project")
+        self.assertEqual(state["agents"], {"codex": "on-demand"})
+        self.assertIn("Unmanaged", err)
+
+    def test_failure_rolls_back_all_agent_files(self):
+        state, changes = m.plan(self.root, "project", self.state, "codex", "install", "on-demand")
+        original = m.write_atomic
+        calls = []
+        def failing(path, content):
+            calls.append(path)
+            if len(calls) == 2:
+                raise PermissionError("simulated permission failure")
+            original(path, content)
+        with mock.patch.object(m, "write_atomic", side_effect=failing):
+            with self.assertRaises(PermissionError):
+                m.commit(self.root, state, changes)
+        self.assertFalse((self.root / m.STATE / "manifest.json").exists())
+        self.assertFalse(any(path.is_file() for path in self.root.rglob("*")))
+
+    def test_manifest_failure_rolls_back_content(self):
+        state, changes = m.plan(self.root, "project", self.state, "codex", "install", "always-on")
+        original = m.write_atomic
+        def failing(path, content):
+            if path.name == "manifest.json":
+                raise PermissionError("manifest denied")
+            original(path, content)
+        with mock.patch.object(m, "write_atomic", side_effect=failing):
+            with self.assertRaises(PermissionError):
+                m.commit(self.root, state, changes)
+        self.assertFalse((self.root / "AGENTS.md").exists())
+
+    def test_concurrent_edit_after_plan_is_preserved(self):
+        (self.root / "AGENTS.md").write_text("before")
+        state, changes = m.plan(self.root, "project", self.state, "codex", "install", "always-on")
+        (self.root / "AGENTS.md").write_text("after")
+        with self.assertRaisesRegex(m.Conflict, "changed since"):
+            m.commit(self.root, state, changes)
+        self.assertEqual((self.root / "AGENTS.md").read_text(), "after")
+
+    def test_safe_paths_reject_traversal(self):
+        for path in ("../elsewhere", "/absolute", "C:/outside", ".agents/../outside", "back\\slash"):
+            with self.subTest(path=path), self.assertRaises(m.Conflict):
+                m.safe_path(self.root, path)
+
+    def test_symlink_destination_is_rejected(self):
+        destination = self.root / "real"
+        destination.mkdir()
+        try:
+            (self.root / ".agents").symlink_to(destination, target_is_directory=True)
+        except OSError:
+            self.skipTest("OS does not allow creating symlinks")
+        with self.assertRaisesRegex(m.Conflict, "Linked"):
+            self.apply()
+
+    def test_hardlink_destination_is_rejected(self):
+        original = self.root / "original"
+        original.write_text("hello")
+        try:
+            os.link(original, self.root / "AGENTS.md")
+        except OSError:
+            self.skipTest("Filesystem does not allow hardlinks")
+        with self.assertRaisesRegex(m.Conflict, "Hard-linked"):
+            self.apply(mode="always-on")
+
+    def test_manifest_cannot_redirect_writes(self):
+        self.apply(mode="always-on")
+        state = json.loads(json.dumps(self.state))
+        state["resources"]["private.txt"] = state["resources"].pop("AGENTS.md")
+        (self.root / m.STATE / "manifest.json").write_text(json.dumps(state))
+        with self.assertRaisesRegex(m.Conflict, "does not belong"):
+            m.load_state(self.root, "project")
+
+    def test_missing_managed_file_reported_as_drift(self):
+        self.apply()
+        (self.root / ".agents/skills/i-have-adhd/SKILL.md").unlink()
+        self.assertIn("drift", m.status(self.root, "project", self.state, "codex"))
+
+    def test_status_does_not_claim_native_install_absent(self):
+        code, out, err = self.cli("status", "--project", str(self.root), "--agent", "pi")
+        self.assertEqual(code, 0)
+        self.assertIn("native/UI installations not inspected", out)
+        self.assertEqual(list(self.root.iterdir()), [])
+
+    def test_guided_and_unsupported_no_commands_or_writes(self):
+        with mock.patch.object(m.shutil, "which", return_value=None), mock.patch("subprocess.run") as run:
+            code, out, err = self.cli("install", "--project", str(self.root), "--agent", "qwen", "--mode", "always-on", "--apply")
+            self.assertEqual(code, 2)
+            self.assertIn("unsupported", out)
+            self.assertNotIn("Native alternative", out)
+            run.assert_not_called()
+        self.assertEqual(list(self.root.iterdir()), [])
+
+    def test_custom_configuration_is_guided_without_writes(self):
+        with mock.patch.object(m.Path, "home", return_value=self.root), mock.patch.dict(os.environ, {"CODEX_HOME": "custom"}):
+            code, out, err = self.cli("install", "--user", "--agent", "codex", "--apply")
+        self.assertEqual(code, 2)
+        self.assertIn("custom configuration", out)
+        self.assertEqual(list(self.root.iterdir()), [])
+
+    def test_guided_native_dependency_is_not_installed(self):
+        with mock.patch.object(m.Path, "home", return_value=self.root), mock.patch.object(m.shutil, "which", return_value=None), mock.patch("subprocess.run") as run:
+            code, out, err = self.cli("install", "--user", "--agent", "qwen", "--apply")
+            run.assert_not_called()
+        self.assertEqual(code, 2)
+        self.assertIn("Dependency missing: qwen", out)
+        self.assertEqual(list(self.root.iterdir()), [])
+
+    def test_existing_documented_snippet_is_detected(self):
+        (self.root / "AGENTS.md").write_text("## Output style\nThe reader has ADHD. Shape every response.")
+        with self.assertRaisesRegex(m.Conflict, "unmanaged"):
+            self.apply(mode="always-on")
+        self.assertIn("unmanaged", m.status(self.root, "project", self.state, "codex"))
+
+    def test_lock_blocks_competing_run_without_removing_it(self):
+        (self.root / m.STATE).mkdir()
+        lock = self.root / m.STATE / "lock"
+        lock.write_text("other run")
+        code, out, err = self.cli("install", "--project", str(self.root), "--agent", "codex", "--apply")
+        self.assertEqual(code, 1)
+        self.assertTrue(lock.exists())
+
+    def test_scope_required(self):
+        with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            m.main(["install", "--agent", "codex"])
+
+    def test_user_scope_isolated(self):
+        with mock.patch.object(m.Path, "home", return_value=self.root):
+            code, out, err = self.cli("install", "--user", "--agent", "codex", "--mode", "always-on", "--apply")
+        self.assertEqual((code, err), (0, ""))
+        self.assertTrue((self.root / ".codex/AGENTS.md").exists())
+        self.assertFalse((self.root / "AGENTS.md").exists())
+
+    def test_gemini_prompt_uses_canonical_body(self):
+        import tomllib
+        rendered = m.desired("gemini", "user", "on-demand")[".gemini/commands/i-have-adhd.toml"][1]
+        self.assertEqual(tomllib.loads(rendered.decode())["prompt"], m.body() + "\n{{args}}\n")
+
+    def test_unicode_directory_subprocess(self):
+        root = self.root / "a\u00e7\u00e3o"
+        root.mkdir()
+        result = subprocess.run([sys.executable, str(ROOT / "scripts/manage_install.py"), "install",
+                                 "--agent", "codex", "--project", str(root), "--apply"],
+                                capture_output=True, text=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue((root / "AGENTS.md").exists() or (root / ".agents/skills/i-have-adhd/SKILL.md").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Refs #193.

Add a preview-first Python installation manager for the agents documented in INSTALL.md. Users can select multiple agents and an explicit project/user scope, choose on-demand or always-on, update from a reviewed checkout, remove owned content, inspect status, or export portable Markdown.

Previously each integration required its own installation and maintenance steps. Supported filesystem routes now share a single interface and ownership manifest; native/UI routes remain guided. This does **not** automate native package managers. Existing plugins, hooks, rules and installation methods are unchanged.

## Authorship and provenance — select exactly one

- [ ] Human-authored
- [x] Autonomous agent-authored
- [ ] Hybrid

Agent/tool and model/version: Codex, GPT-6; local validation used codex-cli 0.153.4.
Agent contribution: repository investigation, implementation, tests, documentation, self-review and isolated discovery smoke.
Human verification: requirements and scope selected by the human; complete diff review is pending. No independent human verification is claimed.

## Labels

Target: Target:Integrations
Author: Author:AI
Workflow: enhancement

## Safety and compatibility

Mutations require --apply and an explicit scope. File/block hashes protect manual edits, shared resources retain owners, and ordinary write failures roll back the current agent. Previous successful agents remain recorded. Previews perform no destination writes. Tests use temporary directories.

No new dependencies, network requests, native CLI mutation, hooks, background services or paid model calls. Known custom configuration overrides fall back to guidance. Native/UI installations cannot be fully detected or adopted. Abrupt termination and concurrent edits require the documented manual recovery procedure.

Non-breaking and additive. Canonical skill and mirrors are unchanged. Undo is uninstall using the same agents/scope; edited resources require reconciliation first. Empty directories and manifest may remain.

## Verification

- Windows, Python 3.12.10: python -m unittest tests.test_manage_install -v — 35 tests, 34 passed, one skipped because Windows could not create a symlink.
- python -m unittest discover -s tests -v — 86 tests, four errors and one skip. The same four errors reproduce in the original commit 6f1f982d0a47c65899af3c5a7450b7098bc65325 (51 tests, four errors).
- The existing failures are three EndToEndTest cases in test_judge and test_generation_runs_outside_the_repository in test_run_evals; all raise FileNotFoundError/WinError 2 launching their stub runners on this host.
- python scripts/run_evals.py validate — passed. Test cost output comes from fixtures; no provider evaluation was run.
- git diff --check — passed.
- Real Codex app-server, isolated configuration/project: skills/list found i-have-adhd after installation and no longer found it after uninstall and forceReload. No model turn was requested.

Linux and macOS execution remains pending. The added workflow covers both plus Windows on Python 3.11 and 3.13. Other agent runtimes were not exercised; file roundtrip tests are not evidence of runtime behavior. The new manager tests every automatic adapter/mode/scope with temporary roots.

## Contribution status

Proposal: #193. This draft is an implementation for discussion; maintainer feedback is pending. PR #139 concerns runtime delivery/activation and is not modified here. Searches of open/closed installation proposals found no directly matching unified-manager implementation; issue #2 describes the earlier installer being removed in favor of marketplace installation. Maintainer agreement is still needed.

- [ ] The submitting human reviewed the complete diff and accepts responsibility.
- [x] Failed, skipped and unrun checks are disclosed.

