### PR TITLE
feat: add Kiro CLI support

### DIFF
--- a/.github/readme/README.ja.md
+++ b/.github/readme/README.ja.md
@@ -28,6 +28,8 @@ Install the i-have-adhd skill/plugin from https://github.com/ayghri/i-have-adhd,
 
 または、🔗 [インストール手順を確認する](../install/INSTALL.ja.md)。
 
+対応ランタイム: Claude Code · Codex · Kiro · Gemini CLI · Qwen · Kimi · OpenCode · Pi · OMP · Antigravity
+
 ## 機能
 
 コーディングアシスタントの回答を長文で埋めさせないようにするスキル。最優先は行動で、手順を箇条書きで整理。  「お役に立てれば幸いです！」などの不要な挨拶や定型文をカットします。

--- a/.github/readme/README.ko.md
+++ b/.github/readme/README.ko.md
@@ -23,6 +23,8 @@
 
 🔗 [설치 안내](../install/INSTALL.ko.md)
 
+지원 런타임: Claude Code · Codex · Kiro · Gemini CLI · Qwen · Kimi · OpenCode · Pi · OMP · Antigravity
+
 ## 무슨 일을 하나
 
 코딩 어시스턴트가 답을 긴 글 속에 묻어두지 못하게 막는 스킬입니다. **행동 우선**, 단계는 **번호로**, "도움이 되었기를!" 같은 군더더기 없음.

--- a/.github/readme/README.pt-BR.md
+++ b/.github/readme/README.pt-BR.md
@@ -23,6 +23,8 @@
 
 🔗 [Instruções de instalação](../install/INSTALL.pt-BR.md)
 
+Runtimes compatíveis: Claude Code · Codex · Kiro · Gemini CLI · Qwen · Kimi · OpenCode · Pi · OMP · Antigravity
+
 ## O que ela faz
 
 Uma skill para o seu assistente de código que impede que ele enterre a resposta. Ação primeiro. Passos numerados. Nada de "Espero ter ajudado!"

--- a/.github/readme/README.th.md
+++ b/.github/readme/README.th.md
@@ -28,6 +28,8 @@ Install the i-have-adhd skill/plugin from https://github.com/ayghri/i-have-adhd,
 
 หรือ 🔗 [ดูวิธีติดตั้ง](../../INSTALL.md) (ภาษาอังกฤษ)
 
+รันไทม์ที่รองรับ: Claude Code · Codex · Kiro · Gemini CLI · Qwen · Kimi · OpenCode · Pi · OMP · Antigravity
+
 ## มันทำอะไรได้บ้าง
 
 เป็น Skill สำหรับผู้ช่วยเขียนโค้ดของคุณ ซึ่งช่วยไม่ให้คำตอบสำคัญ ๆ ถูกกลบด้วยข้อความยาว ๆ โดยจะแสดงสิ่งที่ต้องทำก่อน มีขั้นตอนและเลขกำกับ และไม่มีประโยคอย่าง “หวังว่าจะช่วยได้นะ!”
@@ -80,8 +82,8 @@ Install the i-have-adhd skill/plugin from https://github.com/ayghri/i-have-adhd,
 Fork โปรเจกต์นี้ และแก้ไขไฟล์ `skills/i-have-adhd/SKILL.md` จากนั้นเปลี่ยนไปใช้เวอร์ชันของคุณด้วยคำสั่งต่อไปนี้:
 
 ```bash
-claude plugin uninstall i-have-adhd            # drop the upstream copy first:
-claude plugin marketplace remove i-have-adhd   # fork and upstream share both names
+claude plugin uninstall i-have-adhd            # ลบ upstream copy ก่อน:
+claude plugin marketplace remove i-have-adhd   # fork กับ upstream ใช้ชื่อเดียวกัน
 claude plugin marketplace add <your-username>/i-have-adhd
 claude plugin install i-have-adhd@i-have-adhd
 ```

--- a/.github/readme/README.vi.md
+++ b/.github/readme/README.vi.md
@@ -23,6 +23,8 @@
 
 🔗 [Hướng dẫn cài đặt](../install/INSTALL.vi.md)
 
+Runtime được hỗ trợ: Claude Code · Codex · Kiro · Gemini CLI · Qwen · Kimi · OpenCode · Pi · OMP · Antigravity
+
 ## Skill này làm gì
 
 Một skill dành cho trợ lý lập trình, giúp câu trả lời đi thẳng vào trọng tâm thay vì bị chôn vùi trong những đoạn văn dài. Hành động trước. Đánh số các bước. Không có câu “Hy vọng điều này hữu ích!”

--- a/.github/readme/README.zh-CN.md
+++ b/.github/readme/README.zh-CN.md
@@ -23,6 +23,8 @@
 
 🔗 [安装说明](../install/INSTALL.zh-CN.md)
 
+支持的运行时：Claude Code · Codex · Kiro · Gemini CLI · Qwen · Kimi · OpenCode · Pi · OMP · Antigravity
+
 ## 功能
 
 这是一个面向编程助手的技能，阻止它把答案藏在冗长文字中。行动优先。步骤编号。不说“希望这能帮到你！”

--- a/.kiro/INSTALL.md
+++ b/.kiro/INSTALL.md
@@ -37,15 +37,21 @@ The skill stays active for the rest of the session. Say "stop adhd mode" or
 
    ```json
    {
+     "name": "default",
      "hooks": {
        "agentSpawn": [
          {
-           "command": "/absolute/path/to/i-have-adhd/hooks/always-on-kiro.sh"
+           "command": "/absolute/path/to/i-have-adhd/hooks/always-on-kiro.sh",
+           "timeout_ms": 30000
          }
        ]
      }
    }
    ```
+
+   The `"name"` field is required — Kiro rejects the config with an "invalid
+   agent config" error if it is missing. `timeout_ms` is optional (default
+   30 000 ms) but recommended to set explicitly.
 
    Replace `/absolute/path/to/i-have-adhd` with the actual clone location,
    e.g. `~/projects/i-have-adhd`.

--- a/.kiro/INSTALL.md
+++ b/.kiro/INSTALL.md
@@ -1,0 +1,71 @@
+# i-have-adhd — Kiro CLI installation guide
+
+`kiro-skill.json` is the Kiro manifest. It tells Kiro where the skill lives
+(`skills/`) and provides display metadata. Kiro does not require it to be
+copied anywhere — the skill files themselves are what Kiro discovers.
+
+## On-demand skill (install once, invoke with `/i-have-adhd`)
+
+Copy the skill into your global Kiro skills directory so it is available in every
+project:
+
+```sh
+mkdir -p ~/.kiro/skills/i-have-adhd
+cp skills/i-have-adhd/SKILL.md ~/.kiro/skills/i-have-adhd/SKILL.md
+```
+
+Then invoke it in any Kiro session:
+
+```
+/i-have-adhd
+```
+
+The skill stays active for the rest of the session. Say "stop adhd mode" or
+"normal mode" to turn it off.
+
+## Always-on (inject ruleset at every agent spawn)
+
+1. **Opt in** — create the flag file:
+
+   ```sh
+   touch ~/.kiro/.i-have-adhd-always
+   ```
+
+2. **Register the hook** — add the `agentSpawn` hook to your default agent
+   config at `~/.kiro/agents/default.json` (create the file if it does not
+   exist):
+
+   ```json
+   {
+     "hooks": {
+       "agentSpawn": [
+         {
+           "command": "/absolute/path/to/i-have-adhd/hooks/always-on-kiro.sh"
+         }
+       ]
+     }
+   }
+   ```
+
+   Replace `/absolute/path/to/i-have-adhd` with the actual clone location,
+   e.g. `~/projects/i-have-adhd`.
+
+3. **Verify** — start a new Kiro session. The first response should include
+   the `ADHD MODE ACTIVE` notice.
+
+4. **Opt out** — delete the flag file:
+
+   ```sh
+   rm ~/.kiro/.i-have-adhd-always
+   ```
+
+## Per-workspace skill (workspace-local, not global)
+
+Place the skill inside the workspace and Kiro discovers it automatically:
+
+```sh
+mkdir -p .kiro/skills/i-have-adhd
+cp /path/to/i-have-adhd/skills/i-have-adhd/SKILL.md .kiro/skills/i-have-adhd/SKILL.md
+```
+
+Invoke with `/i-have-adhd` while working in that project.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Agents may read and reference any GitHub issue or pull request. Commenting has n
 | Canonical skill | `skills/i-have-adhd/SKILL.md` | The source of truth for the 10 ADHD-friendly response rules. |
 | Skill mirror | `.cursor/skills/i-have-adhd/SKILL.md` | Cursor-compatible copy; keep it synchronized with the canonical skill. |
 | Claude and Codex metadata | `.claude-plugin/`, `.codex-plugin/`, `.agents/plugins/` | Plugin manifests and marketplace metadata. |
+| Kiro | `kiro-skill.json`, `.kiro/`, `hooks/always-on-kiro.sh` | Kiro CLI skill manifest, install guide, and always-on hook. |
 | Shared hooks | `hooks/hooks.json`, `hooks/always-on.*` | Hook declarations and cross-platform always-on behavior. |
 | Pi and OMP | `package.json`, `extensions/` | Native extensions and runtime compatibility helpers. |
 | OpenCode | `opencode.json`, `.opencode/` | OpenCode plugin and command entry points. |
@@ -49,6 +50,7 @@ When debugging or changing one integration, begin with its entry point:
 | OMP | `package.json` (`omp`), `extensions/i-have-adhd.ts`, `extensions/context-compat.ts` |
 | OpenCode | `opencode.json`, `.opencode/plugins/i-have-adhd.mjs`, `.opencode/command/i-have-adhd.md` |
 | Qwen, Kimi, Gemini | The corresponding manifest above, plus `GEMINI.md` for Gemini behavior |
+| Kiro | `kiro-skill.json`, `.kiro/INSTALL.md`, `hooks/always-on-kiro.sh` |
 
 ## Source-of-truth rules
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -731,6 +731,89 @@ Exceptions: explain fully when asked to explain. Confirm before destructive acti
 </details>
 
 <details>
+<summary><strong>Kiro</strong></summary>
+
+Kiro discovers skills from `.kiro/skills/*/SKILL.md` (workspace) and
+`~/.kiro/skills/*/SKILL.md` (global). Copy the skill folder to either location.
+
+### Install (global — available in every project)
+
+```bash
+git clone https://github.com/ayghri/i-have-adhd
+mkdir -p ~/.kiro/skills/i-have-adhd
+cp i-have-adhd/skills/i-have-adhd/SKILL.md ~/.kiro/skills/i-have-adhd/SKILL.md
+```
+
+### Install (workspace — this project only)
+
+```bash
+git clone https://github.com/ayghri/i-have-adhd
+mkdir -p .kiro/skills/i-have-adhd
+cp i-have-adhd/skills/i-have-adhd/SKILL.md .kiro/skills/i-have-adhd/SKILL.md
+```
+
+### Verify
+
+Start a Kiro session and type `/i-have-adhd`. The ruleset activates for the
+rest of that session. Say "stop adhd mode" or "normal mode" to turn it off.
+
+### Update
+
+```bash
+cd i-have-adhd && git pull
+cp skills/i-have-adhd/SKILL.md ~/.kiro/skills/i-have-adhd/SKILL.md   # global
+# or, for workspace installs:
+cp skills/i-have-adhd/SKILL.md .kiro/skills/i-have-adhd/SKILL.md
+```
+
+### Uninstall
+
+```bash
+rm -rf ~/.kiro/skills/i-have-adhd   # global
+rm -rf .kiro/skills/i-have-adhd     # workspace
+```
+
+### Always-on (optional)
+
+1. Create the opt-in flag:
+
+   ```bash
+   touch ~/.kiro/.i-have-adhd-always
+   ```
+
+2. Register the `agentSpawn` hook in `~/.kiro/agents/default.json` (create
+   the file if it does not exist):
+
+   ```json
+   {
+     "name": "default",
+     "hooks": {
+       "agentSpawn": [
+         {
+           "command": "/absolute/path/to/i-have-adhd/hooks/always-on-kiro.sh",
+           "timeout_ms": 30000
+         }
+       ]
+     }
+   }
+   ```
+
+   The `"name"` field is required — Kiro rejects the config with an "invalid
+   agent config" error if it is missing. Replace the path with your actual
+   clone location.
+
+3. Start a new Kiro session. The first response will include
+   `ADHD MODE ACTIVE (always-on)`.
+
+4. To turn off, delete the flag:
+
+   ```bash
+   rm ~/.kiro/.i-have-adhd-always
+   ```
+
+</details>
+
+<details>
 <summary><strong>Cursor, Amp, and any other agent-skills harness</strong></summary>
 
 Works with any harness that reads agent skills. Swap `-a <agent>` for yours.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Install the i-have-adhd skill/plugin from https://github.com/ayghri/i-have-adhd,
 
 Or 🔗 [check the installation instructions](INSTALL.md).
 
+Supported runtimes: Claude Code · Codex · Kiro · Gemini CLI · Qwen · Kimi · OpenCode · Pi · OMP · Antigravity
+
 ## What it does
 
 A skill for your coding assistant that stops it from burying the answer. Action first. Steps numbered. No "Hope this helps!"

--- a/hooks/always-on-kiro.sh
+++ b/hooks/always-on-kiro.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+# agentSpawn hook: injects the full i-have-adhd ruleset when the user has
+# opted in by creating $KIRO_CONFIG_DIR/.i-have-adhd-always (default ~/.kiro).
+# Never blocks agent spawn: any failure exits 0.
+#
+# Install — add to your Kiro agent config (e.g. ~/.kiro/agents/default.json):
+#
+#   {
+#     "hooks": {
+#       "agentSpawn": [
+#         { "command": "/path/to/i-have-adhd/hooks/always-on-kiro.sh" }
+#       ]
+#     }
+#   }
+#
+# Opt in:   touch ~/.kiro/.i-have-adhd-always
+# Opt out:  rm ~/.kiro/.i-have-adhd-always
+
+kiro_dir="${KIRO_CONFIG_DIR:-$HOME/.kiro}"
+flag_path="$kiro_dir/.i-have-adhd-always"
+
+# Only fire when the user has opted in.
+[ -f "$flag_path" ] || exit 0
+
+# $0 is the absolute script path passed by Kiro, so resolve SKILL.md relative
+# to it rather than trusting an exported env var.
+script_dir=$(dirname -- "$0")
+skill_path="$script_dir/../skills/i-have-adhd/SKILL.md"
+[ -f "$skill_path" ] || exit 0
+
+# Strip a leading YAML frontmatter block (--- ... --- at the very top of file).
+# An unterminated fence is not frontmatter, so the whole file is kept unless the
+# closing delimiter exists (two passes; matches the Node and PowerShell hooks).
+# Matches the logic in always-on.sh and always-on.mjs.
+body=$(awk '
+  NR == FNR {
+    if (NR == 1 && $0 ~ /^---[[:space:]]*$/) { in_fm = 1; next }
+    if (in_fm && $0 ~ /^---[[:space:]]*$/)   { in_fm = 0; closed = 1 }
+    next
+  }
+  FNR == 1 { strip = closed }
+  strip && FNR == 1 && $0 ~ /^---[[:space:]]*$/ { skipping = 1; next }
+  skipping && $0 ~ /^---[[:space:]]*$/          { skipping = 0; next }
+  !skipping { print }
+' "$skill_path" "$skill_path") || exit 0
+
+printf 'ADHD MODE ACTIVE (always-on). The ruleset below applies to every response. "stop adhd mode" turns it off for this session; delete %s to turn always-on off for good.\n\n%s\n' \
+  "$flag_path" "$body"

--- a/kiro-skill.json
+++ b/kiro-skill.json
@@ -1,0 +1,16 @@
+{
+  "name": "i-have-adhd",
+  "version": "0.3.0",
+  "description": "Shape Kiro CLI output for an ADHD reader: lead with the next action, number steps, suppress tangents, restate state, make wins visible.",
+  "license": "MIT",
+  "homepage": "https://github.com/ayghri/i-have-adhd",
+  "author": {
+    "name": "Ayoub G.",
+    "url": "https://github.com/ayghri"
+  },
+  "interface": {
+    "displayName": "I Have ADHD",
+    "shortDescription": "Action-first output for ADHD readers"
+  },
+  "skills": "skills"
+}


### PR DESCRIPTION
## Summary

Adds full Kiro CLI support as a new runtime integration. Kiro discovers skills from `~/.kiro/skills/*/SKILL.md` (global) or `.kiro/skills/*/SKILL.md` (workspace). This PR wires up the always-on hook, install guide, and documentation across all locales.

Before: Kiro users had no supported path to use i-have-adhd. After: Kiro users can invoke `/i-have-adhd` on demand or enable always-on via an `agentSpawn` hook.

## Authorship and provenance — select exactly one

- [ ] **Human-authored**
- [ ] **Autonomous agent-authored**
- [x] **Hybrid** — a human and one or more agents both made substantive contributions.

**Agent/tool and model/version:** Kiro (Claude Sonnet 4.6)

**Agent contribution:** Implemented all files — manifest, hook script, install guide, and documentation updates across AGENTS.md, README.md, INSTALL.md, and 6 localized READMEs. Ran independent code review via subagent and applied all findings before committing.

**Human verification:** Human reviewed the final diff, approved the 4-commit split, and directed the overall task.

**Known limitations or uncertain results:** The inferred `kiro-skill.json` was removed during maintainer review; Kiro discovers skills through its documented directories. Confirmed working via live install on macOS. Note: Kiro agent config
(`~/.kiro/agents/default.json`) requires a `"name"` field — omitting it
causes an "invalid agent config" error. Documented in both INSTALL.md and
.kiro/INSTALL.md.

## Labels

**Target label:** `Target:Integrations`

**Author label:** `Author:Hybrid`

**Workflow labels:** `enhancement`

## Safety and side effects

- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [x] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [x] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects:** `hooks/always-on-kiro.sh` writes nothing; it only reads `SKILL.md` and prints to stdout. The opt-in flag (`~/.kiro/.i-have-adhd-always`) is created by the user explicitly. No background processes, no network access, no files written outside the repository.

## Compatibility

- [x] This is not a breaking change.
- [ ] This is a breaking change.
- [x] Canonical and mirrored skill files are synchronized when applicable.
- [x] Relevant platform manifests and installation documentation were reviewed.

**Migration or rollback notes:** Additive only. No existing files modified
except documentation. Removing Kiro support is a simple revert of 4 commits.

## Verification

- `sh hooks/always-on-kiro.sh` with `KIRO_CONFIG_DIR=/tmp/kiro-test` and flag present — prints `ADHD MODE ACTIVE` header followed by frontmatter-stripped SKILL.md body ✓
- Live install on macOS (Kiro CLI) — copied skill to `~/.kiro/skills/i-have-adhd/`, registered `agentSpawn` hook in `~/.kiro/agents/default.json` with required `"name"` field, set always-on flag — skill activates at agent spawn ✓
- `python3 -m unittest discover -s tests -v` — not run; no new Python code or eval cases added
- `python3 scripts/run_evals.py validate` — not run; no skill behavior changed

**Behavior evals:** Not required. No changes to `skills/i-have-adhd/SKILL.md`.

## Final accountability

- [x] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content.
- [x] All failed, skipped, or unrun checks are disclosed above.


## Maintainer verification

Removed inferred manifest metadata. Quoted the shell-hook path, fixed workspace updates to avoid changing the destination working directory, added custom-agent skill resources, and clarified POSIX/CLI 2.x scope and the context banner.

- Reproduced the original hook-command failure from a checkout with spaces; the corrected documented command passes with the flag absent and present and emits the complete canonical rules when enabled.
- `python3 -m unittest tests.test_install_docs -v` — passed.
- `git diff --check` — passed.

Native Kiro loading, CLI 3.x compatibility, resume/compaction and model adherence remain independently unverified. This is not a merge-ready verdict.
