### PR TITLE
fix(hooks): trim PowerShell trailing blank lines;Fix/powershell trailing newlines

### DIFF
--- a/hooks/always-on.ps1
+++ b/hooks/always-on.ps1
@@ -40,6 +40,7 @@ try {
   } else {
     ""
   }
+  $body = $body.TrimEnd([char]13, [char]10)
 
   $banner = 'ADHD MODE ACTIVE (always-on). The ruleset below applies to every response. ' +
     '"stop adhd mode" turns it off for this session; delete '

--- a/tests/test_always_on_hooks.py
+++ b/tests/test_always_on_hooks.py
@@ -81,7 +81,7 @@ class AlwaysOnHookTest(unittest.TestCase):
     @staticmethod
     def normalize(stdout):
         # The banner embeds the flag path. On Windows the sh runtime joins it
-        # with "/" while node and PowerShell join with "\"; both name the same
+        # with "/" while node and PowerShell join with "\\"; both name the same
         # file, so unify separators (and newlines) before comparing runtimes.
         return stdout.replace("\r\n", "\n").replace("\\", "/")
 
@@ -109,6 +109,23 @@ class AlwaysOnHookTest(unittest.TestCase):
                 normalized = self.normalize(result.stdout)
                 self.assertNotIn("name: fixture", normalized)
                 self.assertIn("\n\nFixture body.\n", normalized)
+                outputs[name] = normalized
+
+        self.assertEqual(1, len(set(outputs.values())))
+
+    def test_runtimes_trim_trailing_blank_lines_from_skill_body(self):
+        skill_path = self.plugin_root / "skills" / "i-have-adhd" / "SKILL.md"
+        skill_path.write_text("---\nname: fixture\n---\nFixture body.\n\n\n")
+        (self.config_dir / ".i-have-adhd-always").touch()
+        outputs = {}
+
+        for name, command in self.runtimes():
+            with self.subTest(runtime=name):
+                result = self.run_hook(command)
+                self.assertEqual(0, result.returncode)
+                self.assertEqual("", result.stderr)
+                normalized = self.normalize(result.stdout)
+                self.assertTrue(normalized.endswith("\n\nFixture body.\n"), normalized)
                 outputs[name] = normalized
 
         self.assertEqual(1, len(set(outputs.values())))


### PR DESCRIPTION
## Summary

<!-- What changed, why it is needed, and the observable behavior before and after. -->

## Authorship and provenance — select exactly one

- [x] **Human-authored** — substantive implementation and text were produced by a human.
- [ ] **Autonomous agent-authored** — an agent planned and produced most of the substantive change.
- [ ] **Hybrid** — a human and one or more agents both made substantive contributions.

**Agent/tool and model/version:** <!-- Write “None” for human-authored PRs. -->

**Agent contribution:** <!-- Planning, code, tests, docs, review, or other work. -->

**Human verification:** <!-- What the submitting human personally reviewed and ran. -->

**Known limitations or uncertain results:** <!-- Write “None known” only after review. -->

## Labels

**Target label:** <!-- Select exactly one: Target:Integrations, Target:Evals, Target:Rules, or Target:Docs. -->

**Author label:** <!-- Select exactly one: Author:Human, Author:Hybrid, or Author:AI. -->

**Workflow labels:** <!-- Add applicable labels: bug, enhancement, issue, question, or duplicate. -->

## Safety and side effects

- [ ] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [ ] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [ ] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [ ] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [ ] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects, permissions, network access, and cost:**

<!-- State “None” when applicable; otherwise describe exact scope and rollback. -->

## Compatibility

- [ ] This is not a breaking change.
- [ ] This is a breaking change; it was discussed, and migration/deprecation documentation is included below.
- [ ] Canonical and mirrored skill files are synchronized when applicable.
- [ ] Relevant platform manifests and installation documentation were reviewed.

**Migration or rollback notes:**

## Verification

<!-- List only commands actually run and their results. Remove unrun examples. -->

<!-- Common checks, when relevant:
python3 -m unittest discover -s tests -v
python3 scripts/run_evals.py validate
-->

- `<command>` — `<result>`

**Behavior evals:** <!-- Required for material skill-behavior changes; include runner/model/cases/trials/rubric and release-gate result. -->

## Final accountability

- [ ] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content.
- [ ] All failed, skipped, or unrun checks are disclosed above.
