### PR TITLE
docs: add Indonesian README translation

### DIFF
--- a/.github/readme/README.id.md
+++ b/.github/readme/README.id.md
@@ -1,0 +1,104 @@
+<p align="center">
+  <img src="../../logo.png" alt="i-have-adhd" width="140" />
+</p>
+<p align="center">
+  <strong align="center">Output yang ramah ADHD. Tanpa perlu diagnosis ADHD!</strong>
+</p>
+<p align="center">
+  <a href="../../LICENSE"><img src="https://img.shields.io/github/license/ayghri/i-have-adhd?style=flat" alt="Lisensi"></a>
+</p>
+
+<p align="center">
+  <a href="../../README.md" title="English" aria-label="English">🇬🇧</a> ·
+  <a href="README.zh-CN.md" title="简体中文" aria-label="简体中文">🇨🇳</a> ·
+  <a href="README.pt-BR.md" title="Português (Brasil)" aria-label="Português (Brasil)">🇧🇷</a> ·
+  <a href="README.ja.md" title="日本語" aria-label="日本語">🇯🇵</a> ·
+  <a href="README.vi.md" title="Tiếng Việt" aria-label="Tiếng Việt">🇻🇳</a> ·
+  <a href="README.ko.md" title="한국어" aria-label="한국어">🇰🇷</a> ·
+  <a href="README.th.md" title="ภาษาไทย" aria-label="ภาษาไทย">🇹🇭</a> ·
+  <strong title="Bahasa Indonesia" aria-label="Bahasa Indonesia">🇮🇩</strong>
+</p>
+
+
+## Instalasi
+
+Salin/tempel ke prompt CLI Anda:
+
+```text
+Install the i-have-adhd skill/plugin from https://github.com/ayghri/i-have-adhd, refer to the repo's AGENTS.md for instructions.
+```
+
+Atau 🔗 [lihat panduan instalasi](../../INSTALL.md) (bahasa Inggris)
+
+## Apa yang dilakukannya
+
+Sebuah skill untuk asisten coding Anda yang mencegahnya mengubur jawaban. Aksi dulu. Langkah diberi nomor. Tanpa "Semoga membantu!"
+
+
+## Apa yang berubah
+
+
+<table>
+<tr>
+<td width="50%">
+
+## Sebelum
+
+> Pertanyaan bagus! Coba saya pikirkan dulu. Alur autentikasi Anda punya beberapa bagian yang saling terkait: middleware, verifikasi token, dan penanganan cookie. Melihat `src/auth.ts`, fungsi `verifyToken` (sekitar baris 42-58) sepertinya masih memakai API `jsonwebtoken` versi lama. Salah satu pendekatannya adalah memperbarui paket tersebut dan menulis ulang fungsi itu. Setelah melakukan perubahan, Anda sebaiknya menjalankan tes autentikasi untuk memastikan tidak ada yang rusak. Oh ya, mungkin Anda juga ingin meninjau versi dependensi Anda secara keseluruhan. Semoga membantu! Beri tahu saya kalau mau membahasnya lebih dalam.
+
+</td>
+
+<td width="50%">
+
+## Sesudah
+
+> Jalankan `npm install jsonwebtoken@latest`, lalu edit `src/auth.ts:42`.
+>
+> 1. Buka `src/auth.ts`
+> 2. Ganti `verifyToken` (baris 42–58) dengan potongan kode di bawah
+> 3. Jalankan `npm test -- auth.spec.ts`
+>
+> Berikutnya: tempelkan baris kegagalan pertama jika ada tes yang gagal.
+
+</td>
+</tr>
+</table>
+
+
+## Aturannya
+
+10 aturan. Teks lengkapnya ada di [SKILL.md](../../skills/i-have-adhd/SKILL.md).
+
+1. Mulai dengan aksi berikutnya.
+2. Beri nomor untuk tugas multi-langkah.
+3. Akhiri dengan satu langkah berikutnya yang konkret.
+4. Singkirkan bahasan yang menyimpang.
+5. Nyatakan ulang status di setiap giliran.
+6. Estimasi waktu yang spesifik (dalam menit, bukan "sebentar").
+7. Tampilkan hasil yang sudah dicapai.
+8. Laporkan error secara lugas.
+9. Batasi daftar maksimal 5 item.
+10. Tanpa pembuka. Tanpa rekap. Tanpa basa-basi penutup.
+
+## Sesuaikan
+
+Fork, edit `skills/i-have-adhd/SKILL.md`, lalu pasang salinan Anda:
+
+```bash
+claude plugin uninstall i-have-adhd            # drop the upstream copy first:
+claude plugin marketplace remove i-have-adhd   # fork and upstream share both names
+claude plugin marketplace add <your-username>/i-have-adhd
+claude plugin install i-have-adhd@i-have-adhd
+```
+
+Mulai ulang Claude Code, lalu panggil `/i-have-adhd` lagi.
+
+## Kredit
+
+Terinspirasi secara bebas dari *The Adult ADHD Tool Kit* karya J. Russell Ramsay dan Anthony L. Rostain. Diadaptasi untuk cara sebuah LLM sebaiknya merespons, bukan cara manusia sebaiknya mengatur harinya.
+
+## Lisensi
+
+MIT.
+
+Beri ⭐ kalau ini menghemat satu kali scroll melewati satu "Pertanyaan bagus!"

--- a/.github/readme/README.ja.md
+++ b/.github/readme/README.ja.md
@@ -15,7 +15,8 @@
   <strong title="日本語" aria-label="日本語">🇯🇵</strong> ·
   <a href="README.vi.md" title="Tiếng Việt" aria-label="Tiếng Việt">🇻🇳</a> ·
   <a href="README.ko.md" title="한국어" aria-label="한국어">🇰🇷</a> ·
-  <a href="README.th.md" title="ภาษาไทย" aria-label="ภาษาไทย">🇹🇭</a>
+  <a href="README.th.md" title="ภาษาไทย" aria-label="ภาษาไทย">🇹🇭</a> ·
+  <a href="README.id.md" title="Bahasa Indonesia" aria-label="Bahasa Indonesia">🇮🇩</a>
 </p>
 
 ## インストール

--- a/.github/readme/README.ko.md
+++ b/.github/readme/README.ko.md
@@ -15,7 +15,8 @@
   <a href="README.ja.md" title="日本語" aria-label="日本語">🇯🇵</a> ·
   <a href="README.vi.md" title="Tiếng Việt" aria-label="Tiếng Việt">🇻🇳</a> ·
   <strong title="한국어" aria-label="한국어">🇰🇷</strong> ·
-  <a href="README.th.md" title="ภาษาไทย" aria-label="ภาษาไทย">🇹🇭</a>
+  <a href="README.th.md" title="ภาษาไทย" aria-label="ภาษาไทย">🇹🇭</a> ·
+  <a href="README.id.md" title="Bahasa Indonesia" aria-label="Bahasa Indonesia">🇮🇩</a>
 </p>
 
 

--- a/.github/readme/README.pt-BR.md
+++ b/.github/readme/README.pt-BR.md
@@ -15,7 +15,8 @@
   <a href="README.ja.md" title="日本語" aria-label="日本語">🇯🇵</a> ·
   <a href="README.vi.md" title="Tiếng Việt" aria-label="Tiếng Việt">🇻🇳</a> ·
   <a href="README.ko.md" title="한국어" aria-label="한국어">🇰🇷</a> ·
-  <a href="README.th.md" title="ภาษาไทย" aria-label="ภาษาไทย">🇹🇭</a>
+  <a href="README.th.md" title="ภาษาไทย" aria-label="ภาษาไทย">🇹🇭</a> ·
+  <a href="README.id.md" title="Bahasa Indonesia" aria-label="Bahasa Indonesia">🇮🇩</a>
 </p>
 
 

--- a/.github/readme/README.th.md
+++ b/.github/readme/README.th.md
@@ -15,7 +15,8 @@
   <a href="README.ja.md" title="日本語" aria-label="日本語">🇯🇵</a> ·
   <a href="README.vi.md" title="Tiếng Việt" aria-label="Tiếng Việt">🇻🇳</a> ·
   <a href="README.ko.md" title="한국어" aria-label="한국어">🇰🇷</a> ·
-  <strong title="ภาษาไทย" aria-label="ภาษาไทย">🇹🇭</strong>
+  <strong title="ภาษาไทย" aria-label="ภาษาไทย">🇹🇭</strong> ·
+  <a href="README.id.md" title="Bahasa Indonesia" aria-label="Bahasa Indonesia">🇮🇩</a>
 </p>
 
 ## การติดตั้ง

--- a/.github/readme/README.vi.md
+++ b/.github/readme/README.vi.md
@@ -15,7 +15,8 @@
   <a href="README.ja.md" title="日本語" aria-label="日本語">🇯🇵</a> ·
   <strong title="Tiếng Việt" aria-label="Tiếng Việt">🇻🇳</strong> ·
   <a href="README.ko.md" title="한국어" aria-label="한국어">🇰🇷</a> ·
-  <a href="README.th.md" title="ภาษาไทย" aria-label="ภาษาไทย">🇹🇭</a>
+  <a href="README.th.md" title="ภาษาไทย" aria-label="ภาษาไทย">🇹🇭</a> ·
+  <a href="README.id.md" title="Bahasa Indonesia" aria-label="Bahasa Indonesia">🇮🇩</a>
 </p>
 
 

--- a/.github/readme/README.zh-CN.md
+++ b/.github/readme/README.zh-CN.md
@@ -15,7 +15,8 @@
   <a href="README.ja.md" title="日本語" aria-label="日本語">🇯🇵</a> ·
   <a href="README.vi.md" title="Tiếng Việt" aria-label="Tiếng Việt">🇻🇳</a> ·
   <a href="README.ko.md" title="한국어" aria-label="한국어">🇰🇷</a> ·
-  <a href="README.th.md" title="ภาษาไทย" aria-label="ภาษาไทย">🇹🇭</a>
+  <a href="README.th.md" title="ภาษาไทย" aria-label="ภาษาไทย">🇹🇭</a> ·
+  <a href="README.id.md" title="Bahasa Indonesia" aria-label="Bahasa Indonesia">🇮🇩</a>
 </p>
 
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
   <a href=".github/readme/README.ja.md" title="日本語" aria-label="日本語">🇯🇵</a> ·
   <a href=".github/readme/README.vi.md" title="Tiếng Việt" aria-label="Tiếng Việt">🇻🇳</a> ·
   <a href=".github/readme/README.ko.md" title="한국어" aria-label="한국어">🇰🇷</a> ·
-  <a href=".github/readme/README.th.md" title="ภาษาไทย" aria-label="ภาษาไทย">🇹🇭</a>
+  <a href=".github/readme/README.th.md" title="ภาษาไทย" aria-label="ภาษาไทย">🇹🇭</a> ·
+  <a href=".github/readme/README.id.md" title="Bahasa Indonesia" aria-label="Bahasa Indonesia">🇮🇩</a>
 </p>
 
 


### PR DESCRIPTION
## Summary

Adds Bahasa Indonesia to the README localization set, following the existing Tier 1 pattern.

**New:** `.github/readme/README.id.md` — full Indonesian translation of `README.md`.

**Updated:** the language navigation row in the 7 existing READMEs (`README.md` and the 6 in `.github/readme/`), so every file lists all 8 languages in the same order. Indonesian is `<strong>` in `README.id.md` and a link everywhere else. `+2/-1` lines per file, no other content touched.

Observable behavior before: the nav row showed 7 languages and there was no Indonesian README. After: 8 languages, and `README.id.md` renders with the same structure as the English original (identical HTML tag counts and blank-line layout, so the before/after comparison table renders the same way).

Following the precedent set by `README.th.md`, this is README-only. There is no `INSTALL.id.md`, so the install link points at `../../INSTALL.md` and is marked `(bahasa Inggris)`.

### Translation decisions

Kept verbatim in English, because they are copy-paste payloads rather than prose:

- both fenced blocks — the install prompt and the four `claude plugin …` commands, bash comments included (byte-identical to `README.md`, verified with `diff`)
- `/i-have-adhd`, `npm install jsonwebtoken@latest`, `src/auth.ts:42`, `npm test -- auth.spec.ts`, `verifyToken`, `jsonwebtoken`, `skills/i-have-adhd/SKILL.md`, `AGENTS.md`, `MIT`
- the book title *The Adult ADHD Tool Kit* and both author names

Translated: the tagline, the before/after example prose, the 10 rule summaries, section headings, and the license badge alt text. The tagline keeps the "no diagnosis needed" framing — "Output yang ramah ADHD. Tanpa perlu diagnosis ADHD!" — so the README makes no medical claim.

## Authorship and provenance — select exactly one

- [ ] **Human-authored** — substantive implementation and text were produced by a human.
- [x] **Autonomous agent-authored** — an agent planned and produced most of the substantive change.
- [ ] **Hybrid** — a human and one or more agents both made substantive contributions.

**Agent/tool and model/version:** Claude Code 2.1.270, model Opus 5 (`claude-opus-5`).

**Agent contribution:** Surveyed the repository for existing Indonesian support (none found), proposed the Tier 1 scope, wrote the Indonesian translation, edited the 7 navigation rows, and ran the verification commands below.

**Human verification:** The submitting human set the scope and constraints (README-only, the exact file list, the rule that technical literals stay in English, no runtime or skill changes) and reviewed the change in the session. The human has not independently re-run the verification commands at the time of submission; the outputs below were produced by the agent and are reproduced verbatim.

**Known limitations or uncertain results:** The Indonesian text has not been reviewed by a second native speaker — a review pass from an Indonesian-speaking maintainer or contributor is welcome, particularly on the tagline and the "Apa yang dilakukannya" paragraph. The test suite has 5 pre-existing failures, detailed under Verification.

## Labels

**Target label:** `Target:Docs`

**Author label:** `Author:AI`

**Workflow labels:** `enhancement`

## Safety and side effects

- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [x] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [x] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects, permissions, network access, and cost:** None. Documentation only — no scripts, hooks, workflows, manifests, or eval code are touched, and no provider calls were made.

## Compatibility

- [x] This is not a breaking change.
- [ ] This is a breaking change; it was discussed, and migration/deprecation documentation is included below.
- [x] Canonical and mirrored skill files are synchronized when applicable.
- [x] Relevant platform manifests and installation documentation were reviewed.

`skills/i-have-adhd/SKILL.md` and its `.cursor` mirror are byte-for-byte untouched, so the `cursor-skill in sync` check is unaffected. No manifest, hook, extension, workflow, test, or eval file is modified — installation methods, invocation names, file locations, and opt-in behavior are all unchanged. `.github/install/` is untouched, so `tests/test_install_docs.py` still sees the same set of guides.

**Migration or rollback notes:** None needed. Reverting the commit removes the new file and restores the previous 7-language navigation rows.

## Verification

- `python3 -m unittest discover -s tests -v` — `Ran 51 tests`, `FAILED (failures=5)`. **The full suite does not pass.** All 5 failures are in `test_opencode_plugin.py` and are pre-existing: the identical 5 failures reproduce on a clean tree at base commit `6f1f982`, before any change in this PR. They are a macOS path-normalization mismatch (`/var/folders/…` vs `/private/var/folders/…`) in an area this PR does not touch, and are not addressed here to keep the change focused.
- `tests/test_install_docs.py` — passes. It globs `.github/install/`, which this PR does not modify.
- Relative link check across all 8 README files — 88 relative links resolved, 0 broken.
- Navigation shape check across all 8 README files — each has exactly 8 entries in the same order, exactly one `<strong>` (its own language), correct `·` separators, and a working link to `README.id.md`.
- Structure parity — `diff` of the fenced blocks against `README.md` reports identical; HTML tag counts and blank-line layout match the English original exactly.
- `git diff --check` — clean; no trailing whitespace, tabs, or CRLF in the new file.

**Behavior evals:** Not applicable. This is documentation only — no skill text, prompt text, hook, or runtime behavior changed, so there is nothing for a baseline/candidate comparison to measure.

## Final accountability

- [x] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content.
- [x] All failed, skipped, or unrun checks are disclosed above.
