### PR TITLE
docs(hermes): fix skill activation instructions

### DIFF
--- a/.github/install/INSTALL.zh-CN.md
+++ b/.github/install/INSTALL.zh-CN.md
@@ -355,7 +355,13 @@ Copilot 遵循 `disable-model-invocation`：与 Claude Code 相同，在调用�
 hermes skills install ayghri/i-have-adhd/skills/i-have-adhd
 ```
 
-输入 `/i-have-adhd`。 The skill installs into `~/.hermes/skills/` and is exposed as a slash command at the next session start.
+技能会安装到 `~/.hermes/skills/`。
+
+如需显式启用，请直接要求 Hermes 使用 `i-have-adhd` 技能，例如：
+
+> 在本次会话中使用 i-have-adhd 技能。
+
+当对话内容与技能描述匹配时，Hermes 也可能自动加载该技能。
 
 想先浏览内容？将此仓库添加为技能源（“tap”），然后搜索并安装：
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -362,7 +362,13 @@ Exceptions: explain fully when asked to explain. Confirm before destructive acti
 hermes skills install ayghri/i-have-adhd/skills/i-have-adhd
 ```
 
-Type `/i-have-adhd`. The skill installs into `~/.hermes/skills/` and is exposed as a slash command at the next session start.
+The skill installs into `~/.hermes/skills/`.
+
+To activate it explicitly, ask Hermes to use the `i-have-adhd` skill, for example:
+
+> Use the i-have-adhd skill for this session.
+
+Hermes may also load the skill automatically when the conversation matches its description.
 
 Prefer to browse first? Add this repo as a skill source (a "tap"), then search and install:
 


### PR DESCRIPTION
## Summary

Fix the Hermes installation documentation to accurately describe how the `i-have-adhd` skill is activated.

The current documentation instructs users to type `/i-have-adhd` and states that the skill is exposed as a slash command. However, Hermes does not expose installed skills as per-skill slash commands.

This change:

- removes the incorrect `/i-have-adhd` activation instruction
- documents explicit natural-language activation of the skill
- notes that Hermes may load the skill automatically when the conversation matches its description
- updates the Chinese installation guide to keep it synchronized with the English documentation

Before this change, Hermes users could follow the documented `/i-have-adhd` instruction and find that it does not work. After this change, the documentation reflects the actual skill activation behavior.

Fixes #118.

## Authorship and provenance — select exactly one

- [ ] **Human-authored** — substantive implementation and text were produced by a human.
- [ ] **Autonomous agent-authored** — an agent planned and produced most of the substantive change.
- [x] **Hybrid** — a human and one or more agents both made substantive contributions.

**Agent/tool and model/version:** ChatGPT, GPT-5.6 Sol

**Agent contribution:** Helped analyze issue #118, identify the affected documentation, propose the documentation changes, and review the PR structure and wording.

**Human verification:** I reviewed issue #118, manually reviewed the English and Chinese Hermes installation documentation, reviewed the complete diff, and ran `git diff --check`.

**Known limitations or uncertain results:** None known.

## Labels

**Target label:** Target:Docs

**Author label:** Author:Hybrid

**Workflow labels:** bug

## Safety and side effects

- [x] The change does not access or expose secrets, private files, or unrelated user/repository data.
- [x] Scripts, hooks, workflows, and evals are bounded and do not create surprising or irreversible side effects.
- [x] No destructive, privileged, production, externally visible, or persistent action occurs without explicit user intent and appropriate safeguards.
- [x] Network access, third-party code, permissions, and provider costs are minimized and documented.
- [x] Prompt text, examples, and fixtures contain no hidden instructions that weaken safety or expand agent authority.

**Side effects, permissions, network access, and cost:**

None. This is a documentation-only change and introduces no runtime behavior, permissions, network access, or additional cost.

## Compatibility

- [x] This is not a breaking change.
- [ ] This is a breaking change; it was discussed, and migration/deprecation documentation is included below.
- [x] Canonical and mirrored skill files are synchronized when applicable.
- [x] Relevant platform manifests and installation documentation were reviewed.

**Migration or rollback notes:**

No migration is required. This change only corrects the documented Hermes activation instructions. It can be rolled back by reverting the documentation changes.

## Verification

- `git diff --check` — passed with no whitespace errors
- Manual review of `INSTALL.md` — Hermes activation instructions correctly describe natural-language activation
- Manual review of `.github/install/INSTALL.zh-CN.md` — Chinese Hermes instructions are synchronized with the English documentation

**Behavior evals:** Not applicable. This PR only changes installation documentation and does not modify skill behavior.

## Final accountability

- [x] I reviewed the complete diff, removed unrelated generated changes, and take responsibility for the submitted content.
- [x] All failed, skipped, or unrun checks are disclosed above.